### PR TITLE
Remove runner identity env

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Provision cluster
         working-directory: bootstrap
-        env:
-          TF_VAR_k8s_runner_identity_id: 439e0da2-88cd-46d7-bb9c-56c723c15606
         run: ./apply.sh -y
 
       - name: Extract cluster admin token


### PR DESCRIPTION
## Summary
- remove TF_VAR_k8s_runner_identity_id from bootstrap apply step

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1
- go test ./...
- go vet ./...

Refs #222