### PR TITLE
fix: add e2e runner emptyDir

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -103,6 +103,13 @@ deployments:
                 value: "threads:50051"
               - name: RUNNER_ADDRESS
                 value: "runner:50051"
+            volumeMounts:
+              - containerPath: /opt/app/data
+                volume:
+                  name: data
+        volumes:
+          - name: data
+            emptyDir: {}
         labels:
           app.kubernetes.io/name: agents-orchestrator-e2e
 


### PR DESCRIPTION
## Summary
- mount an emptyDir volume at /opt/app/data for the e2e-runner container

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/teams/v1 --path agynio/api/secrets/v1
- go test ./...
- go vet ./...

Refs #5