### PR TITLE
fix(reconciler): cleanup terminal workloads

### DIFF
--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -744,10 +744,11 @@ func (f *fakeRunnerDialer) Dial(ctx context.Context, runnerID string) (runnerv1.
 func (f *fakeRunnerDialer) Close() {}
 
 type fakeRunnersClient struct {
-	createWorkload func(context.Context, *runnersv1.CreateWorkloadRequest, ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error)
-	deleteWorkload func(context.Context, *runnersv1.DeleteWorkloadRequest, ...grpc.CallOption) (*runnersv1.DeleteWorkloadResponse, error)
-	listWorkloads  func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error)
-	listRunners    func(context.Context, *runnersv1.ListRunnersRequest, ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error)
+	createWorkload       func(context.Context, *runnersv1.CreateWorkloadRequest, ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error)
+	deleteWorkload       func(context.Context, *runnersv1.DeleteWorkloadRequest, ...grpc.CallOption) (*runnersv1.DeleteWorkloadResponse, error)
+	listWorkloads        func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error)
+	listRunners          func(context.Context, *runnersv1.ListRunnersRequest, ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error)
+	updateWorkloadStatus func(context.Context, *runnersv1.UpdateWorkloadStatusRequest, ...grpc.CallOption) (*runnersv1.UpdateWorkloadStatusResponse, error)
 }
 
 func (f *fakeRunnersClient) RegisterRunner(context.Context, *runnersv1.RegisterRunnerRequest, ...grpc.CallOption) (*runnersv1.RegisterRunnerResponse, error) {
@@ -788,7 +789,10 @@ func (f *fakeRunnersClient) CreateWorkload(ctx context.Context, req *runnersv1.C
 	return nil, errNotImplemented
 }
 
-func (f *fakeRunnersClient) UpdateWorkloadStatus(context.Context, *runnersv1.UpdateWorkloadStatusRequest, ...grpc.CallOption) (*runnersv1.UpdateWorkloadStatusResponse, error) {
+func (f *fakeRunnersClient) UpdateWorkloadStatus(ctx context.Context, req *runnersv1.UpdateWorkloadStatusRequest, opts ...grpc.CallOption) (*runnersv1.UpdateWorkloadStatusResponse, error) {
+	if f.updateWorkloadStatus != nil {
+		return f.updateWorkloadStatus(ctx, req, opts...)
+	}
 	return nil, errNotImplemented
 }
 
@@ -817,6 +821,7 @@ func (f *fakeRunnersClient) ListWorkloads(ctx context.Context, req *runnersv1.Li
 type fakeRunnerClient struct {
 	startWorkload         func(context.Context, *runnerv1.StartWorkloadRequest, ...grpc.CallOption) (*runnerv1.StartWorkloadResponse, error)
 	stopWorkload          func(context.Context, *runnerv1.StopWorkloadRequest, ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error)
+	inspectWorkload       func(context.Context, *runnerv1.InspectWorkloadRequest, ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error)
 	findWorkloadsByLabels func(context.Context, *runnerv1.FindWorkloadsByLabelsRequest, ...grpc.CallOption) (*runnerv1.FindWorkloadsByLabelsResponse, error)
 }
 
@@ -842,7 +847,10 @@ func (f *fakeRunnerClient) RemoveWorkload(context.Context, *runnerv1.RemoveWorkl
 	return nil, errNotImplemented
 }
 
-func (f *fakeRunnerClient) InspectWorkload(context.Context, *runnerv1.InspectWorkloadRequest, ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+func (f *fakeRunnerClient) InspectWorkload(ctx context.Context, req *runnerv1.InspectWorkloadRequest, opts ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+	if f.inspectWorkload != nil {
+		return f.inspectWorkload(ctx, req, opts...)
+	}
 	return nil, errNotImplemented
 }
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -260,16 +260,25 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 		log.Printf("reconciler: dial runner %s for workload %s: %v", runnerID, workloadID, err)
 		return
 	}
-	if _, err := runnerClient.StopWorkload(ctx, &runnerv1.StopWorkloadRequest{
-		WorkloadId: workloadID,
-		TimeoutSec: r.stopSec,
-	}); err != nil {
+	if err := r.stopRunnerWorkload(ctx, runnerClient, workloadID); err != nil {
 		log.Printf("reconciler: stop workload %s: %v", workloadID, err)
 		return
 	}
-	if r.zitiMgmt != nil && workload.GetZitiIdentityId() != "" {
-		if err := r.deleteIdentity(ctx, workload.GetZitiIdentityId()); err != nil {
-			log.Printf("reconciler: delete ziti identity %s after stopping workload %s: %v", workload.GetZitiIdentityId(), workloadID, err)
+	r.deleteWorkloadRecord(ctx, workloadID, workload.GetZitiIdentityId())
+}
+
+func (r *Reconciler) stopRunnerWorkload(ctx context.Context, runnerClient runnerv1.RunnerServiceClient, workloadID string) error {
+	_, err := runnerClient.StopWorkload(ctx, &runnerv1.StopWorkloadRequest{
+		WorkloadId: workloadID,
+		TimeoutSec: r.stopSec,
+	})
+	return err
+}
+
+func (r *Reconciler) deleteWorkloadRecord(ctx context.Context, workloadID string, zitiIdentityID string) {
+	if r.zitiMgmt != nil && zitiIdentityID != "" {
+		if err := r.deleteIdentity(ctx, zitiIdentityID); err != nil {
+			log.Printf("reconciler: delete ziti identity %s after stopping workload %s: %v", zitiIdentityID, workloadID, err)
 		}
 	}
 	if _, err := r.runners.DeleteWorkload(ctx, &runnersv1.DeleteWorkloadRequest{Id: workloadID}); err != nil {

--- a/internal/reconciler/status.go
+++ b/internal/reconciler/status.go
@@ -62,9 +62,26 @@ func (r *Reconciler) updateWorkloadStatuses(ctx context.Context) error {
 			Containers: workload.GetContainers(),
 		}); err != nil {
 			log.Printf("reconciler: warn: update workload %s status: %v", workloadID, err)
+			continue
+		}
+		if isTerminalWorkloadStatus(status) {
+			if err := r.stopRunnerWorkload(ctx, runnerClient, workloadID); err != nil {
+				log.Printf("reconciler: warn: stop workload %s after terminal status: %v", workloadID, err)
+			}
+			r.deleteWorkloadRecord(ctx, workloadID, workload.GetZitiIdentityId())
 		}
 	}
 	return nil
+}
+
+func isTerminalWorkloadStatus(status runnersv1.WorkloadStatus) bool {
+	switch status {
+	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED:
+		return true
+	default:
+		return false
+	}
 }
 
 func workloadStatusFromInspect(resp *runnerv1.InspectWorkloadResponse) (runnersv1.WorkloadStatus, error) {

--- a/internal/reconciler/status_test.go
+++ b/internal/reconciler/status_test.go
@@ -1,10 +1,14 @@
 package reconciler
 
 import (
+	"context"
+	"errors"
+	"reflect"
 	"testing"
 
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"google.golang.org/grpc"
 )
 
 func TestWorkloadStatusFromInspect(t *testing.T) {
@@ -123,5 +127,146 @@ func TestWorkloadStatusFromInspect(t *testing.T) {
 				t.Fatalf("expected %v, got %v", testCase.want, got)
 			}
 		})
+	}
+}
+
+func TestUpdateWorkloadStatusesCleansUpTerminal(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadID := "workload-1"
+
+	calls := []string{}
+	runner := &fakeRunnerClient{
+		inspectWorkload: func(_ context.Context, req *runnerv1.InspectWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+			calls = append(calls, "inspect")
+			if req.GetWorkloadId() != workloadID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return &runnerv1.InspectWorkloadResponse{StateStatus: k8sPhaseSucceeded}, nil
+		},
+		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+			calls = append(calls, "stop")
+			if req.GetWorkloadId() != workloadID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return &runnerv1.StopWorkloadResponse{}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			calls = append(calls, "dial")
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			calls = append(calls, "list")
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
+			}}, nil
+		},
+		updateWorkloadStatus: func(_ context.Context, req *runnersv1.UpdateWorkloadStatusRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadStatusResponse, error) {
+			calls = append(calls, "update")
+			if req.GetId() != workloadID {
+				return nil, errors.New("unexpected workload id")
+			}
+			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED {
+				return nil, errors.New("unexpected workload status")
+			}
+			return &runnersv1.UpdateWorkloadStatusResponse{}, nil
+		},
+		deleteWorkload: func(_ context.Context, req *runnersv1.DeleteWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.DeleteWorkloadResponse, error) {
+			calls = append(calls, "delete")
+			if req.GetId() != workloadID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return &runnersv1.DeleteWorkloadResponse{}, nil
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+	})
+
+	if err := reconciler.updateWorkloadStatuses(ctx); err != nil {
+		t.Fatalf("update workload statuses: %v", err)
+	}
+
+	expectedCalls := []string{"list", "dial", "inspect", "update", "stop", "delete"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("unexpected call order: %v", calls)
+	}
+}
+
+func TestUpdateWorkloadStatusesSkipsCleanupForNonTerminal(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadID := "workload-1"
+
+	stopCalled := false
+	deleteCalled := false
+	updateCalled := false
+
+	runner := &fakeRunnerClient{
+		inspectWorkload: func(_ context.Context, req *runnerv1.InspectWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+			if req.GetWorkloadId() != workloadID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return &runnerv1.InspectWorkloadResponse{StateStatus: dockerStateRunning}, nil
+		},
+		stopWorkload: func(_ context.Context, _ *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+			stopCalled = true
+			return &runnerv1.StopWorkloadResponse{}, nil
+		},
+	}
+
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING},
+			}}, nil
+		},
+		updateWorkloadStatus: func(_ context.Context, req *runnersv1.UpdateWorkloadStatusRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadStatusResponse, error) {
+			updateCalled = true
+			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+				return nil, errors.New("unexpected workload status")
+			}
+			return &runnersv1.UpdateWorkloadStatusResponse{}, nil
+		},
+		deleteWorkload: func(_ context.Context, _ *runnersv1.DeleteWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.DeleteWorkloadResponse, error) {
+			deleteCalled = true
+			return &runnersv1.DeleteWorkloadResponse{}, nil
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+	})
+
+	if err := reconciler.updateWorkloadStatuses(ctx); err != nil {
+		t.Fatalf("update workload statuses: %v", err)
+	}
+	if !updateCalled {
+		t.Fatal("expected update workload status call")
+	}
+	if stopCalled {
+		t.Fatal("expected no stop workload call")
+	}
+	if deleteCalled {
+		t.Fatal("expected no delete workload call")
 	}
 }


### PR DESCRIPTION
## Summary
- clean up workloads after terminal status updates
- reuse shared cleanup helpers for status reconciliation
- add coverage for terminal and non-terminal status updates

## Testing
- go test ./...
- go vet ./...

Refs #103