### PR TITLE
fix: remove tenant id usage

### DIFF
--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -34,9 +34,6 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if req.GetAgentId() != agentID.String() {
 				return nil, errors.New("unexpected agent id")
 			}
-			if req.GetTenantId() != placeholderTenantID {
-				return nil, errors.New("unexpected tenant id")
-			}
 			return &zitimgmtv1.CreateAgentIdentityResponse{ZitiIdentityId: zitiID, EnrollmentJwt: jwt}, nil
 		},
 	}
@@ -369,9 +366,6 @@ func TestReconcileOrphanIdentitiesDeletesOrphans(t *testing.T) {
 		listManagedIdentities: func(_ context.Context, req *zitimgmtv1.ListManagedIdentitiesRequest, _ ...grpc.CallOption) (*zitimgmtv1.ListManagedIdentitiesResponse, error) {
 			if req.GetIdentityType() != zitimgmtv1.IdentityType_IDENTITY_TYPE_AGENT {
 				return nil, errors.New("unexpected identity type")
-			}
-			if req.GetTenantId() != placeholderTenantID {
-				return nil, errors.New("unexpected tenant id")
 			}
 			return &zitimgmtv1.ListManagedIdentitiesResponse{
 				Identities: []*zitimgmtv1.ManagedIdentity{

--- a/internal/reconciler/orphan.go
+++ b/internal/reconciler/orphan.go
@@ -32,7 +32,6 @@ func (r *Reconciler) reconcileOrphanIdentities(ctx context.Context) error {
 	for {
 		resp, err := r.zitiMgmt.ListManagedIdentities(ctx, &zitimgmtv1.ListManagedIdentitiesRequest{
 			IdentityType: zitimgmtv1.IdentityType_IDENTITY_TYPE_AGENT,
-			TenantId:     placeholderTenantID,
 			PageSize:     managedIdentityPageSize,
 			PageToken:    pageToken,
 		})

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -14,9 +14,6 @@ import (
 	"github.com/agynio/agents-orchestrator/internal/store"
 )
 
-// TODO: resolve real tenant_id when multi-tenancy is implemented across all services.
-const placeholderTenantID = "00000000-0000-0000-0000-000000000000"
-
 type Reconciler struct {
 	threads   threadsv1.ThreadsServiceClient
 	agents    agentsv1.AgentsServiceClient
@@ -123,8 +120,7 @@ func (r *Reconciler) createIdentity(ctx context.Context, target AgentThread) (*i
 		return nil, nil
 	}
 	identityResp, err := r.zitiMgmt.CreateAgentIdentity(ctx, &zitimgmtv1.CreateAgentIdentityRequest{
-		AgentId:  target.AgentID.String(),
-		TenantId: placeholderTenantID,
+		AgentId: target.AgentID.String(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create ziti identity for agent %s thread %s: %w", target.AgentID.String(), target.ThreadID.String(), err)


### PR DESCRIPTION
## Summary
- remove tenant_id usage from ziti management requests
- update reconciler tests to drop tenant_id expectations

## Testing
- go vet ./...
- go test ./...
- go build ./...

Closes #44