### PR TITLE
fix(e2e): register identities in tests

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -153,6 +153,8 @@ deployments:
                 value: "agents:50051"
               - name: THREADS_ADDRESS
                 value: "threads:50051"
+              - name: IDENTITY_ADDRESS
+                value: "identity:50051"
               - name: RUNNER_ADDRESS
                 value: "k8s-runner:50051"
             volumeMounts:
@@ -208,7 +210,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=agents-orchestrator-e2e" \
         -n ${ORCHESTRATOR_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       purge_deployments e2e-runner
       exit $EXIT_CODE

--- a/test/e2e/dedup_test.go
+++ b/test/e2e/dedup_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
@@ -20,10 +21,12 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 
 	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
+	identityConn := dialGRPC(t, identityAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
+	identityClient := identityv1.NewIdentityServiceClient(identityConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-nodup-%s", uuid.NewString()))
@@ -33,7 +36,7 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 
-	userID := newUserID()
+	userID := registerUserIdentity(t, ctx, identityClient)
 	thread := createThread(t, ctx, threadsClient, []string{userID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {

--- a/test/e2e/idle_test.go
+++ b/test/e2e/idle_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
@@ -20,10 +21,12 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 
 	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
+	identityConn := dialGRPC(t, identityAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
+	identityClient := identityv1.NewIdentityServiceClient(identityConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-idle-%s", uuid.NewString()))
@@ -33,7 +36,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 
-	userID := newUserID()
+	userID := registerUserIdentity(t, ctx, identityClient)
 	thread := createThread(t, ctx, threadsClient, []string{userID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
@@ -31,9 +32,10 @@ const (
 )
 
 var (
-	agentsAddr  = envOrDefault("AGENTS_ADDRESS", "agents:50051")
-	threadsAddr = envOrDefault("THREADS_ADDRESS", "threads:50051")
-	runnerAddr  = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")
+	agentsAddr   = envOrDefault("AGENTS_ADDRESS", "agents:50051")
+	threadsAddr  = envOrDefault("THREADS_ADDRESS", "threads:50051")
+	runnerAddr   = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")
+	identityAddr = envOrDefault("IDENTITY_ADDRESS", "identity:50051")
 )
 
 func envOrDefault(key, fallback string) string {
@@ -88,9 +90,17 @@ func pollUntil(ctx context.Context, interval time.Duration, check func(ctx conte
 	}
 }
 
-// newUserID returns a random UUID to use as a fake user participant.
-func newUserID() string {
-	return uuid.New().String()
+func registerUserIdentity(t *testing.T, ctx context.Context, client identityv1.IdentityServiceClient) string {
+	t.Helper()
+	userID := uuid.New().String()
+	_, err := client.RegisterIdentity(ctx, &identityv1.RegisterIdentityRequest{
+		IdentityId:   userID,
+		IdentityType: identityv1.IdentityType_IDENTITY_TYPE_USER,
+	})
+	if err != nil {
+		t.Fatalf("register user identity %s: %v", userID, err)
+	}
+	return userID
 }
 
 // --- Setup Helpers ---

--- a/test/e2e/multi_test.go
+++ b/test/e2e/multi_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
@@ -20,10 +21,12 @@ func TestMultipleAgentsSeparateThreads(t *testing.T) {
 
 	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
+	identityConn := dialGRPC(t, identityAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
+	identityClient := identityv1.NewIdentityServiceClient(identityConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	agentA := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-a-%s", uuid.NewString()))
@@ -36,7 +39,7 @@ func TestMultipleAgentsSeparateThreads(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentAID) })
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentBID) })
 
-	userID := newUserID()
+	userID := registerUserIdentity(t, ctx, identityClient)
 	threadA := createThread(t, ctx, threadsClient, []string{userID, agentAID})
 	threadB := createThread(t, ctx, threadsClient, []string{userID, agentBID})
 	threadAID := threadA.GetId()
@@ -132,10 +135,12 @@ func TestSameAgentMultipleThreads(t *testing.T) {
 
 	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
+	identityConn := dialGRPC(t, identityAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
+	identityClient := identityv1.NewIdentityServiceClient(identityConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-multi-thread-%s", uuid.NewString()))
@@ -145,7 +150,7 @@ func TestSameAgentMultipleThreads(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 
-	userID := newUserID()
+	userID := registerUserIdentity(t, ctx, identityClient)
 	threadA := createThread(t, ctx, threadsClient, []string{userID, agentID})
 	threadB := createThread(t, ctx, threadsClient, []string{userID, agentID})
 	threadAID := threadA.GetId()

--- a/test/e2e/pipeline_test.go
+++ b/test/e2e/pipeline_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
@@ -20,10 +21,12 @@ func TestFullPipelineMessageResponse(t *testing.T) {
 
 	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
+	identityConn := dialGRPC(t, identityAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
+	identityClient := identityv1.NewIdentityServiceClient(identityConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-pipeline-%s", uuid.NewString()))
@@ -33,7 +36,7 @@ func TestFullPipelineMessageResponse(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 
-	userID := newUserID()
+	userID := registerUserIdentity(t, ctx, identityClient)
 	thread := createThread(t, ctx, threadsClient, []string{userID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
@@ -20,10 +21,12 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 
 	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
+	identityConn := dialGRPC(t, identityAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
 
 	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
+	identityClient := identityv1.NewIdentityServiceClient(identityConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-start-%s", uuid.NewString()))
@@ -33,7 +36,7 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 
-	userID := newUserID()
+	userID := registerUserIdentity(t, ctx, identityClient)
 	thread := createThread(t, ctx, threadsClient, []string{userID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {


### PR DESCRIPTION
## Summary
- add identity env/path wiring for e2e runner
- register user identities before thread/message actions in e2e tests

## Testing
- buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1
- go test ./...
- go vet ./...

Closes #92