### PR TITLE
refactor: rename teams to agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             --path agynio/api/runner/v1 \
             --path agynio/api/threads/v1 \
             --path agynio/api/notifications/v1 \
-            --path agynio/api/teams/v1 \
+            --path agynio/api/agents/v1 \
             --path agynio/api/secrets/v1
 
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN buf generate buf.build/agynio/api \
     --path agynio/api/runner/v1 \
     --path agynio/api/threads/v1 \
     --path agynio/api/notifications/v1 \
-    --path agynio/api/teams/v1 \
+    --path agynio/api/agents/v1 \
     --path agynio/api/secrets/v1
 
 COPY . .

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -72,7 +72,7 @@ env:
     value: ""
   - name: NOTIFICATIONS_ADDRESS
     value: ""
-  - name: TEAMS_ADDRESS
+  - name: AGENTS_ADDRESS
     value: ""
   - name: SECRETS_ADDRESS
     value: ""

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -9,10 +9,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	notificationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/notifications/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	secretsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/secrets/v1"
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/agynio/agents-orchestrator/internal/assembler"
 	"github.com/agynio/agents-orchestrator/internal/config"
@@ -69,11 +69,11 @@ func run() error {
 	}
 	defer notificationsConn.Close()
 
-	teamsConn, err := grpc.DialContext(ctx, cfg.TeamsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	agentsConn, err := grpc.DialContext(ctx, cfg.AgentsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return fmt.Errorf("dial teams: %w", err)
+		return fmt.Errorf("dial agents: %w", err)
 	}
-	defer teamsConn.Close()
+	defer agentsConn.Close()
 
 	secretsConn, err := grpc.DialContext(ctx, cfg.SecretsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -97,14 +97,14 @@ func run() error {
 
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
 	notificationsClient := notificationsv1.NewNotificationsServiceClient(notificationsConn)
-	teamsClient := teamsv1.NewTeamsServiceClient(teamsConn)
+	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	secretsClient := secretsv1.NewSecretsServiceClient(secretsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	store := store.NewStore(pool)
 	subscriber := subscriber.New(notificationsClient)
-	assembler := assembler.New(teamsClient, secretsClient, &cfg)
-	reconciler := reconciler.New(threadsClient, teamsClient, runnerClient, store, assembler, subscriber.Wake(), cfg.PollInterval, cfg.IdleTimeout, cfg.StopTimeoutSec)
+	assembler := assembler.New(agentsClient, secretsClient, &cfg)
+	reconciler := reconciler.New(threadsClient, agentsClient, runnerClient, store, assembler, subscriber.Wake(), cfg.PollInterval, cfg.IdleTimeout, cfg.StopTimeoutSec)
 
 	start := func(leadCtx context.Context) {
 		group, groupCtx := errgroup.WithContext(leadCtx)

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -62,7 +62,7 @@ functions:
                     --path agynio/api/runner/v1 \
                     --path agynio/api/threads/v1 \
                     --path agynio/api/notifications/v1 \
-                    --path agynio/api/teams/v1 \
+                    --path agynio/api/agents/v1 \
                     --path agynio/api/secrets/v1
                   exec go run ./cmd/orchestrator
               volumeMounts:
@@ -102,8 +102,8 @@ deployments:
         containers:
           - image: ${E2E_IMAGE}
             env:
-              - name: TEAMS_ADDRESS
-                value: "teams:50051"
+              - name: AGENTS_ADDRESS
+                value: "agents:50051"
               - name: THREADS_ADDRESS
                 value: "threads:50051"
               - name: RUNNER_ADDRESS
@@ -163,7 +163,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=agents-orchestrator-e2e" \
         -n ${ORCHESTRATOR_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/teams/v1 --path agynio/api/secrets/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	secretsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/secrets/v1"
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
 	"github.com/agynio/agents-orchestrator/internal/config"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 	"github.com/google/uuid"
@@ -19,13 +19,13 @@ import (
 const listPageSize int32 = 100
 
 type Assembler struct {
-	teams   teamsv1.TeamsServiceClient
+	agents  agentsv1.AgentsServiceClient
 	secrets secretsv1.SecretsServiceClient
 	cfg     *config.Config
 }
 
-func New(teams teamsv1.TeamsServiceClient, secrets secretsv1.SecretsServiceClient, cfg *config.Config) *Assembler {
-	return &Assembler{teams: teams, secrets: secrets, cfg: cfg}
+func New(agents agentsv1.AgentsServiceClient, secrets secretsv1.SecretsServiceClient, cfg *config.Config) *Assembler {
+	return &Assembler{agents: agents, secrets: secrets, cfg: cfg}
 }
 
 func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (*runnerv1.StartWorkloadRequest, error) {
@@ -35,9 +35,9 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}
 
 	resolver := newEnvResolver(a.secrets)
-	volumeResolver := newVolumeResolver(a.teams, agentID)
+	volumeResolver := newVolumeResolver(a.agents, agentID)
 
-	agentEnvs, err := a.listEnvs(ctx, &teamsv1.ListEnvsRequest{AgentId: agentID.String()})
+	agentEnvs, err := a.listEnvs(ctx, &agentsv1.ListEnvsRequest{AgentId: agentID.String()})
 	if err != nil {
 		return nil, fmt.Errorf("list agent envs: %w", err)
 	}
@@ -46,7 +46,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		return nil, fmt.Errorf("resolve agent envs: %w", err)
 	}
 
-	agentScripts, err := a.listInitScripts(ctx, &teamsv1.ListInitScriptsRequest{AgentId: agentID.String()})
+	agentScripts, err := a.listInitScripts(ctx, &agentsv1.ListInitScriptsRequest{AgentId: agentID.String()})
 	if err != nil {
 		return nil, fmt.Errorf("list agent init scripts: %w", err)
 	}
@@ -61,7 +61,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		return nil, fmt.Errorf("encode skills: %w", err)
 	}
 
-	agentAttachments, err := a.listVolumeAttachments(ctx, &teamsv1.ListVolumeAttachmentsRequest{AgentId: agentID.String()})
+	agentAttachments, err := a.listVolumeAttachments(ctx, &agentsv1.ListVolumeAttachmentsRequest{AgentId: agentID.String()})
 	if err != nil {
 		return nil, fmt.Errorf("list agent volume attachments: %w", err)
 	}
@@ -129,8 +129,8 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}, nil
 }
 
-func (a *Assembler) fetchAgent(ctx context.Context, agentID uuid.UUID) (*teamsv1.Agent, error) {
-	resp, err := a.teams.GetAgent(ctx, &teamsv1.GetAgentRequest{Id: agentID.String()})
+func (a *Assembler) fetchAgent(ctx context.Context, agentID uuid.UUID) (*agentsv1.Agent, error) {
+	resp, err := a.agents.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID.String()})
 	if err != nil {
 		return nil, err
 	}
@@ -152,11 +152,11 @@ func (a *Assembler) fetchAgent(ctx context.Context, agentID uuid.UUID) (*teamsv1
 	return agent, nil
 }
 
-func (a *Assembler) listMcps(ctx context.Context, agentID uuid.UUID) ([]*teamsv1.Mcp, error) {
-	resp := []*teamsv1.Mcp{}
+func (a *Assembler) listMcps(ctx context.Context, agentID uuid.UUID) ([]*agentsv1.Mcp, error) {
+	resp := []*agentsv1.Mcp{}
 	token := ""
 	for {
-		page, err := a.teams.ListMcps(ctx, &teamsv1.ListMcpsRequest{
+		page, err := a.agents.ListMcps(ctx, &agentsv1.ListMcpsRequest{
 			AgentId:   agentID.String(),
 			PageSize:  listPageSize,
 			PageToken: token,
@@ -172,11 +172,11 @@ func (a *Assembler) listMcps(ctx context.Context, agentID uuid.UUID) ([]*teamsv1
 	}
 }
 
-func (a *Assembler) listHooks(ctx context.Context, agentID uuid.UUID) ([]*teamsv1.Hook, error) {
-	resp := []*teamsv1.Hook{}
+func (a *Assembler) listHooks(ctx context.Context, agentID uuid.UUID) ([]*agentsv1.Hook, error) {
+	resp := []*agentsv1.Hook{}
 	token := ""
 	for {
-		page, err := a.teams.ListHooks(ctx, &teamsv1.ListHooksRequest{
+		page, err := a.agents.ListHooks(ctx, &agentsv1.ListHooksRequest{
 			AgentId:   agentID.String(),
 			PageSize:  listPageSize,
 			PageToken: token,
@@ -192,11 +192,11 @@ func (a *Assembler) listHooks(ctx context.Context, agentID uuid.UUID) ([]*teamsv
 	}
 }
 
-func (a *Assembler) listSkills(ctx context.Context, agentID uuid.UUID) ([]*teamsv1.Skill, error) {
-	resp := []*teamsv1.Skill{}
+func (a *Assembler) listSkills(ctx context.Context, agentID uuid.UUID) ([]*agentsv1.Skill, error) {
+	resp := []*agentsv1.Skill{}
 	token := ""
 	for {
-		page, err := a.teams.ListSkills(ctx, &teamsv1.ListSkillsRequest{
+		page, err := a.agents.ListSkills(ctx, &agentsv1.ListSkillsRequest{
 			AgentId:   agentID.String(),
 			PageSize:  listPageSize,
 			PageToken: token,
@@ -212,11 +212,11 @@ func (a *Assembler) listSkills(ctx context.Context, agentID uuid.UUID) ([]*teams
 	}
 }
 
-func (a *Assembler) listEnvs(ctx context.Context, req *teamsv1.ListEnvsRequest) ([]*teamsv1.Env, error) {
-	resp := []*teamsv1.Env{}
+func (a *Assembler) listEnvs(ctx context.Context, req *agentsv1.ListEnvsRequest) ([]*agentsv1.Env, error) {
+	resp := []*agentsv1.Env{}
 	token := ""
 	for {
-		page, err := a.teams.ListEnvs(ctx, &teamsv1.ListEnvsRequest{
+		page, err := a.agents.ListEnvs(ctx, &agentsv1.ListEnvsRequest{
 			AgentId:   req.GetAgentId(),
 			McpId:     req.GetMcpId(),
 			HookId:    req.GetHookId(),
@@ -234,11 +234,11 @@ func (a *Assembler) listEnvs(ctx context.Context, req *teamsv1.ListEnvsRequest) 
 	}
 }
 
-func (a *Assembler) listInitScripts(ctx context.Context, req *teamsv1.ListInitScriptsRequest) ([]*teamsv1.InitScript, error) {
-	resp := []*teamsv1.InitScript{}
+func (a *Assembler) listInitScripts(ctx context.Context, req *agentsv1.ListInitScriptsRequest) ([]*agentsv1.InitScript, error) {
+	resp := []*agentsv1.InitScript{}
 	token := ""
 	for {
-		page, err := a.teams.ListInitScripts(ctx, &teamsv1.ListInitScriptsRequest{
+		page, err := a.agents.ListInitScripts(ctx, &agentsv1.ListInitScriptsRequest{
 			AgentId:   req.GetAgentId(),
 			McpId:     req.GetMcpId(),
 			HookId:    req.GetHookId(),
@@ -256,11 +256,11 @@ func (a *Assembler) listInitScripts(ctx context.Context, req *teamsv1.ListInitSc
 	}
 }
 
-func (a *Assembler) listVolumeAttachments(ctx context.Context, req *teamsv1.ListVolumeAttachmentsRequest) ([]*teamsv1.VolumeAttachment, error) {
-	resp := []*teamsv1.VolumeAttachment{}
+func (a *Assembler) listVolumeAttachments(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) ([]*agentsv1.VolumeAttachment, error) {
+	resp := []*agentsv1.VolumeAttachment{}
 	token := ""
 	for {
-		page, err := a.teams.ListVolumeAttachments(ctx, &teamsv1.ListVolumeAttachmentsRequest{
+		page, err := a.agents.ListVolumeAttachments(ctx, &agentsv1.ListVolumeAttachmentsRequest{
 			VolumeId:  req.GetVolumeId(),
 			AgentId:   req.GetAgentId(),
 			McpId:     req.GetMcpId(),
@@ -279,7 +279,7 @@ func (a *Assembler) listVolumeAttachments(ctx context.Context, req *teamsv1.List
 	}
 }
 
-func (a *Assembler) buildMcpSidecar(ctx context.Context, resolver *envResolver, volumeResolver *volumeResolver, mcp *teamsv1.Mcp) (*runnerv1.ContainerSpec, error) {
+func (a *Assembler) buildMcpSidecar(ctx context.Context, resolver *envResolver, volumeResolver *volumeResolver, mcp *agentsv1.Mcp) (*runnerv1.ContainerSpec, error) {
 	if mcp == nil {
 		return nil, fmt.Errorf("mcp is nil")
 	}
@@ -295,9 +295,9 @@ func (a *Assembler) buildMcpSidecar(ctx context.Context, resolver *envResolver, 
 		ctx,
 		resolver,
 		volumeResolver,
-		&teamsv1.ListEnvsRequest{McpId: mcpID.String()},
-		&teamsv1.ListInitScriptsRequest{McpId: mcpID.String()},
-		&teamsv1.ListVolumeAttachmentsRequest{McpId: mcpID.String()},
+		&agentsv1.ListEnvsRequest{McpId: mcpID.String()},
+		&agentsv1.ListInitScriptsRequest{McpId: mcpID.String()},
+		&agentsv1.ListVolumeAttachmentsRequest{McpId: mcpID.String()},
 	)
 	if err != nil {
 		return nil, err
@@ -311,7 +311,7 @@ func (a *Assembler) buildMcpSidecar(ctx context.Context, resolver *envResolver, 
 	}, nil
 }
 
-func (a *Assembler) buildHookSidecar(ctx context.Context, resolver *envResolver, volumeResolver *volumeResolver, hook *teamsv1.Hook) (*runnerv1.ContainerSpec, error) {
+func (a *Assembler) buildHookSidecar(ctx context.Context, resolver *envResolver, volumeResolver *volumeResolver, hook *agentsv1.Hook) (*runnerv1.ContainerSpec, error) {
 	if hook == nil {
 		return nil, fmt.Errorf("hook is nil")
 	}
@@ -327,9 +327,9 @@ func (a *Assembler) buildHookSidecar(ctx context.Context, resolver *envResolver,
 		ctx,
 		resolver,
 		volumeResolver,
-		&teamsv1.ListEnvsRequest{HookId: hookID.String()},
-		&teamsv1.ListInitScriptsRequest{HookId: hookID.String()},
-		&teamsv1.ListVolumeAttachmentsRequest{HookId: hookID.String()},
+		&agentsv1.ListEnvsRequest{HookId: hookID.String()},
+		&agentsv1.ListInitScriptsRequest{HookId: hookID.String()},
+		&agentsv1.ListVolumeAttachmentsRequest{HookId: hookID.String()},
 	)
 	if err != nil {
 		return nil, err
@@ -343,7 +343,7 @@ func (a *Assembler) buildHookSidecar(ctx context.Context, resolver *envResolver,
 	}, nil
 }
 
-func baseAgentEnvVars(cfg *config.Config, agent *teamsv1.Agent, agentID, threadID uuid.UUID, skillsJSON, initScript string) []*runnerv1.EnvVar {
+func baseAgentEnvVars(cfg *config.Config, agent *agentsv1.Agent, agentID, threadID uuid.UUID, skillsJSON, initScript string) []*runnerv1.EnvVar {
 	vars := []*runnerv1.EnvVar{
 		{Name: "AGENT_ID", Value: agentID.String()},
 		{Name: "AGENT_NAME", Value: agent.GetName()},
@@ -366,7 +366,7 @@ type skillPayload struct {
 	Body string `json:"body"`
 }
 
-func buildSkillsJSON(skills []*teamsv1.Skill) (string, error) {
+func buildSkillsJSON(skills []*agentsv1.Skill) (string, error) {
 	payload := make([]skillPayload, len(skills))
 	for i, skill := range skills {
 		payload[i] = skillPayload{Name: skill.GetName(), Body: skill.GetBody()}
@@ -378,11 +378,11 @@ func buildSkillsJSON(skills []*teamsv1.Skill) (string, error) {
 	return string(data), nil
 }
 
-func concatInitScripts(scripts []*teamsv1.InitScript) string {
+func concatInitScripts(scripts []*agentsv1.InitScript) string {
 	if len(scripts) == 0 {
 		return ""
 	}
-	sorted := append([]*teamsv1.InitScript(nil), scripts...)
+	sorted := append([]*agentsv1.InitScript(nil), scripts...)
 	sort.SliceStable(sorted, func(i, j int) bool {
 		itime := initScriptTime(sorted[i])
 		jtime := initScriptTime(sorted[j])
@@ -401,7 +401,7 @@ func concatInitScripts(scripts []*teamsv1.InitScript) string {
 	return builder.String()
 }
 
-func initScriptTime(script *teamsv1.InitScript) time.Time {
+func initScriptTime(script *agentsv1.InitScript) time.Time {
 	if script == nil {
 		return time.Time{}
 	}
@@ -415,7 +415,7 @@ func initScriptTime(script *teamsv1.InitScript) time.Time {
 	return meta.GetCreatedAt().AsTime()
 }
 
-func initScriptID(script *teamsv1.InitScript) string {
+func initScriptID(script *agentsv1.InitScript) string {
 	if script == nil {
 		return ""
 	}
@@ -427,22 +427,22 @@ func initScriptID(script *teamsv1.InitScript) string {
 }
 
 type volumeResolver struct {
-	teams   teamsv1.TeamsServiceClient
+	agents  agentsv1.AgentsServiceClient
 	agentID uuid.UUID
-	cache   map[string]*teamsv1.Volume
+	cache   map[string]*agentsv1.Volume
 	specs   map[string]*runnerv1.VolumeSpec
 }
 
-func newVolumeResolver(teams teamsv1.TeamsServiceClient, agentID uuid.UUID) *volumeResolver {
+func newVolumeResolver(agents agentsv1.AgentsServiceClient, agentID uuid.UUID) *volumeResolver {
 	return &volumeResolver{
-		teams:   teams,
+		agents:  agents,
 		agentID: agentID,
-		cache:   map[string]*teamsv1.Volume{},
+		cache:   map[string]*agentsv1.Volume{},
 		specs:   map[string]*runnerv1.VolumeSpec{},
 	}
 }
 
-func (v *volumeResolver) mountsFor(ctx context.Context, attachments []*teamsv1.VolumeAttachment) ([]*runnerv1.VolumeMount, error) {
+func (v *volumeResolver) mountsFor(ctx context.Context, attachments []*agentsv1.VolumeAttachment) ([]*runnerv1.VolumeMount, error) {
 	mounts := make([]*runnerv1.VolumeMount, 0, len(attachments))
 	for _, attachment := range attachments {
 		if attachment == nil {
@@ -479,12 +479,12 @@ func (v *volumeResolver) Specs() []*runnerv1.VolumeSpec {
 	return specs
 }
 
-func (v *volumeResolver) getVolume(ctx context.Context, volumeID uuid.UUID) (*teamsv1.Volume, error) {
+func (v *volumeResolver) getVolume(ctx context.Context, volumeID uuid.UUID) (*agentsv1.Volume, error) {
 	key := volumeID.String()
 	if cached, ok := v.cache[key]; ok {
 		return cached, nil
 	}
-	resp, err := v.teams.GetVolume(ctx, &teamsv1.GetVolumeRequest{Id: key})
+	resp, err := v.agents.GetVolume(ctx, &agentsv1.GetVolumeRequest{Id: key})
 	if err != nil {
 		return nil, fmt.Errorf("get volume %s: %w", key, err)
 	}
@@ -496,7 +496,7 @@ func (v *volumeResolver) getVolume(ctx context.Context, volumeID uuid.UUID) (*te
 	return volume, nil
 }
 
-func (a *Assembler) resolveSidecarResources(ctx context.Context, resolver *envResolver, volumeResolver *volumeResolver, envReq *teamsv1.ListEnvsRequest, initReq *teamsv1.ListInitScriptsRequest, attachmentReq *teamsv1.ListVolumeAttachmentsRequest) ([]*runnerv1.EnvVar, []*runnerv1.VolumeMount, error) {
+func (a *Assembler) resolveSidecarResources(ctx context.Context, resolver *envResolver, volumeResolver *volumeResolver, envReq *agentsv1.ListEnvsRequest, initReq *agentsv1.ListInitScriptsRequest, attachmentReq *agentsv1.ListVolumeAttachmentsRequest) ([]*runnerv1.EnvVar, []*runnerv1.VolumeMount, error) {
 	vars, err := a.listEnvs(ctx, envReq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list sidecar envs: %w", err)
@@ -524,7 +524,7 @@ func (a *Assembler) resolveSidecarResources(ctx context.Context, resolver *envRe
 	return envVars, mounts, nil
 }
 
-func (v *volumeResolver) ensureSpec(volumeID uuid.UUID, volume *teamsv1.Volume) *runnerv1.VolumeSpec {
+func (v *volumeResolver) ensureSpec(volumeID uuid.UUID, volume *agentsv1.Volume) *runnerv1.VolumeSpec {
 	key := volumeID.String()
 	if spec, ok := v.specs[key]; ok {
 		return spec

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	secretsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/secrets/v1"
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
 	"github.com/agynio/agents-orchestrator/internal/config"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
@@ -21,8 +21,8 @@ func TestAssemblerMainContainer(t *testing.T) {
 	agentID := uuid.New()
 	threadID := uuid.New()
 
-	agent := &teamsv1.Agent{
-		Meta:          &teamsv1.EntityMeta{Id: agentID.String()},
+	agent := &agentsv1.Agent{
+		Meta:          &agentsv1.EntityMeta{Id: agentID.String()},
 		Name:          "assistant",
 		Role:          "ops",
 		Model:         "gpt-test",
@@ -30,45 +30,45 @@ func TestAssemblerMainContainer(t *testing.T) {
 		Configuration: "{\"mode\":\"test\"}",
 	}
 
-	skills := []*teamsv1.Skill{{Name: "skill-a", Body: "do-a"}}
+	skills := []*agentsv1.Skill{{Name: "skill-a", Body: "do-a"}}
 
-	teamsClient := &fakeTeamsClient{
-		getAgent: func(_ context.Context, req *teamsv1.GetAgentRequest, _ ...grpc.CallOption) (*teamsv1.GetAgentResponse, error) {
+	agentsClient := &fakeAgentsClient{
+		getAgent: func(_ context.Context, req *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
 			if req.GetId() != agentID.String() {
 				return nil, errors.New("unexpected agent id")
 			}
-			return &teamsv1.GetAgentResponse{Agent: agent}, nil
+			return &agentsv1.GetAgentResponse{Agent: agent}, nil
 		},
-		listSkills: func(_ context.Context, req *teamsv1.ListSkillsRequest, _ ...grpc.CallOption) (*teamsv1.ListSkillsResponse, error) {
+		listSkills: func(_ context.Context, req *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
 			if req.GetAgentId() != agentID.String() {
 				return nil, errors.New("unexpected skills agent id")
 			}
-			return &teamsv1.ListSkillsResponse{Skills: skills}, nil
+			return &agentsv1.ListSkillsResponse{Skills: skills}, nil
 		},
-		listEnvs: func(_ context.Context, req *teamsv1.ListEnvsRequest, _ ...grpc.CallOption) (*teamsv1.ListEnvsResponse, error) {
+		listEnvs: func(_ context.Context, req *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			if req.GetAgentId() == agentID.String() {
-				return &teamsv1.ListEnvsResponse{Envs: []*teamsv1.Env{
-					{Meta: &teamsv1.EntityMeta{Id: uuid.NewString()}, Name: "CUSTOM_ENV", Source: &teamsv1.Env_Value{Value: "custom"}},
+				return &agentsv1.ListEnvsResponse{Envs: []*agentsv1.Env{
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "CUSTOM_ENV", Source: &agentsv1.Env_Value{Value: "custom"}},
 				}}, nil
 			}
-			return &teamsv1.ListEnvsResponse{}, nil
+			return &agentsv1.ListEnvsResponse{}, nil
 		},
-		listInitScripts: func(_ context.Context, req *teamsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*teamsv1.ListInitScriptsResponse, error) {
+		listInitScripts: func(_ context.Context, req *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			if req.GetAgentId() != agentID.String() {
-				return &teamsv1.ListInitScriptsResponse{}, nil
+				return &agentsv1.ListInitScriptsResponse{}, nil
 			}
-			return &teamsv1.ListInitScriptsResponse{InitScripts: []*teamsv1.InitScript{
-				{Meta: &teamsv1.EntityMeta{Id: uuid.NewString()}, Script: "echo ready"},
+			return &agentsv1.ListInitScriptsResponse{InitScripts: []*agentsv1.InitScript{
+				{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Script: "echo ready"},
 			}}, nil
 		},
-		listVolumeAttachments: func(_ context.Context, _ *teamsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*teamsv1.ListVolumeAttachmentsResponse, error) {
-			return &teamsv1.ListVolumeAttachmentsResponse{}, nil
+		listVolumeAttachments: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
 		},
-		listMcps: func(_ context.Context, _ *teamsv1.ListMcpsRequest, _ ...grpc.CallOption) (*teamsv1.ListMcpsResponse, error) {
-			return &teamsv1.ListMcpsResponse{}, nil
+		listMcps: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
+			return &agentsv1.ListMcpsResponse{}, nil
 		},
-		listHooks: func(_ context.Context, _ *teamsv1.ListHooksRequest, _ ...grpc.CallOption) (*teamsv1.ListHooksResponse, error) {
-			return &teamsv1.ListHooksResponse{}, nil
+		listHooks: func(_ context.Context, _ *agentsv1.ListHooksRequest, _ ...grpc.CallOption) (*agentsv1.ListHooksResponse, error) {
+			return &agentsv1.ListHooksResponse{}, nil
 		},
 	}
 
@@ -78,7 +78,7 @@ func TestAssemblerMainContainer(t *testing.T) {
 		AgentNotificationsAddress: "notifications:50052",
 	}
 
-	assembler := New(teamsClient, &fakeSecretsClient{}, &cfg)
+	assembler := New(agentsClient, &fakeSecretsClient{}, &cfg)
 	request, err := assembler.Assemble(ctx, agentID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -149,37 +149,37 @@ func TestAssemblerResolvesSecretEnv(t *testing.T) {
 		},
 	}
 
-	teamsClient := &fakeTeamsClient{
-		getAgent: func(_ context.Context, _ *teamsv1.GetAgentRequest, _ ...grpc.CallOption) (*teamsv1.GetAgentResponse, error) {
-			return &teamsv1.GetAgentResponse{Agent: &teamsv1.Agent{Meta: &teamsv1.EntityMeta{Id: agentID.String()}}}, nil
+	agentsClient := &fakeAgentsClient{
+		getAgent: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}}}, nil
 		},
-		listSkills: func(_ context.Context, _ *teamsv1.ListSkillsRequest, _ ...grpc.CallOption) (*teamsv1.ListSkillsResponse, error) {
-			return &teamsv1.ListSkillsResponse{}, nil
+		listSkills: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
+			return &agentsv1.ListSkillsResponse{}, nil
 		},
-		listEnvs: func(_ context.Context, req *teamsv1.ListEnvsRequest, _ ...grpc.CallOption) (*teamsv1.ListEnvsResponse, error) {
+		listEnvs: func(_ context.Context, req *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			if req.GetAgentId() == agentID.String() {
-				return &teamsv1.ListEnvsResponse{Envs: []*teamsv1.Env{
-					{Meta: &teamsv1.EntityMeta{Id: uuid.NewString()}, Name: "SECRET_ENV", Source: &teamsv1.Env_SecretId{SecretId: "secret-1"}},
-					{Meta: &teamsv1.EntityMeta{Id: uuid.NewString()}, Name: "SECRET_ENV_TWO", Source: &teamsv1.Env_SecretId{SecretId: "secret-1"}},
+				return &agentsv1.ListEnvsResponse{Envs: []*agentsv1.Env{
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "SECRET_ENV", Source: &agentsv1.Env_SecretId{SecretId: "secret-1"}},
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "SECRET_ENV_TWO", Source: &agentsv1.Env_SecretId{SecretId: "secret-1"}},
 				}}, nil
 			}
-			return &teamsv1.ListEnvsResponse{}, nil
+			return &agentsv1.ListEnvsResponse{}, nil
 		},
-		listInitScripts: func(_ context.Context, _ *teamsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*teamsv1.ListInitScriptsResponse, error) {
-			return &teamsv1.ListInitScriptsResponse{}, nil
+		listInitScripts: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
+			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		listVolumeAttachments: func(_ context.Context, _ *teamsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*teamsv1.ListVolumeAttachmentsResponse, error) {
-			return &teamsv1.ListVolumeAttachmentsResponse{}, nil
+		listVolumeAttachments: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
 		},
-		listMcps: func(_ context.Context, _ *teamsv1.ListMcpsRequest, _ ...grpc.CallOption) (*teamsv1.ListMcpsResponse, error) {
-			return &teamsv1.ListMcpsResponse{}, nil
+		listMcps: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
+			return &agentsv1.ListMcpsResponse{}, nil
 		},
-		listHooks: func(_ context.Context, _ *teamsv1.ListHooksRequest, _ ...grpc.CallOption) (*teamsv1.ListHooksResponse, error) {
-			return &teamsv1.ListHooksResponse{}, nil
+		listHooks: func(_ context.Context, _ *agentsv1.ListHooksRequest, _ ...grpc.CallOption) (*agentsv1.ListHooksResponse, error) {
+			return &agentsv1.ListHooksResponse{}, nil
 		},
 	}
 
-	assembler := New(teamsClient, secretsClient, &config.Config{})
+	assembler := New(agentsClient, secretsClient, &config.Config{})
 	request, err := assembler.Assemble(ctx, agentID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -199,58 +199,58 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 	mcpID := uuid.New()
 	volumeID := uuid.New()
 
-	teamsClient := &fakeTeamsClient{
-		getAgent: func(_ context.Context, _ *teamsv1.GetAgentRequest, _ ...grpc.CallOption) (*teamsv1.GetAgentResponse, error) {
-			return &teamsv1.GetAgentResponse{Agent: &teamsv1.Agent{Meta: &teamsv1.EntityMeta{Id: agentID.String()}}}, nil
+	agentsClient := &fakeAgentsClient{
+		getAgent: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}}}, nil
 		},
-		listSkills: func(_ context.Context, _ *teamsv1.ListSkillsRequest, _ ...grpc.CallOption) (*teamsv1.ListSkillsResponse, error) {
-			return &teamsv1.ListSkillsResponse{}, nil
+		listSkills: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
+			return &agentsv1.ListSkillsResponse{}, nil
 		},
-		listMcps: func(_ context.Context, _ *teamsv1.ListMcpsRequest, _ ...grpc.CallOption) (*teamsv1.ListMcpsResponse, error) {
-			return &teamsv1.ListMcpsResponse{Mcps: []*teamsv1.Mcp{
-				{Meta: &teamsv1.EntityMeta{Id: mcpID.String()}, Image: "mcp-image", Command: "run-mcp"},
+		listMcps: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
+			return &agentsv1.ListMcpsResponse{Mcps: []*agentsv1.Mcp{
+				{Meta: &agentsv1.EntityMeta{Id: mcpID.String()}, Image: "mcp-image", Command: "run-mcp"},
 			}}, nil
 		},
-		listEnvs: func(_ context.Context, req *teamsv1.ListEnvsRequest, _ ...grpc.CallOption) (*teamsv1.ListEnvsResponse, error) {
+		listEnvs: func(_ context.Context, req *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			if req.GetMcpId() == mcpID.String() {
-				return &teamsv1.ListEnvsResponse{Envs: []*teamsv1.Env{
-					{Meta: &teamsv1.EntityMeta{Id: uuid.NewString()}, Name: "MCP_ENV", Source: &teamsv1.Env_Value{Value: "enabled"}},
+				return &agentsv1.ListEnvsResponse{Envs: []*agentsv1.Env{
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "MCP_ENV", Source: &agentsv1.Env_Value{Value: "enabled"}},
 				}}, nil
 			}
-			return &teamsv1.ListEnvsResponse{}, nil
+			return &agentsv1.ListEnvsResponse{}, nil
 		},
-		listInitScripts: func(_ context.Context, req *teamsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*teamsv1.ListInitScriptsResponse, error) {
+		listInitScripts: func(_ context.Context, req *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			if req.GetMcpId() == mcpID.String() {
-				return &teamsv1.ListInitScriptsResponse{InitScripts: []*teamsv1.InitScript{
-					{Meta: &teamsv1.EntityMeta{Id: uuid.NewString(), CreatedAt: timestamppb.New(time.Unix(5, 0))}, Script: "echo mcp"},
+				return &agentsv1.ListInitScriptsResponse{InitScripts: []*agentsv1.InitScript{
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString(), CreatedAt: timestamppb.New(time.Unix(5, 0))}, Script: "echo mcp"},
 				}}, nil
 			}
-			return &teamsv1.ListInitScriptsResponse{}, nil
+			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		listVolumeAttachments: func(_ context.Context, req *teamsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*teamsv1.ListVolumeAttachmentsResponse, error) {
+		listVolumeAttachments: func(_ context.Context, req *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
 			if req.GetMcpId() == mcpID.String() {
-				return &teamsv1.ListVolumeAttachmentsResponse{VolumeAttachments: []*teamsv1.VolumeAttachment{
-					{Meta: &teamsv1.EntityMeta{Id: uuid.NewString()}, VolumeId: volumeID.String()},
+				return &agentsv1.ListVolumeAttachmentsResponse{VolumeAttachments: []*agentsv1.VolumeAttachment{
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, VolumeId: volumeID.String()},
 				}}, nil
 			}
-			return &teamsv1.ListVolumeAttachmentsResponse{}, nil
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
 		},
-		getVolume: func(_ context.Context, req *teamsv1.GetVolumeRequest, _ ...grpc.CallOption) (*teamsv1.GetVolumeResponse, error) {
+		getVolume: func(_ context.Context, req *agentsv1.GetVolumeRequest, _ ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error) {
 			if req.GetId() != volumeID.String() {
 				return nil, errors.New("unexpected volume id")
 			}
-			return &teamsv1.GetVolumeResponse{Volume: &teamsv1.Volume{
-				Meta:       &teamsv1.EntityMeta{Id: volumeID.String()},
+			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{
+				Meta:       &agentsv1.EntityMeta{Id: volumeID.String()},
 				Persistent: true,
 				MountPath:  "/data",
 			}}, nil
 		},
-		listHooks: func(_ context.Context, _ *teamsv1.ListHooksRequest, _ ...grpc.CallOption) (*teamsv1.ListHooksResponse, error) {
-			return &teamsv1.ListHooksResponse{}, nil
+		listHooks: func(_ context.Context, _ *agentsv1.ListHooksRequest, _ ...grpc.CallOption) (*agentsv1.ListHooksResponse, error) {
+			return &agentsv1.ListHooksResponse{}, nil
 		},
 	}
 
-	assembler := New(teamsClient, &fakeSecretsClient{}, &config.Config{})
+	assembler := New(agentsClient, &fakeSecretsClient{}, &config.Config{})
 	request, err := assembler.Assemble(ctx, agentID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -345,193 +345,193 @@ func equalStringSlice(left, right []string) bool {
 	return true
 }
 
-type fakeTeamsClient struct {
-	getAgent              func(context.Context, *teamsv1.GetAgentRequest, ...grpc.CallOption) (*teamsv1.GetAgentResponse, error)
-	listSkills            func(context.Context, *teamsv1.ListSkillsRequest, ...grpc.CallOption) (*teamsv1.ListSkillsResponse, error)
-	listEnvs              func(context.Context, *teamsv1.ListEnvsRequest, ...grpc.CallOption) (*teamsv1.ListEnvsResponse, error)
-	listInitScripts       func(context.Context, *teamsv1.ListInitScriptsRequest, ...grpc.CallOption) (*teamsv1.ListInitScriptsResponse, error)
-	listVolumeAttachments func(context.Context, *teamsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*teamsv1.ListVolumeAttachmentsResponse, error)
-	listMcps              func(context.Context, *teamsv1.ListMcpsRequest, ...grpc.CallOption) (*teamsv1.ListMcpsResponse, error)
-	listHooks             func(context.Context, *teamsv1.ListHooksRequest, ...grpc.CallOption) (*teamsv1.ListHooksResponse, error)
-	getVolume             func(context.Context, *teamsv1.GetVolumeRequest, ...grpc.CallOption) (*teamsv1.GetVolumeResponse, error)
+type fakeAgentsClient struct {
+	getAgent              func(context.Context, *agentsv1.GetAgentRequest, ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+	listSkills            func(context.Context, *agentsv1.ListSkillsRequest, ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error)
+	listEnvs              func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error)
+	listInitScripts       func(context.Context, *agentsv1.ListInitScriptsRequest, ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error)
+	listVolumeAttachments func(context.Context, *agentsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error)
+	listMcps              func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error)
+	listHooks             func(context.Context, *agentsv1.ListHooksRequest, ...grpc.CallOption) (*agentsv1.ListHooksResponse, error)
+	getVolume             func(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
 }
 
 var errNotImplemented = errors.New("not implemented")
 
-func (f *fakeTeamsClient) CreateAgent(context.Context, *teamsv1.CreateAgentRequest, ...grpc.CallOption) (*teamsv1.CreateAgentResponse, error) {
+func (f *fakeAgentsClient) CreateAgent(context.Context, *agentsv1.CreateAgentRequest, ...grpc.CallOption) (*agentsv1.CreateAgentResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) GetAgent(ctx context.Context, req *teamsv1.GetAgentRequest, opts ...grpc.CallOption) (*teamsv1.GetAgentResponse, error) {
+func (f *fakeAgentsClient) GetAgent(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
 	if f.getAgent != nil {
 		return f.getAgent(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) UpdateAgent(context.Context, *teamsv1.UpdateAgentRequest, ...grpc.CallOption) (*teamsv1.UpdateAgentResponse, error) {
+func (f *fakeAgentsClient) UpdateAgent(context.Context, *agentsv1.UpdateAgentRequest, ...grpc.CallOption) (*agentsv1.UpdateAgentResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) DeleteAgent(context.Context, *teamsv1.DeleteAgentRequest, ...grpc.CallOption) (*teamsv1.DeleteAgentResponse, error) {
+func (f *fakeAgentsClient) DeleteAgent(context.Context, *agentsv1.DeleteAgentRequest, ...grpc.CallOption) (*agentsv1.DeleteAgentResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) ListAgents(context.Context, *teamsv1.ListAgentsRequest, ...grpc.CallOption) (*teamsv1.ListAgentsResponse, error) {
+func (f *fakeAgentsClient) ListAgents(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) CreateVolume(context.Context, *teamsv1.CreateVolumeRequest, ...grpc.CallOption) (*teamsv1.CreateVolumeResponse, error) {
+func (f *fakeAgentsClient) CreateVolume(context.Context, *agentsv1.CreateVolumeRequest, ...grpc.CallOption) (*agentsv1.CreateVolumeResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) GetVolume(ctx context.Context, req *teamsv1.GetVolumeRequest, opts ...grpc.CallOption) (*teamsv1.GetVolumeResponse, error) {
+func (f *fakeAgentsClient) GetVolume(ctx context.Context, req *agentsv1.GetVolumeRequest, opts ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error) {
 	if f.getVolume != nil {
 		return f.getVolume(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) UpdateVolume(context.Context, *teamsv1.UpdateVolumeRequest, ...grpc.CallOption) (*teamsv1.UpdateVolumeResponse, error) {
+func (f *fakeAgentsClient) UpdateVolume(context.Context, *agentsv1.UpdateVolumeRequest, ...grpc.CallOption) (*agentsv1.UpdateVolumeResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) DeleteVolume(context.Context, *teamsv1.DeleteVolumeRequest, ...grpc.CallOption) (*teamsv1.DeleteVolumeResponse, error) {
+func (f *fakeAgentsClient) DeleteVolume(context.Context, *agentsv1.DeleteVolumeRequest, ...grpc.CallOption) (*agentsv1.DeleteVolumeResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) ListVolumes(context.Context, *teamsv1.ListVolumesRequest, ...grpc.CallOption) (*teamsv1.ListVolumesResponse, error) {
+func (f *fakeAgentsClient) ListVolumes(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) CreateVolumeAttachment(context.Context, *teamsv1.CreateVolumeAttachmentRequest, ...grpc.CallOption) (*teamsv1.CreateVolumeAttachmentResponse, error) {
+func (f *fakeAgentsClient) CreateVolumeAttachment(context.Context, *agentsv1.CreateVolumeAttachmentRequest, ...grpc.CallOption) (*agentsv1.CreateVolumeAttachmentResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) GetVolumeAttachment(context.Context, *teamsv1.GetVolumeAttachmentRequest, ...grpc.CallOption) (*teamsv1.GetVolumeAttachmentResponse, error) {
+func (f *fakeAgentsClient) GetVolumeAttachment(context.Context, *agentsv1.GetVolumeAttachmentRequest, ...grpc.CallOption) (*agentsv1.GetVolumeAttachmentResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) DeleteVolumeAttachment(context.Context, *teamsv1.DeleteVolumeAttachmentRequest, ...grpc.CallOption) (*teamsv1.DeleteVolumeAttachmentResponse, error) {
+func (f *fakeAgentsClient) DeleteVolumeAttachment(context.Context, *agentsv1.DeleteVolumeAttachmentRequest, ...grpc.CallOption) (*agentsv1.DeleteVolumeAttachmentResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) ListVolumeAttachments(ctx context.Context, req *teamsv1.ListVolumeAttachmentsRequest, opts ...grpc.CallOption) (*teamsv1.ListVolumeAttachmentsResponse, error) {
+func (f *fakeAgentsClient) ListVolumeAttachments(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest, opts ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
 	if f.listVolumeAttachments != nil {
 		return f.listVolumeAttachments(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) CreateMcp(context.Context, *teamsv1.CreateMcpRequest, ...grpc.CallOption) (*teamsv1.CreateMcpResponse, error) {
+func (f *fakeAgentsClient) CreateMcp(context.Context, *agentsv1.CreateMcpRequest, ...grpc.CallOption) (*agentsv1.CreateMcpResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) GetMcp(context.Context, *teamsv1.GetMcpRequest, ...grpc.CallOption) (*teamsv1.GetMcpResponse, error) {
+func (f *fakeAgentsClient) GetMcp(context.Context, *agentsv1.GetMcpRequest, ...grpc.CallOption) (*agentsv1.GetMcpResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) UpdateMcp(context.Context, *teamsv1.UpdateMcpRequest, ...grpc.CallOption) (*teamsv1.UpdateMcpResponse, error) {
+func (f *fakeAgentsClient) UpdateMcp(context.Context, *agentsv1.UpdateMcpRequest, ...grpc.CallOption) (*agentsv1.UpdateMcpResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) DeleteMcp(context.Context, *teamsv1.DeleteMcpRequest, ...grpc.CallOption) (*teamsv1.DeleteMcpResponse, error) {
+func (f *fakeAgentsClient) DeleteMcp(context.Context, *agentsv1.DeleteMcpRequest, ...grpc.CallOption) (*agentsv1.DeleteMcpResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) ListMcps(ctx context.Context, req *teamsv1.ListMcpsRequest, opts ...grpc.CallOption) (*teamsv1.ListMcpsResponse, error) {
+func (f *fakeAgentsClient) ListMcps(ctx context.Context, req *agentsv1.ListMcpsRequest, opts ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 	if f.listMcps != nil {
 		return f.listMcps(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) CreateSkill(context.Context, *teamsv1.CreateSkillRequest, ...grpc.CallOption) (*teamsv1.CreateSkillResponse, error) {
+func (f *fakeAgentsClient) CreateSkill(context.Context, *agentsv1.CreateSkillRequest, ...grpc.CallOption) (*agentsv1.CreateSkillResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) GetSkill(context.Context, *teamsv1.GetSkillRequest, ...grpc.CallOption) (*teamsv1.GetSkillResponse, error) {
+func (f *fakeAgentsClient) GetSkill(context.Context, *agentsv1.GetSkillRequest, ...grpc.CallOption) (*agentsv1.GetSkillResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) UpdateSkill(context.Context, *teamsv1.UpdateSkillRequest, ...grpc.CallOption) (*teamsv1.UpdateSkillResponse, error) {
+func (f *fakeAgentsClient) UpdateSkill(context.Context, *agentsv1.UpdateSkillRequest, ...grpc.CallOption) (*agentsv1.UpdateSkillResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) DeleteSkill(context.Context, *teamsv1.DeleteSkillRequest, ...grpc.CallOption) (*teamsv1.DeleteSkillResponse, error) {
+func (f *fakeAgentsClient) DeleteSkill(context.Context, *agentsv1.DeleteSkillRequest, ...grpc.CallOption) (*agentsv1.DeleteSkillResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) ListSkills(ctx context.Context, req *teamsv1.ListSkillsRequest, opts ...grpc.CallOption) (*teamsv1.ListSkillsResponse, error) {
+func (f *fakeAgentsClient) ListSkills(ctx context.Context, req *agentsv1.ListSkillsRequest, opts ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
 	if f.listSkills != nil {
 		return f.listSkills(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) CreateHook(context.Context, *teamsv1.CreateHookRequest, ...grpc.CallOption) (*teamsv1.CreateHookResponse, error) {
+func (f *fakeAgentsClient) CreateHook(context.Context, *agentsv1.CreateHookRequest, ...grpc.CallOption) (*agentsv1.CreateHookResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) GetHook(context.Context, *teamsv1.GetHookRequest, ...grpc.CallOption) (*teamsv1.GetHookResponse, error) {
+func (f *fakeAgentsClient) GetHook(context.Context, *agentsv1.GetHookRequest, ...grpc.CallOption) (*agentsv1.GetHookResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) UpdateHook(context.Context, *teamsv1.UpdateHookRequest, ...grpc.CallOption) (*teamsv1.UpdateHookResponse, error) {
+func (f *fakeAgentsClient) UpdateHook(context.Context, *agentsv1.UpdateHookRequest, ...grpc.CallOption) (*agentsv1.UpdateHookResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) DeleteHook(context.Context, *teamsv1.DeleteHookRequest, ...grpc.CallOption) (*teamsv1.DeleteHookResponse, error) {
+func (f *fakeAgentsClient) DeleteHook(context.Context, *agentsv1.DeleteHookRequest, ...grpc.CallOption) (*agentsv1.DeleteHookResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) ListHooks(ctx context.Context, req *teamsv1.ListHooksRequest, opts ...grpc.CallOption) (*teamsv1.ListHooksResponse, error) {
+func (f *fakeAgentsClient) ListHooks(ctx context.Context, req *agentsv1.ListHooksRequest, opts ...grpc.CallOption) (*agentsv1.ListHooksResponse, error) {
 	if f.listHooks != nil {
 		return f.listHooks(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) CreateEnv(context.Context, *teamsv1.CreateEnvRequest, ...grpc.CallOption) (*teamsv1.CreateEnvResponse, error) {
+func (f *fakeAgentsClient) CreateEnv(context.Context, *agentsv1.CreateEnvRequest, ...grpc.CallOption) (*agentsv1.CreateEnvResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) GetEnv(context.Context, *teamsv1.GetEnvRequest, ...grpc.CallOption) (*teamsv1.GetEnvResponse, error) {
+func (f *fakeAgentsClient) GetEnv(context.Context, *agentsv1.GetEnvRequest, ...grpc.CallOption) (*agentsv1.GetEnvResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) UpdateEnv(context.Context, *teamsv1.UpdateEnvRequest, ...grpc.CallOption) (*teamsv1.UpdateEnvResponse, error) {
+func (f *fakeAgentsClient) UpdateEnv(context.Context, *agentsv1.UpdateEnvRequest, ...grpc.CallOption) (*agentsv1.UpdateEnvResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) DeleteEnv(context.Context, *teamsv1.DeleteEnvRequest, ...grpc.CallOption) (*teamsv1.DeleteEnvResponse, error) {
+func (f *fakeAgentsClient) DeleteEnv(context.Context, *agentsv1.DeleteEnvRequest, ...grpc.CallOption) (*agentsv1.DeleteEnvResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) ListEnvs(ctx context.Context, req *teamsv1.ListEnvsRequest, opts ...grpc.CallOption) (*teamsv1.ListEnvsResponse, error) {
+func (f *fakeAgentsClient) ListEnvs(ctx context.Context, req *agentsv1.ListEnvsRequest, opts ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 	if f.listEnvs != nil {
 		return f.listEnvs(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) CreateInitScript(context.Context, *teamsv1.CreateInitScriptRequest, ...grpc.CallOption) (*teamsv1.CreateInitScriptResponse, error) {
+func (f *fakeAgentsClient) CreateInitScript(context.Context, *agentsv1.CreateInitScriptRequest, ...grpc.CallOption) (*agentsv1.CreateInitScriptResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) GetInitScript(context.Context, *teamsv1.GetInitScriptRequest, ...grpc.CallOption) (*teamsv1.GetInitScriptResponse, error) {
+func (f *fakeAgentsClient) GetInitScript(context.Context, *agentsv1.GetInitScriptRequest, ...grpc.CallOption) (*agentsv1.GetInitScriptResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) UpdateInitScript(context.Context, *teamsv1.UpdateInitScriptRequest, ...grpc.CallOption) (*teamsv1.UpdateInitScriptResponse, error) {
+func (f *fakeAgentsClient) UpdateInitScript(context.Context, *agentsv1.UpdateInitScriptRequest, ...grpc.CallOption) (*agentsv1.UpdateInitScriptResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) DeleteInitScript(context.Context, *teamsv1.DeleteInitScriptRequest, ...grpc.CallOption) (*teamsv1.DeleteInitScriptResponse, error) {
+func (f *fakeAgentsClient) DeleteInitScript(context.Context, *agentsv1.DeleteInitScriptRequest, ...grpc.CallOption) (*agentsv1.DeleteInitScriptResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (f *fakeTeamsClient) ListInitScripts(ctx context.Context, req *teamsv1.ListInitScriptsRequest, opts ...grpc.CallOption) (*teamsv1.ListInitScriptsResponse, error) {
+func (f *fakeAgentsClient) ListInitScripts(ctx context.Context, req *agentsv1.ListInitScriptsRequest, opts ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 	if f.listInitScripts != nil {
 		return f.listInitScripts(ctx, req, opts...)
 	}

--- a/internal/assembler/envresolve.go
+++ b/internal/assembler/envresolve.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	secretsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/secrets/v1"
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
 )
 
 type envResolver struct {
@@ -18,7 +18,7 @@ func newEnvResolver(secrets secretsv1.SecretsServiceClient) *envResolver {
 	return &envResolver{secrets: secrets, cache: map[string]string{}}
 }
 
-func (r *envResolver) ResolveEnvVars(ctx context.Context, envs []*teamsv1.Env) ([]*runnerv1.EnvVar, error) {
+func (r *envResolver) ResolveEnvVars(ctx context.Context, envs []*agentsv1.Env) ([]*runnerv1.EnvVar, error) {
 	vars := make([]*runnerv1.EnvVar, 0, len(envs))
 	for _, env := range envs {
 		if env == nil {
@@ -37,11 +37,11 @@ func (r *envResolver) ResolveEnvVars(ctx context.Context, envs []*teamsv1.Env) (
 	return vars, nil
 }
 
-func (r *envResolver) resolveValue(ctx context.Context, env *teamsv1.Env) (string, error) {
+func (r *envResolver) resolveValue(ctx context.Context, env *agentsv1.Env) (string, error) {
 	switch source := env.GetSource().(type) {
-	case *teamsv1.Env_Value:
+	case *agentsv1.Env_Value:
 		return source.Value, nil
-	case *teamsv1.Env_SecretId:
+	case *agentsv1.Env_SecretId:
 		if source.SecretId == "" {
 			return "", fmt.Errorf("env %s secret_id is empty", envID(env))
 		}
@@ -60,7 +60,7 @@ func (r *envResolver) resolveValue(ctx context.Context, env *teamsv1.Env) (strin
 	}
 }
 
-func envID(env *teamsv1.Env) string {
+func envID(env *agentsv1.Env) string {
 	if env == nil {
 		return ""
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	DatabaseURL               string
 	ThreadsAddress            string
 	NotificationsAddress      string
-	TeamsAddress              string
+	AgentsAddress             string
 	SecretsAddress            string
 	RunnerAddress             string
 	RunnerSharedSecret        string
@@ -39,9 +39,9 @@ func FromEnv() (Config, error) {
 	if cfg.NotificationsAddress == "" {
 		cfg.NotificationsAddress = "notifications:50051"
 	}
-	cfg.TeamsAddress = os.Getenv("TEAMS_ADDRESS")
-	if cfg.TeamsAddress == "" {
-		cfg.TeamsAddress = "teams:50051"
+	cfg.AgentsAddress = os.Getenv("AGENTS_ADDRESS")
+	if cfg.AgentsAddress == "" {
+		cfg.AgentsAddress = "agents:50051"
 	}
 	cfg.SecretsAddress = os.Getenv("SECRETS_ADDRESS")
 	if cfg.SecretsAddress == "" {

--- a/internal/reconciler/desired.go
+++ b/internal/reconciler/desired.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 	"github.com/google/uuid"
@@ -50,11 +50,11 @@ func (r *Reconciler) fetchDesired(ctx context.Context) ([]AgentThread, error) {
 	return result, nil
 }
 
-func (r *Reconciler) listAgents(ctx context.Context) ([]*teamsv1.Agent, error) {
-	resp := []*teamsv1.Agent{}
+func (r *Reconciler) listAgents(ctx context.Context) ([]*agentsv1.Agent, error) {
+	resp := []*agentsv1.Agent{}
 	token := ""
 	for {
-		page, err := r.teams.ListAgents(ctx, &teamsv1.ListAgentsRequest{
+		page, err := r.agents.ListAgents(ctx, &agentsv1.ListAgentsRequest{
 			PageSize:  desiredPageSize,
 			PageToken: token,
 		})

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/agynio/agents-orchestrator/internal/assembler"
 	"github.com/agynio/agents-orchestrator/internal/store"
@@ -14,7 +14,7 @@ import (
 
 type Reconciler struct {
 	threads   threadsv1.ThreadsServiceClient
-	teams     teamsv1.TeamsServiceClient
+	agents    agentsv1.AgentsServiceClient
 	runner    runnerv1.RunnerServiceClient
 	store     *store.Store
 	assembler *assembler.Assembler
@@ -24,10 +24,10 @@ type Reconciler struct {
 	stopSec   uint32
 }
 
-func New(threads threadsv1.ThreadsServiceClient, teams teamsv1.TeamsServiceClient, runner runnerv1.RunnerServiceClient, store *store.Store, assembler *assembler.Assembler, wake <-chan struct{}, poll, idle time.Duration, stopSec uint32) *Reconciler {
+func New(threads threadsv1.ThreadsServiceClient, agents agentsv1.AgentsServiceClient, runner runnerv1.RunnerServiceClient, store *store.Store, assembler *assembler.Assembler, wake <-chan struct{}, poll, idle time.Duration, stopSec uint32) *Reconciler {
 	return &Reconciler{
 		threads:   threads,
-		teams:     teams,
+		agents:    agents,
 		runner:    runner,
 		store:     store,
 		assembler: assembler,

--- a/test/e2e/dedup_test.go
+++ b/test/e2e/dedup_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
 )
@@ -18,20 +18,20 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	t.Cleanup(cancel)
 
-	teamsConn := dialGRPC(t, teamsAddr)
+	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
-	teamsClient := teamsv1.NewTeamsServiceClient(teamsConn)
+	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
-	agent := createAgent(t, ctx, teamsClient, fmt.Sprintf("e2e-test-agent-nodup-%s", uuid.NewString()))
+	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-nodup-%s", uuid.NewString()))
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, teamsClient, agentID) })
+	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 
 	userID := newUserID()
 	thread := createThread(t, ctx, threadsClient, []string{userID, agentID})

--- a/test/e2e/idle_test.go
+++ b/test/e2e/idle_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
 )
@@ -18,20 +18,20 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	t.Cleanup(cancel)
 
-	teamsConn := dialGRPC(t, teamsAddr)
+	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
-	teamsClient := teamsv1.NewTeamsServiceClient(teamsConn)
+	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
-	agent := createAgent(t, ctx, teamsClient, fmt.Sprintf("e2e-test-agent-idle-%s", uuid.NewString()))
+	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-idle-%s", uuid.NewString()))
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, teamsClient, agentID) })
+	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 
 	userID := newUserID()
 	thread := createThread(t, ctx, threadsClient, []string{userID, agentID})

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
@@ -29,7 +29,7 @@ const (
 )
 
 var (
-	teamsAddr          = envOrDefault("TEAMS_ADDRESS", "teams:50051")
+	agentsAddr         = envOrDefault("AGENTS_ADDRESS", "agents:50051")
 	threadsAddr        = envOrDefault("THREADS_ADDRESS", "threads:50051")
 	runnerAddr         = envOrDefault("RUNNER_ADDRESS", "docker-runner:50051")
 	runnerSharedSecret string
@@ -103,9 +103,9 @@ func newUserID() string {
 
 // --- Setup Helpers ---
 
-func createAgent(t *testing.T, ctx context.Context, client teamsv1.TeamsServiceClient, name string) *teamsv1.Agent {
+func createAgent(t *testing.T, ctx context.Context, client agentsv1.AgentsServiceClient, name string) *agentsv1.Agent {
 	t.Helper()
-	resp, err := client.CreateAgent(ctx, &teamsv1.CreateAgentRequest{
+	resp, err := client.CreateAgent(ctx, &agentsv1.CreateAgentRequest{
 		Name:  name,
 		Role:  "assistant",
 		Model: uuid.New().String(),
@@ -121,9 +121,9 @@ func createAgent(t *testing.T, ctx context.Context, client teamsv1.TeamsServiceC
 	return agent
 }
 
-func deleteAgent(t *testing.T, ctx context.Context, client teamsv1.TeamsServiceClient, agentID string) {
+func deleteAgent(t *testing.T, ctx context.Context, client agentsv1.AgentsServiceClient, agentID string) {
 	t.Helper()
-	_, err := client.DeleteAgent(ctx, &teamsv1.DeleteAgentRequest{Id: agentID})
+	_, err := client.DeleteAgent(ctx, &agentsv1.DeleteAgentRequest{Id: agentID})
 	if err != nil {
 		t.Logf("cleanup: delete agent %s: %v", agentID, err)
 	}

--- a/test/e2e/multi_test.go
+++ b/test/e2e/multi_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
 )
@@ -18,23 +18,23 @@ func TestMultipleAgentsSeparateThreads(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	t.Cleanup(cancel)
 
-	teamsConn := dialGRPC(t, teamsAddr)
+	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
-	teamsClient := teamsv1.NewTeamsServiceClient(teamsConn)
+	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
-	agentA := createAgent(t, ctx, teamsClient, fmt.Sprintf("e2e-test-agent-multi-a-%s", uuid.NewString()))
-	agentB := createAgent(t, ctx, teamsClient, fmt.Sprintf("e2e-test-agent-multi-b-%s", uuid.NewString()))
+	agentA := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-a-%s", uuid.NewString()))
+	agentB := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-b-%s", uuid.NewString()))
 	agentAID := agentA.GetMeta().GetId()
 	agentBID := agentB.GetMeta().GetId()
 	if agentAID == "" || agentBID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, teamsClient, agentAID) })
-	t.Cleanup(func() { deleteAgent(t, ctx, teamsClient, agentBID) })
+	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentAID) })
+	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentBID) })
 
 	userID := newUserID()
 	threadA := createThread(t, ctx, threadsClient, []string{userID, agentAID})
@@ -130,20 +130,20 @@ func TestSameAgentMultipleThreads(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	t.Cleanup(cancel)
 
-	teamsConn := dialGRPC(t, teamsAddr)
+	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
-	teamsClient := teamsv1.NewTeamsServiceClient(teamsConn)
+	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
-	agent := createAgent(t, ctx, teamsClient, fmt.Sprintf("e2e-test-agent-multi-thread-%s", uuid.NewString()))
+	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-thread-%s", uuid.NewString()))
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, teamsClient, agentID) })
+	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 
 	userID := newUserID()
 	threadA := createThread(t, ctx, threadsClient, []string{userID, agentID})

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
-	teamsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/teams/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
 )
@@ -18,20 +18,20 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	t.Cleanup(cancel)
 
-	teamsConn := dialGRPC(t, teamsAddr)
+	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
-	teamsClient := teamsv1.NewTeamsServiceClient(teamsConn)
+	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
-	agent := createAgent(t, ctx, teamsClient, fmt.Sprintf("e2e-test-agent-start-%s", uuid.NewString()))
+	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-start-%s", uuid.NewString()))
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
-	t.Cleanup(func() { deleteAgent(t, ctx, teamsClient, agentID) })
+	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 
 	userID := newUserID()
 	thread := createThread(t, ctx, threadsClient, []string{userID, agentID})


### PR DESCRIPTION
## Summary
- rename teams API references to agents across Go code and tests
- update AGENTS_ADDRESS config plus buf generate paths in CI/dev tooling

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1
- go build ./...
- go vet ./...
- go test ./...

Closes #37