### PR TITLE
chore: expose e2e sync errors

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -137,7 +137,7 @@ pipelines:
       until exec_container \
         --label-selector "app.kubernetes.io/name=agents-orchestrator-e2e" \
         -n ${ORCHESTRATOR_NAMESPACE} \
-        -- test -f /opt/app/data/buf.gen.yaml 2>/dev/null; do
+        -- test -f /opt/app/data/buf.gen.yaml; do
         sleep 3
         ELAPSED=$((ELAPSED + 3))
         if [ "$ELAPSED" -ge 120 ]; then


### PR DESCRIPTION
## Summary
- surface stderr from the e2e sync wait loop for debugging

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/teams/v1 --path agynio/api/secrets/v1
- go test ./...
- go vet ./...

Refs #5