### PR TITLE
Fix chart template separators

### DIFF
--- a/charts/agents-orchestrator/templates/service-base.yaml
+++ b/charts/agents-orchestrator/templates/service-base.yaml
@@ -1,8 +1,15 @@
 {{ include "service-base.rbac" . }}
+---
 {{ include "service-base.serviceAccount" . }}
+---
 {{ include "service-base.service" . }}
+---
 {{ include "service-base.deployment" . }}
+---
 {{ include "service-base.hpa" . }}
+---
 {{ include "service-base.ingress" . }}
+---
 {{ include "service-base.pdb" . }}
+---
 {{ include "service-base.metrics" . }}


### PR DESCRIPTION
## Summary
- add YAML document separators between service-base template includes

## Testing
- helm dependency build charts/agents-orchestrator
- helm lint charts/agents-orchestrator
- helm template test charts/agents-orchestrator --set env[0].name=DATABASE_URL --set env[0].value=test

Closes #7