### PR TITLE
fix(config): add ziti-aware defaults

### DIFF
--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -289,6 +289,47 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	}
 }
 
+func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost:5432/db")
+	t.Setenv("THREADS_ADDRESS", "")
+	t.Setenv("NOTIFICATIONS_ADDRESS", "")
+	t.Setenv("AGENTS_ADDRESS", "")
+	t.Setenv("SECRETS_ADDRESS", "")
+	t.Setenv("RUNNER_ADDRESS", "")
+	t.Setenv("ZITI_ENABLED", "true")
+	t.Setenv("ZITI_MANAGEMENT_ADDRESS", "")
+	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "")
+	t.Setenv("ZITI_SIDECAR_IMAGE", "")
+	t.Setenv("CLUSTER_DNS", "")
+	t.Setenv("DEFAULT_INIT_IMAGE", "init-image")
+	t.Setenv("AGENT_GATEWAY_ADDRESS", "")
+	t.Setenv("AGENT_LLM_BASE_URL", "")
+	t.Setenv("AGENT_MODEL_OVERRIDE", "")
+	t.Setenv("POLL_INTERVAL", "")
+	t.Setenv("IDLE_TIMEOUT", "")
+	t.Setenv("STOP_TIMEOUT_SEC", "")
+	t.Setenv("LEASE_NAME", "")
+	t.Setenv("LEASE_NAMESPACE", "")
+
+	cfg, err := config.FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+
+	agentID := uuid.New()
+	threadID := uuid.New()
+	agent := &agentsv1.Agent{
+		Name:          "assistant",
+		Role:          "ops",
+		Model:         "gpt-test",
+		Configuration: "{}",
+	}
+
+	envs := envMap(baseAgentEnvVars(&cfg, agent, agentID, threadID, "[]", ""))
+	assertEnv(t, envs, "GATEWAY_ADDRESS", "gateway.ziti:443")
+	assertEnv(t, envs, "LLM_BASE_URL", "https://llm-proxy.ziti/v1")
+}
+
 func TestAssemblerModelOverrideEnv(t *testing.T) {
 	agentID := uuid.New()
 	threadID := uuid.New()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,22 @@ func FromEnv() (Config, error) {
 		}
 		cfg.ZitiEnabled = parsed
 	}
+	cfg.AgentGatewayAddress = os.Getenv("AGENT_GATEWAY_ADDRESS")
+	if cfg.AgentGatewayAddress == "" {
+		if cfg.ZitiEnabled {
+			cfg.AgentGatewayAddress = "gateway.ziti:443"
+		} else {
+			cfg.AgentGatewayAddress = "gateway:8080"
+		}
+	}
+	cfg.AgentLLMBaseURL = os.Getenv("AGENT_LLM_BASE_URL")
+	if cfg.AgentLLMBaseURL == "" {
+		if cfg.ZitiEnabled {
+			cfg.AgentLLMBaseURL = "https://llm-proxy.ziti/v1"
+		} else {
+			cfg.AgentLLMBaseURL = "http://llm-proxy:8080/v1"
+		}
+	}
 	cfg.ZitiManagementAddress = os.Getenv("ZITI_MANAGEMENT_ADDRESS")
 	if cfg.ZitiManagementAddress == "" {
 		cfg.ZitiManagementAddress = "ziti-management:50051"
@@ -83,7 +99,7 @@ func FromEnv() (Config, error) {
 	}
 	cfg.ZitiSidecarImage = os.Getenv("ZITI_SIDECAR_IMAGE")
 	if cfg.ZitiSidecarImage == "" {
-		cfg.ZitiSidecarImage = "openziti/ziti-tunnel:latest"
+		cfg.ZitiSidecarImage = "openziti/ziti-tunnel:1.6.14"
 	}
 	cfg.ClusterDNS = os.Getenv("CLUSTER_DNS")
 	if cfg.ClusterDNS == "" {
@@ -92,14 +108,6 @@ func FromEnv() (Config, error) {
 	cfg.DefaultInitImage = os.Getenv("DEFAULT_INIT_IMAGE")
 	if cfg.DefaultInitImage == "" {
 		return Config{}, fmt.Errorf("DEFAULT_INIT_IMAGE must be set")
-	}
-	cfg.AgentGatewayAddress = os.Getenv("AGENT_GATEWAY_ADDRESS")
-	if cfg.AgentGatewayAddress == "" {
-		cfg.AgentGatewayAddress = "gateway:8080"
-	}
-	cfg.AgentLLMBaseURL = os.Getenv("AGENT_LLM_BASE_URL")
-	if cfg.AgentLLMBaseURL == "" {
-		cfg.AgentLLMBaseURL = "http://llm-proxy:8080/v1"
 	}
 	cfg.AgentModelOverride = os.Getenv("AGENT_MODEL_OVERRIDE")
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,67 @@
+package config
+
+import "testing"
+
+func TestFromEnvDefaultsNonZiti(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("ZITI_ENABLED", "false")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.ZitiEnabled {
+		t.Fatal("expected ZitiEnabled to be false")
+	}
+	if cfg.AgentGatewayAddress != "gateway:8080" {
+		t.Fatalf("expected gateway address %q, got %q", "gateway:8080", cfg.AgentGatewayAddress)
+	}
+	if cfg.AgentLLMBaseURL != "http://llm-proxy:8080/v1" {
+		t.Fatalf("expected llm base url %q, got %q", "http://llm-proxy:8080/v1", cfg.AgentLLMBaseURL)
+	}
+	if cfg.ZitiSidecarImage != "openziti/ziti-tunnel:1.6.14" {
+		t.Fatalf("expected ziti sidecar image %q, got %q", "openziti/ziti-tunnel:1.6.14", cfg.ZitiSidecarImage)
+	}
+}
+
+func TestFromEnvDefaultsZiti(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("ZITI_ENABLED", "true")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if !cfg.ZitiEnabled {
+		t.Fatal("expected ZitiEnabled to be true")
+	}
+	if cfg.AgentGatewayAddress != "gateway.ziti:443" {
+		t.Fatalf("expected gateway address %q, got %q", "gateway.ziti:443", cfg.AgentGatewayAddress)
+	}
+	if cfg.AgentLLMBaseURL != "https://llm-proxy.ziti/v1" {
+		t.Fatalf("expected llm base url %q, got %q", "https://llm-proxy.ziti/v1", cfg.AgentLLMBaseURL)
+	}
+}
+
+func setBaseEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost:5432/db")
+	t.Setenv("THREADS_ADDRESS", "")
+	t.Setenv("NOTIFICATIONS_ADDRESS", "")
+	t.Setenv("AGENTS_ADDRESS", "")
+	t.Setenv("SECRETS_ADDRESS", "")
+	t.Setenv("RUNNER_ADDRESS", "")
+	t.Setenv("ZITI_MANAGEMENT_ADDRESS", "")
+	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "")
+	t.Setenv("ZITI_SIDECAR_IMAGE", "")
+	t.Setenv("CLUSTER_DNS", "")
+	t.Setenv("DEFAULT_INIT_IMAGE", "init-image")
+	t.Setenv("AGENT_GATEWAY_ADDRESS", "")
+	t.Setenv("AGENT_LLM_BASE_URL", "")
+	t.Setenv("AGENT_MODEL_OVERRIDE", "")
+	t.Setenv("POLL_INTERVAL", "")
+	t.Setenv("IDLE_TIMEOUT", "")
+	t.Setenv("STOP_TIMEOUT_SEC", "")
+	t.Setenv("LEASE_NAME", "")
+	t.Setenv("LEASE_NAMESPACE", "")
+}


### PR DESCRIPTION
## Summary
- make agent gateway/LLM defaults Ziti-aware
- pin default Ziti sidecar image
- add config/env coverage for Ziti defaults

## Testing
- go test ./...
- go vet ./...

Refs #77