### PR TITLE
fix(e2e): sync runner secret

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -4,6 +4,11 @@ vars:
   ORCHESTRATOR_NAMESPACE: platform
   DEV_IMAGE: ghcr.io/agynio/devcontainer-go:1
   E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
+  RUNNER_SHARED_SECRET:
+    command: bash
+    args:
+      - -c
+      - kubectl get deployment docker-runner -n ${ORCHESTRATOR_NAMESPACE} -o jsonpath='{.spec.template.spec.containers[?(@.name=="docker-runner")].env[?(@.name=="DOCKER_RUNNER_SHARED_SECRET")].value}'
 
 functions:
   disable_argocd_sync: |-
@@ -104,7 +109,7 @@ deployments:
               - name: RUNNER_ADDRESS
                 value: "docker-runner:50051"
               - name: DOCKER_RUNNER_SHARED_SECRET
-                value: "e2e-test-secret"
+                value: "${RUNNER_SHARED_SECRET}"
             volumeMounts:
               - containerPath: /opt/app/data
                 volume:

--- a/internal/runnerauth/interceptor_test.go
+++ b/internal/runnerauth/interceptor_test.go
@@ -12,7 +12,7 @@ func TestHashBodyEmpty(t *testing.T) {
 func TestBuildSignaturePayloadAndSign(t *testing.T) {
 	secret := "test-secret"
 	method := "post"
-	path := "/agynio.runner.v1.RunnerService/FindWorkloadsByLabels"
+	path := "/agynio.api.runner.v1.RunnerService/FindWorkloadsByLabels"
 	timestamp := "1700000000000"
 	nonce := "6f9a2b7d-9b45-4bba-8e10-8e7cce8072b6"
 	bodyHash := "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
@@ -23,7 +23,7 @@ func TestBuildSignaturePayloadAndSign(t *testing.T) {
 		t.Fatalf("expected payload %q, got %q", expectedPayload, payload)
 	}
 
-	expectedSignature := "4ETIVMCQlIaQtqa4IRwOmcVnHlpUowqYgfWOnRdCiBU="
+	expectedSignature := "6o4jXSgpjQhHtHR9dmfqTqj+YlGpGSLfSMDklO0Ovac="
 	signature := signPayload([]byte(secret), payload)
 	if signature != expectedSignature {
 		t.Fatalf("expected signature %q, got %q", expectedSignature, signature)


### PR DESCRIPTION
## Summary
- load docker-runner shared secret from the cluster for e2e runner via DevSpace vars
- correct runnerauth test path and expected HMAC signature

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/teams/v1 --path agynio/api/secrets/v1
- go test -json ./...
- go vet ./...

Refs #26