### PR TITLE
fix(chart): remove whitespace trimming from template includes

### DIFF
--- a/charts/agents-orchestrator/templates/service-base.yaml
+++ b/charts/agents-orchestrator/templates/service-base.yaml
@@ -1,8 +1,8 @@
-{{- include "service-base.rbac" . -}}
-{{- include "service-base.serviceAccount" . -}}
-{{- include "service-base.service" . -}}
-{{- include "service-base.deployment" . -}}
-{{- include "service-base.hpa" . -}}
-{{- include "service-base.ingress" . -}}
-{{- include "service-base.pdb" . -}}
-{{- include "service-base.metrics" . -}}
+{{ include "service-base.rbac" . }}
+{{ include "service-base.serviceAccount" . }}
+{{ include "service-base.service" . }}
+{{ include "service-base.deployment" . }}
+{{ include "service-base.hpa" . }}
+{{ include "service-base.ingress" . }}
+{{ include "service-base.pdb" . }}
+{{ include "service-base.metrics" . }}


### PR DESCRIPTION
## Problem

The `helm lint` step in the release workflow fails because the template file uses whitespace-trimming includes (`{{- include ... -}}`). The trailing dash strips newlines between template outputs, concatenating YAML documents:

```
name: test-agents-orchestratorapiVersion: v1
```

This causes `helm lint` to fail with: `unable to parse YAML: error converting YAML to JSON: yaml: line 19: mapping values are not allowed in this context`

## Fix

Remove the whitespace trimming dashes from all `include` calls in `service-base.yaml`:
```
- {{- include "service-base.rbac" . -}}
+ {{ include "service-base.rbac" . }}
```

This preserves newlines between template outputs so YAML document separators (`---`) remain intact.

## Verification

`helm lint charts/agents-orchestrator` passes after this change.

## Context

This same issue exists in other services (`threads`, etc.) but only manifests when the release workflow includes a `helm lint` step. The v0.1.0 release image was pushed successfully but the Helm chart push failed due to this.