### PR TITLE
Add agent LLM base URL env var

### DIFF
--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -369,6 +369,7 @@ func baseAgentEnvVars(cfg *config.Config, agent *agentsv1.Agent, agentID, thread
 		{Name: "AGENT_CONFIG", Value: agent.GetConfiguration()},
 		{Name: "THREAD_ID", Value: threadID.String()},
 		{Name: "GATEWAY_ADDRESS", Value: cfg.AgentGatewayAddress},
+		{Name: "LLM_BASE_URL", Value: cfg.AgentLLMBaseURL},
 		{Name: "AGENT_SKILLS", Value: skillsJSON},
 	}
 	if initScript != "" {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -76,6 +76,7 @@ func TestAssemblerMainContainer(t *testing.T) {
 	cfg := config.Config{
 		DefaultInitImage:    "default-init-image",
 		AgentGatewayAddress: "gateway:50051",
+		AgentLLMBaseURL:     "http://llm:8080/v1",
 	}
 
 	assembler := New(agentsClient, &fakeSecretsClient{}, &cfg)
@@ -154,6 +155,7 @@ func TestAssemblerMainContainer(t *testing.T) {
 	assertEnv(t, envs, "AGENT_CONFIG", agent.GetConfiguration())
 	assertEnv(t, envs, "THREAD_ID", threadID.String())
 	assertEnv(t, envs, "GATEWAY_ADDRESS", cfg.AgentGatewayAddress)
+	assertEnv(t, envs, "LLM_BASE_URL", cfg.AgentLLMBaseURL)
 	assertEnv(t, envs, "CUSTOM_ENV", "custom")
 	assertEnv(t, envs, "INIT_SCRIPT", "echo ready")
 	var parsedSkills []skillPayload
@@ -206,6 +208,7 @@ func TestAssemblerInitImageOverride(t *testing.T) {
 	cfg := config.Config{
 		DefaultInitImage:    "default-init-image",
 		AgentGatewayAddress: "gateway:50051",
+		AgentLLMBaseURL:     "http://llm:8080/v1",
 	}
 
 	assembler := New(agentsClient, &fakeSecretsClient{}, &cfg)
@@ -271,6 +274,7 @@ func TestAssemblerResolvesSecretEnv(t *testing.T) {
 	assembler := New(agentsClient, secretsClient, &config.Config{
 		DefaultInitImage:    "default-init-image",
 		AgentGatewayAddress: "gateway:50051",
+		AgentLLMBaseURL:     "http://llm:8080/v1",
 	})
 	request, err := assembler.Assemble(ctx, agentID, threadID)
 	if err != nil {
@@ -345,6 +349,7 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 	assembler := New(agentsClient, &fakeSecretsClient{}, &config.Config{
 		DefaultInitImage:    "default-init-image",
 		AgentGatewayAddress: "gateway:50051",
+		AgentLLMBaseURL:     "http://llm:8080/v1",
 	})
 	request, err := assembler.Assemble(ctx, agentID, threadID)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	ZitiLeaseRenewalInterval time.Duration
 	DefaultInitImage         string
 	AgentGatewayAddress      string
+	AgentLLMBaseURL          string
 	PollInterval             time.Duration
 	IdleTimeout              time.Duration
 	StopTimeoutSec           uint32
@@ -84,6 +85,10 @@ func FromEnv() (Config, error) {
 	cfg.AgentGatewayAddress = os.Getenv("AGENT_GATEWAY_ADDRESS")
 	if cfg.AgentGatewayAddress == "" {
 		cfg.AgentGatewayAddress = "gateway:50051"
+	}
+	cfg.AgentLLMBaseURL = os.Getenv("AGENT_LLM_BASE_URL")
+	if cfg.AgentLLMBaseURL == "" {
+		cfg.AgentLLMBaseURL = "http://llm:8080/v1"
 	}
 
 	pollInterval := os.Getenv("POLL_INTERVAL")

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -522,6 +522,7 @@ func newTestAssembler(agentID uuid.UUID) *assembler.Assembler {
 	cfg := &config.Config{
 		DefaultInitImage:    "default-init-image",
 		AgentGatewayAddress: "gateway:50051",
+		AgentLLMBaseURL:     "http://llm:8080/v1",
 	}
 	return assembler.New(agentsClient, &fakeSecretsClient{}, cfg)
 }
@@ -646,6 +647,8 @@ func (f *fakeRunnerClient) CancelExecution(context.Context, *runnerv1.CancelExec
 
 type fakeZitiMgmtClient struct {
 	createAgentIdentity    func(context.Context, *zitimgmtv1.CreateAgentIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error)
+	createAppIdentity      func(context.Context, *zitimgmtv1.CreateAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAppIdentityResponse, error)
+	deleteAppIdentity      func(context.Context, *zitimgmtv1.DeleteAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteAppIdentityResponse, error)
 	deleteIdentity         func(context.Context, *zitimgmtv1.DeleteIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteIdentityResponse, error)
 	listManagedIdentities  func(context.Context, *zitimgmtv1.ListManagedIdentitiesRequest, ...grpc.CallOption) (*zitimgmtv1.ListManagedIdentitiesResponse, error)
 	requestServiceIdentity func(context.Context, *zitimgmtv1.RequestServiceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.RequestServiceIdentityResponse, error)
@@ -655,6 +658,20 @@ type fakeZitiMgmtClient struct {
 func (f *fakeZitiMgmtClient) CreateAgentIdentity(ctx context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 	if f.createAgentIdentity != nil {
 		return f.createAgentIdentity(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) CreateAppIdentity(ctx context.Context, req *zitimgmtv1.CreateAppIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateAppIdentityResponse, error) {
+	if f.createAppIdentity != nil {
+		return f.createAppIdentity(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) DeleteAppIdentity(ctx context.Context, req *zitimgmtv1.DeleteAppIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.DeleteAppIdentityResponse, error) {
+	if f.deleteAppIdentity != nil {
+		return f.deleteAppIdentity(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }


### PR DESCRIPTION
## Summary
- add AGENT_LLM_BASE_URL config and propagate LLM_BASE_URL to agent envs
- cover LLM_BASE_URL in assembler tests
- update ziti management test doubles for new RPCs

## Testing
- go build ./...
- go vet ./...
- go test ./...

## Issue
- #50