### PR TITLE
Default agent service addresses

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,11 +56,11 @@ func FromEnv() (Config, error) {
 	}
 	cfg.AgentThreadsAddress = os.Getenv("AGENT_THREADS_ADDRESS")
 	if cfg.AgentThreadsAddress == "" {
-		return Config{}, fmt.Errorf("AGENT_THREADS_ADDRESS must be set")
+		cfg.AgentThreadsAddress = "threads:50051"
 	}
 	cfg.AgentNotificationsAddress = os.Getenv("AGENT_NOTIFICATIONS_ADDRESS")
 	if cfg.AgentNotificationsAddress == "" {
-		return Config{}, fmt.Errorf("AGENT_NOTIFICATIONS_ADDRESS must be set")
+		cfg.AgentNotificationsAddress = "notifications:50051"
 	}
 
 	pollInterval := os.Getenv("POLL_INTERVAL")


### PR DESCRIPTION
## Summary
- default AGENT_THREADS_ADDRESS and AGENT_NOTIFICATIONS_ADDRESS when unset

## Testing
- go test ./...
- helm dependency build charts/agents-orchestrator
- helm lint charts/agents-orchestrator

Closes #14