### PR TITLE
fix: align Dockerfile Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.8
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 ARG BUF_VERSION=1.66.0
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS buf


### PR DESCRIPTION
## Summary
- bump Dockerfile Go version to 1.25 to match go.mod

## Testing
- go test ./...
- go vet ./...

## Issue
- #66