### PR TITLE
fix: correct e2e security context key

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -91,7 +91,7 @@ deployments:
         name: component-chart
         repo: https://charts.devspace.sh
       values:
-        podSecurityContext:
+        securityContext:
           runAsUser: 1000
           fsGroup: 1000
         containers:


### PR DESCRIPTION
## Summary
- switch the e2e-runner Helm values to use securityContext

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/teams/v1 --path agynio/api/secrets/v1
- go test ./...
- go vet ./...

Refs #5