### PR TITLE
fix(ziti): add identity volume and env

### DIFF
--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -25,6 +25,8 @@ const (
 	agentWorkspaceDir                    = "/tmp"
 	agentHomeDir                         = "/root"
 	ZitiSidecarInitContainerName         = "ziti-sidecar"
+	zitiIdentityVolumeName               = "ziti-identity"
+	zitiIdentityMountPath                = "/netfoundry"
 	zitiDNSNameserver                    = "127.0.0.1"
 	zitiSidecarCommand                   = "tproxy"
 	zitiRequiredCapabilityNetAdmin       = "NET_ADMIN"
@@ -117,6 +119,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			Image:                a.cfg.ZitiSidecarImage,
 			Name:                 ZitiSidecarInitContainerName,
 			Cmd:                  []string{zitiSidecarCommand},
+			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
 			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},
 		})
@@ -152,6 +155,12 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		Kind: runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL,
 	}
 	volumes := append(volumeResolver.Specs(), agynBinVolume)
+	if a.cfg.ZitiEnabled {
+		volumes = append(volumes, &runnerv1.VolumeSpec{
+			Name: zitiIdentityVolumeName,
+			Kind: runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL,
+		})
+	}
 	sort.Slice(volumes, func(i, j int) bool { return volumes[i].Name < volumes[j].Name })
 
 	request := &runnerv1.StartWorkloadRequest{

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -260,6 +260,33 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringMap(zitiInit.AdditionalProperties, expectedProperties) {
 		t.Fatalf("expected ziti sidecar properties %+v, got %+v", expectedProperties, zitiInit.AdditionalProperties)
 	}
+	if len(zitiInit.Mounts) != 1 {
+		t.Fatalf("expected 1 ziti sidecar mount, got %d", len(zitiInit.Mounts))
+	}
+	zitiMount := zitiInit.Mounts[0]
+	if zitiMount.Volume != zitiIdentityVolumeName {
+		t.Fatalf("expected ziti mount volume %q, got %q", zitiIdentityVolumeName, zitiMount.Volume)
+	}
+	if zitiMount.MountPath != zitiIdentityMountPath {
+		t.Fatalf("expected ziti mount path %q, got %q", zitiIdentityMountPath, zitiMount.MountPath)
+	}
+	if len(request.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(request.Volumes))
+	}
+	agynBinVolume := findVolumeSpec(request.Volumes, agynBinVolumeName)
+	if agynBinVolume == nil {
+		t.Fatalf("expected %s volume", agynBinVolumeName)
+	}
+	if agynBinVolume.Kind != runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL {
+		t.Fatalf("expected agyn-bin volume kind ephemeral, got %v", agynBinVolume.Kind)
+	}
+	zitiIdentityVolume := findVolumeSpec(request.Volumes, zitiIdentityVolumeName)
+	if zitiIdentityVolume == nil {
+		t.Fatalf("expected %s volume", zitiIdentityVolumeName)
+	}
+	if zitiIdentityVolume.Kind != runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL {
+		t.Fatalf("expected ziti identity volume kind ephemeral, got %v", zitiIdentityVolume.Kind)
+	}
 }
 
 func TestAssemblerModelOverrideEnv(t *testing.T) {

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -51,8 +51,8 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 				return nil, errors.New("missing ziti sidecar init container")
 			}
 			envs := envMap(zitiContainer.GetEnv())
-			if envs["ZITI_ENROLLMENT_JWT"] != jwt {
-				return nil, errors.New("missing ZITI_ENROLLMENT_JWT")
+			if envs["ZITI_ENROLL_TOKEN"] != jwt {
+				return nil, errors.New("missing ZITI_ENROLL_TOKEN")
 			}
 			return &runnerv1.StartWorkloadResponse{Id: workloadID, Status: runnerv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING}, nil
 		},
@@ -104,8 +104,8 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarInitContainerName)
 			if zitiContainer != nil {
 				envs := envMap(zitiContainer.GetEnv())
-				if _, ok := envs["ZITI_ENROLLMENT_JWT"]; ok {
-					return nil, errors.New("unexpected ZITI_ENROLLMENT_JWT")
+				if _, ok := envs["ZITI_ENROLL_TOKEN"]; ok {
+					return nil, errors.New("unexpected ZITI_ENROLL_TOKEN")
 				}
 			}
 			return &runnerv1.StartWorkloadResponse{Id: workloadID, Status: runnerv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING}, nil

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -242,7 +242,7 @@ func failureSummary(failure *runnerv1.WorkloadFailure) string {
 func attachZitiEnrollmentJWT(request *runnerv1.StartWorkloadRequest, jwt string) error {
 	for _, container := range request.InitContainers {
 		if container.Name == assembler.ZitiSidecarInitContainerName {
-			container.Env = append(container.Env, &runnerv1.EnvVar{Name: "ZITI_ENROLLMENT_JWT", Value: jwt})
+			container.Env = append(container.Env, &runnerv1.EnvVar{Name: "ZITI_ENROLL_TOKEN", Value: jwt})
 			return nil
 		}
 	}


### PR DESCRIPTION
## Summary
- rename Ziti enrollment env var to ZITI_ENROLL_TOKEN
- mount ziti-identity ephemeral volume at /netfoundry for the sidecar init container
- update reconciler/assembler tests to cover env var and volume mount expectations

## Testing
- go test ./...
- go vet ./...

Refs #73