### PR TITLE
fix: set e2e runner security context

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -91,6 +91,9 @@ deployments:
         name: component-chart
         repo: https://charts.devspace.sh
       values:
+        podSecurityContext:
+          runAsUser: 1000
+          fsGroup: 1000
         containers:
           - image: ${E2E_IMAGE}
             env:


### PR DESCRIPTION
## Summary
- add pod security context to the e2e-runner deployment to allow sync writes

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/teams/v1 --path agynio/api/secrets/v1
- go test ./...
- go vet ./...

Refs #5