### PR TITLE
fix(assembler): keep agent container alive

### DIFF
--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -89,6 +89,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	main := &runnerv1.ContainerSpec{
 		Image:  image,
 		Name:   fmt.Sprintf("agent-%s", agentID.String()),
+		Cmd:    []string{"/bin/sh", "-c", "exec sleep infinity"},
 		Env:    mainEnv,
 		Mounts: agentMounts,
 		AdditionalProperties: map[string]string{

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -89,6 +89,10 @@ func TestAssemblerMainContainer(t *testing.T) {
 	if request.Main.Image != cfg.DefaultAgentImage {
 		t.Fatalf("expected default image %q, got %q", cfg.DefaultAgentImage, request.Main.Image)
 	}
+	expectedCmd := []string{"/bin/sh", "-c", "exec sleep infinity"}
+	if !equalStringSlice(request.Main.Cmd, expectedCmd) {
+		t.Fatalf("unexpected main cmd: %+v", request.Main.Cmd)
+	}
 	labelsJSON := request.Main.AdditionalProperties["labels_json"]
 	if labelsJSON == "" {
 		t.Fatal("expected labels_json")


### PR DESCRIPTION
## Summary
- keep agent main container alive with an explicit shell command
- add coverage for the main container Cmd setting

## Testing
- go test ./...
- go vet ./...

#31