### PR TITLE
fix(config): use http for ziti llm

### DIFF
--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -327,7 +327,7 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 
 	envs := envMap(baseAgentEnvVars(&cfg, agent, agentID, threadID, "[]", ""))
 	assertEnv(t, envs, "GATEWAY_ADDRESS", "gateway.ziti:443")
-	assertEnv(t, envs, "LLM_BASE_URL", "https://llm-proxy.ziti/v1")
+	assertEnv(t, envs, "LLM_BASE_URL", "http://llm-proxy.ziti/v1")
 }
 
 func TestAssemblerModelOverrideEnv(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,7 +75,7 @@ func FromEnv() (Config, error) {
 	cfg.AgentLLMBaseURL = os.Getenv("AGENT_LLM_BASE_URL")
 	if cfg.AgentLLMBaseURL == "" {
 		if cfg.ZitiEnabled {
-			cfg.AgentLLMBaseURL = "https://llm-proxy.ziti/v1"
+			cfg.AgentLLMBaseURL = "http://llm-proxy.ziti/v1"
 		} else {
 			cfg.AgentLLMBaseURL = "http://llm-proxy:8080/v1"
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,8 +38,8 @@ func TestFromEnvDefaultsZiti(t *testing.T) {
 	if cfg.AgentGatewayAddress != "gateway.ziti:443" {
 		t.Fatalf("expected gateway address %q, got %q", "gateway.ziti:443", cfg.AgentGatewayAddress)
 	}
-	if cfg.AgentLLMBaseURL != "https://llm-proxy.ziti/v1" {
-		t.Fatalf("expected llm base url %q, got %q", "https://llm-proxy.ziti/v1", cfg.AgentLLMBaseURL)
+	if cfg.AgentLLMBaseURL != "http://llm-proxy.ziti/v1" {
+		t.Fatalf("expected llm base url %q, got %q", "http://llm-proxy.ziti/v1", cfg.AgentLLMBaseURL)
 	}
 }
 


### PR DESCRIPTION
## Summary
- default Ziti LLM base URL to http for llm-proxy
- update config/assembler tests to match

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1
- go test ./...
- go vet ./...

Refs: #83