### PR TITLE
test(e2e): use fixed model name

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -98,7 +98,7 @@ func createAgent(t *testing.T, ctx context.Context, client agentsv1.AgentsServic
 	resp, err := client.CreateAgent(ctx, &agentsv1.CreateAgentRequest{
 		Name:  name,
 		Role:  "assistant",
-		Model: uuid.New().String(),
+		Model: "test-model",
 		Image: "alpine:3.21",
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- use a stable model name in e2e agent creation

## Testing
- go test ./...
- go vet ./...

Ref #57