### PR TITLE
fix: rename e2e devspace command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,4 +71,4 @@ jobs:
 
       - name: Run E2E tests
         working-directory: service
-        run: devspace run test:e2e
+        run: devspace run test-e2e

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -104,8 +104,8 @@ deployments:
           app.kubernetes.io/name: agents-orchestrator-e2e
 
 commands:
-  test:e2e: |-
-    devspace run-pipeline test:e2e $@
+  test-e2e: |-
+    devspace run-pipeline test-e2e $@
 
 pipelines:
   dev:
@@ -125,7 +125,7 @@ pipelines:
         stop_dev agents-orchestrator
       fi
 
-  test:e2e:
+  test-e2e:
     run: |-
       create_deployments e2e-runner
       start_dev e2e-runner &


### PR DESCRIPTION
## Summary
- rename DevSpace test:e2e command/pipeline to test-e2e
- update E2E workflow to run devspace run test-e2e

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/teams/v1 --path agynio/api/secrets/v1
- go test ./...
- go vet ./...

Refs #5