### PR TITLE
chore: bump chart version to 0.1.4

### DIFF
--- a/charts/agents-orchestrator/Chart.yaml
+++ b/charts/agents-orchestrator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agents-orchestrator
 description: Helm chart for deploying the agents orchestrator.
 type: application
-version: 0.1.3
-appVersion: 0.1.3
+version: 0.1.4
+appVersion: 0.1.4
 home: https://github.com/agynio/agents-orchestrator
 sources:
   - https://github.com/agynio/agents-orchestrator


### PR DESCRIPTION
Bump chart version for release v0.1.4 including agent address defaults.