### PR TITLE
Fix agent container names for threads

### DIFF
--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -88,7 +88,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}
 	main := &runnerv1.ContainerSpec{
 		Image:  image,
-		Name:   fmt.Sprintf("agent-%s", agentID.String()),
+		Name:   fmt.Sprintf("agent-%s-%s", agentID.String()[:8], threadID.String()[:8]),
 		Cmd:    []string{"/bin/sh", "-c", "exec sleep infinity"},
 		Env:    mainEnv,
 		Mounts: agentMounts,

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -89,6 +89,10 @@ func TestAssemblerMainContainer(t *testing.T) {
 	if request.Main.Image != cfg.DefaultAgentImage {
 		t.Fatalf("expected default image %q, got %q", cfg.DefaultAgentImage, request.Main.Image)
 	}
+	expectedName := "agent-" + agentID.String()[:8] + "-" + threadID.String()[:8]
+	if request.Main.Name != expectedName {
+		t.Fatalf("expected main name %q, got %q", expectedName, request.Main.Name)
+	}
 	expectedCmd := []string{"/bin/sh", "-c", "exec sleep infinity"}
 	if !equalStringSlice(request.Main.Cmd, expectedCmd) {
 		t.Fatalf("unexpected main cmd: %+v", request.Main.Cmd)


### PR DESCRIPTION
## Summary
- include thread id suffix in main agent container name to avoid collisions
- assert thread-scoped container naming in assembler tests

## Testing
- go test ./...
- go vet ./...
- KUBECONFIG=/workspace/bootstrap-test/stacks/k8s/.kube/agyn-local-kubeconfig.yaml devspace run test-e2e -n platform

Fixes #33