### PR TITLE
fix: retry ziti enrollment on startup

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -80,6 +80,8 @@ env:
     value: "false"
   - name: ZITI_LEASE_RENEWAL_INTERVAL
     value: "2m"
+  - name: ZITI_ENROLLMENT_TIMEOUT
+    value: "2m"
   - name: ZITI_MANAGEMENT_ADDRESS
     value: ""
   - name: DEFAULT_INIT_IMAGE

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -29,7 +29,14 @@ import (
 	"github.com/openziti/sdk-golang/ziti"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	retryInitialBackoff = 1 * time.Second
+	retryMaxBackoff     = 15 * time.Second
 )
 
 func main() {
@@ -110,7 +117,7 @@ func run() error {
 			return fmt.Errorf("dial ziti management: %w", err)
 		}
 		zitiMgmtClient = zitimgmtv1.NewZitiManagementServiceClient(zitiMgmtConn)
-		zitiCtx, identityID, err := setupZitiIdentity(ctx, zitiMgmtClient)
+		zitiCtx, identityID, err := setupZitiIdentity(ctx, zitiMgmtClient, cfg.ZitiEnrollmentTimeout)
 		if err != nil {
 			return err
 		}
@@ -181,11 +188,18 @@ func run() error {
 	return nil
 }
 
-func setupZitiIdentity(ctx context.Context, client zitimgmtv1.ZitiManagementServiceClient) (ziti.Context, string, error) {
-	identityResp, err := client.RequestServiceIdentity(ctx, &zitimgmtv1.RequestServiceIdentityRequest{
-		ServiceType: zitimgmtv1.ServiceType_SERVICE_TYPE_ORCHESTRATOR,
-	})
-	if err != nil {
+func setupZitiIdentity(ctx context.Context, client zitimgmtv1.ZitiManagementServiceClient, timeout time.Duration) (ziti.Context, string, error) {
+	enrollmentCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var identityResp *zitimgmtv1.RequestServiceIdentityResponse
+	if err := retryWithBackoff(enrollmentCtx, "ziti enrollment", func(attemptCtx context.Context) error {
+		var requestErr error
+		identityResp, requestErr = client.RequestServiceIdentity(attemptCtx, &zitimgmtv1.RequestServiceIdentityRequest{
+			ServiceType: zitimgmtv1.ServiceType_SERVICE_TYPE_ORCHESTRATOR,
+		})
+		return requestErr
+	}); err != nil {
 		return nil, "", fmt.Errorf("request ziti service identity: %w", err)
 	}
 	identityID := identityResp.GetZitiIdentityId()
@@ -210,6 +224,54 @@ func setupZitiIdentity(ctx context.Context, client zitimgmtv1.ZitiManagementServ
 	}
 	ctxImpl.CtrlClt.SetUseOidc(false)
 	return zitiCtx, identityID, nil
+}
+
+func retryWithBackoff(ctx context.Context, operationName string, fn func(context.Context) error) error {
+	backoff := retryInitialBackoff
+	attempt := 1
+	for {
+		err := fn(ctx)
+		if err == nil {
+			return nil
+		}
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if !isRetryableGrpcError(err) {
+			return err
+		}
+
+		delay := backoff
+		if delay > retryMaxBackoff {
+			delay = retryMaxBackoff
+		}
+
+		log.Printf("%s failed (attempt %d), retrying in %s: %v", operationName, attempt, delay, err)
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+
+		backoff *= 2
+		if backoff > retryMaxBackoff {
+			backoff = retryMaxBackoff
+		}
+		attempt++
+	}
+}
+
+func isRetryableGrpcError(err error) bool {
+	statusErr, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	return statusErr.Code() == codes.Unavailable || statusErr.Code() == codes.Unknown
 }
 
 func dialZitiWithRetry(ctx context.Context, zitiCtx ziti.Context, service string) (net.Conn, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	ZitiEnabled              bool
 	ZitiManagementAddress    string
 	ZitiLeaseRenewalInterval time.Duration
+	ZitiEnrollmentTimeout    time.Duration
 	ZitiSidecarImage         string
 	ClusterDNS               string
 	DefaultInitImage         string
@@ -96,6 +97,19 @@ func FromEnv() (Config, error) {
 	}
 	if cfg.ZitiLeaseRenewalInterval <= 0 {
 		return Config{}, fmt.Errorf("ZITI_LEASE_RENEWAL_INTERVAL must be greater than 0")
+	}
+	zitiEnrollmentTimeout := os.Getenv("ZITI_ENROLLMENT_TIMEOUT")
+	if zitiEnrollmentTimeout == "" {
+		cfg.ZitiEnrollmentTimeout = 2 * time.Minute
+	} else {
+		parsed, err := time.ParseDuration(zitiEnrollmentTimeout)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse ZITI_ENROLLMENT_TIMEOUT: %w", err)
+		}
+		cfg.ZitiEnrollmentTimeout = parsed
+	}
+	if cfg.ZitiEnrollmentTimeout <= 0 {
+		return Config{}, fmt.Errorf("ZITI_ENROLLMENT_TIMEOUT must be greater than 0")
 	}
 	cfg.ZitiSidecarImage = os.Getenv("ZITI_SIDECAR_IMAGE")
 	if cfg.ZitiSidecarImage == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	setBaseEnv(t)
@@ -22,6 +25,9 @@ func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	if cfg.ZitiSidecarImage != "openziti/ziti-tunnel:2.0.0-pre8" {
 		t.Fatalf("expected ziti sidecar image %q, got %q", "openziti/ziti-tunnel:2.0.0-pre8", cfg.ZitiSidecarImage)
 	}
+	if cfg.ZitiEnrollmentTimeout != 2*time.Minute {
+		t.Fatalf("expected ziti enrollment timeout %q, got %q", 2*time.Minute, cfg.ZitiEnrollmentTimeout)
+	}
 }
 
 func TestFromEnvDefaultsZiti(t *testing.T) {
@@ -41,6 +47,9 @@ func TestFromEnvDefaultsZiti(t *testing.T) {
 	if cfg.AgentLLMBaseURL != "http://llm-proxy.ziti/v1" {
 		t.Fatalf("expected llm base url %q, got %q", "http://llm-proxy.ziti/v1", cfg.AgentLLMBaseURL)
 	}
+	if cfg.ZitiEnrollmentTimeout != 2*time.Minute {
+		t.Fatalf("expected ziti enrollment timeout %q, got %q", 2*time.Minute, cfg.ZitiEnrollmentTimeout)
+	}
 }
 
 func setBaseEnv(t *testing.T) {
@@ -53,6 +62,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("RUNNER_ADDRESS", "")
 	t.Setenv("ZITI_MANAGEMENT_ADDRESS", "")
 	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "")
+	t.Setenv("ZITI_ENROLLMENT_TIMEOUT", "")
 	t.Setenv("ZITI_SIDECAR_IMAGE", "")
 	t.Setenv("CLUSTER_DNS", "")
 	t.Setenv("DEFAULT_INIT_IMAGE", "init-image")


### PR DESCRIPTION
## Summary
- add ZITI_ENROLLMENT_TIMEOUT config and chart value
- retry ziti enrollment with exponential backoff for transient gRPC errors
- cover enrollment timeout defaults in config tests

## Testing
- GOMAXPROCS=1 go test -p 1 ./...
- GOMAXPROCS=1 go vet ./...

Refs #85