### PR TITLE
Fix Dockerfile numeric UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ WORKDIR /app
 
 COPY --from=build /out/orchestrator /app/orchestrator
 
-RUN addgroup -S app && adduser -S app -G app
+RUN addgroup -g 10001 -S app && adduser -u 10001 -S app -G app
 
-USER app
+USER 10001
 
 ENTRYPOINT ["/app/orchestrator"]

--- a/charts/agents-orchestrator/Chart.yaml
+++ b/charts/agents-orchestrator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agents-orchestrator
 description: Helm chart for deploying the agents orchestrator.
 type: application
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2
 home: https://github.com/agynio/agents-orchestrator
 sources:
   - https://github.com/agynio/agents-orchestrator


### PR DESCRIPTION
## Summary
- set numeric UID/GID in Dockerfile and use numeric USER
- bump chart version/appVersion to 0.1.2

## Testing
- helm dependency build charts/agents-orchestrator
- helm lint charts/agents-orchestrator
- DOCKER_BUILDKIT=1 docker build .

Closes #10