### PR TITLE
fix: update runner address

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -102,7 +102,7 @@ deployments:
               - name: THREADS_ADDRESS
                 value: "threads:50051"
               - name: RUNNER_ADDRESS
-                value: "runner:50051"
+                value: "docker-runner:50051"
             volumeMounts:
               - containerPath: /opt/app/data
                 volume:

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -31,7 +31,7 @@ const (
 var (
 	teamsAddr   = envOrDefault("TEAMS_ADDRESS", "teams:50051")
 	threadsAddr = envOrDefault("THREADS_ADDRESS", "threads:50051")
-	runnerAddr  = envOrDefault("RUNNER_ADDRESS", "runner:50051")
+	runnerAddr  = envOrDefault("RUNNER_ADDRESS", "docker-runner:50051")
 )
 
 func envOrDefault(key, fallback string) string {


### PR DESCRIPTION
## Summary
- update e2e runner address env var to docker-runner
- align test default RUNNER_ADDRESS fallback with docker-runner

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/teams/v1 --path agynio/api/secrets/v1
- go test ./...
- go vet ./...

Refs #5