### PR TITLE
chore: bump chart version to 0.1.1

### DIFF
--- a/charts/agents-orchestrator/Chart.yaml
+++ b/charts/agents-orchestrator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agents-orchestrator
 description: Helm chart for deploying the agents orchestrator.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.1
+appVersion: 0.1.1
 home: https://github.com/agynio/agents-orchestrator
 sources:
   - https://github.com/agynio/agents-orchestrator


### PR DESCRIPTION
Bump chart version for release v0.1.1 with the YAML separator fix.