### PR TITLE
chore(ci): capture e2e logs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,3 +72,18 @@ jobs:
       - name: Run E2E tests
         working-directory: service
         run: devspace run test-e2e -n platform
+
+      - name: Capture platform logs
+        if: always()
+        run: |
+          echo "=== Orchestrator pod logs ==="
+          kubectl logs -n platform -l app.kubernetes.io/name=agents-orchestrator \
+            --tail=500 --timestamps 2>&1 || echo "Failed to fetch orchestrator logs"
+          echo ""
+          echo "=== Docker-runner pod logs ==="
+          kubectl logs -n platform -l app.kubernetes.io/name=docker-runner \
+            -c docker-runner --tail=200 --timestamps 2>&1 || echo "Failed to fetch docker-runner logs"
+          echo ""
+          echo "=== Docker-runner DinD sidecar logs ==="
+          kubectl logs -n platform -l app.kubernetes.io/name=docker-runner \
+            -c docker-daemon --tail=200 --timestamps 2>&1 || echo "Failed to fetch DinD logs"


### PR DESCRIPTION
## Summary
- capture orchestrator and docker-runner pod logs after E2E tests

## Testing
- go test ./...
- go vet ./...

#29