### PR TITLE
fix: pass namespace to e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,4 +71,4 @@ jobs:
 
       - name: Run E2E tests
         working-directory: service
-        run: devspace run test-e2e
+        run: devspace run test-e2e -n platform

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -105,7 +105,7 @@ deployments:
 
 commands:
   test-e2e: |-
-    devspace run-pipeline test-e2e $@
+    devspace run-pipeline test-e2e -n ${DEVSPACE_NAMESPACE} $@
 
 pipelines:
   dev:


### PR DESCRIPTION
## Summary
- pass the DevSpace namespace into the test-e2e command
- run E2E workflow tests with the platform namespace

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/teams/v1 --path agynio/api/secrets/v1
- go test ./...
- go vet ./...

Refs #5