### PR TITLE
test(e2e): add Claude Code scenarios

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: 3f78babcf0f741578516997fa1df2258
-    digest: shake256:db3e541006986820d4a3fe910278577daa43be1c4f132b63741095df16f5e6145c4ec0c41728e4685671ed4078cde755aa973d828ef5465cfbb0db5e247cb093
+    commit: 98c081dc9fcc47a49f1af878dd4ab4cd
+    digest: shake256:495d1fc51aaba8d6b152b71ba0817b89ca47319b359cd4727f2902d1f27de9df35e2944ad864d22d9dfefdd2fd3a24c8dce9e05d902ffa3f138961dca689b4aa
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -315,4 +315,3 @@ dev:
           - .devspace/
           - /.gen/
           - /tmp/
-

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -233,7 +233,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=agents-orchestrator-e2e" \
         -n ${ORCHESTRATOR_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1 && go test -v -count=1 -timeout=20m -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1 && go test -v -count=1 -tags e2e -timeout 30m ./test/e2e/'
       EXIT_CODE=$?
       purge_deployments e2e-runner e2e-rbac
       exit $EXIT_CODE

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -43,10 +43,6 @@ functions:
             - name: agents-orchestrator
               image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with DEV_IMAGE
               env:
-                - name: AGENT_LLM_BASE_URL
-                  value: "http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080/v1"
-                - name: AGENT_GATEWAY_ADDRESS
-                  value: "gateway-gateway.platform.svc.cluster.local:8080"
                 - name: AGENT_TRACING_ADDRESS
                   value: "tracing.platform.svc.cluster.local:50051"
                 - name: ZITI_ENABLED

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -315,3 +315,4 @@ dev:
           - .devspace/
           - /.gen/
           - /tmp/
+

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -27,22 +27,6 @@ functions:
       echo "WARNING: ArgoCD Application 'agents-orchestrator' not found in argocd namespace."
     fi
   patch_deployment: |-
-    echo "Registering k8s-runner with runners service..."
-    kubectl run register-runner --rm -i --restart=Never \
-      --image=ghcr.io/agynio/devcontainer-go:1 \
-      -n ${ORCHESTRATOR_NAMESPACE} \
-      --override-type=strategic \
-      --overrides='{"spec":{"securityContext":{"runAsUser":1000,"fsGroup":1000}}}' \
-      -- buf curl \
-        --schema buf.build/agynio/api \
-        --protocol grpc \
-        --http2-prior-knowledge \
-        -d '{"name":"k8s-runner"}' \
-        http://runners:50051/agynio.api.runners.v1.RunnersService/RegisterRunner 2>&1 || true
-    echo "Updating runner status to enrolled..."
-    kubectl exec -n ${ORCHESTRATOR_NAMESPACE} runners-db-0 -- \
-      psql -U runners -d runners -c "UPDATE runners SET status = 'enrolled' WHERE name = 'k8s-runner'" || true
-    echo "Runner setup complete."
     echo "Patching agents-orchestrator deployment for DevSpace..."
     kubectl patch deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
@@ -66,7 +50,7 @@ functions:
                 - name: AGENT_TRACING_ADDRESS
                   value: "tracing.platform.svc.cluster.local:50051"
                 - name: ZITI_ENABLED
-                  value: "false"
+                  value: "true"
               workingDir: /opt/app/data
               command:
                 - sh

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -864,6 +864,10 @@ func (f *fakeRunnersClient) ListWorkloads(ctx context.Context, req *runnersv1.Li
 	return nil, errNotImplemented
 }
 
+func (f *fakeRunnersClient) BatchUpdateWorkloadSampledAt(context.Context, *runnersv1.BatchUpdateWorkloadSampledAtRequest, ...grpc.CallOption) (*runnersv1.BatchUpdateWorkloadSampledAtResponse, error) {
+	return nil, errNotImplemented
+}
+
 func (f *fakeRunnersClient) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequest, opts ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
 	if f.listVolumes != nil {
 		return f.listVolumes(ctx, req, opts...)
@@ -879,6 +883,10 @@ func (f *fakeRunnersClient) UpdateVolume(ctx context.Context, req *runnersv1.Upd
 	if f.updateVolume != nil {
 		return f.updateVolume(ctx, req, opts...)
 	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeRunnersClient) BatchUpdateVolumeSampledAt(context.Context, *runnersv1.BatchUpdateVolumeSampledAtRequest, ...grpc.CallOption) (*runnersv1.BatchUpdateVolumeSampledAtResponse, error) {
 	return nil, errNotImplemented
 }
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -36,8 +36,9 @@ const (
 	tracingSummaryTimeout  = 2 * time.Minute
 	tracingStartTimeBuffer = 30 * time.Second
 
-	testLLMEndpointCodex = "https://testllm.dev/v1/org/agynio/suite/codex/responses"
-	testLLMEndpointAgn   = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
+	testLLMEndpointCodex  = "https://testllm.dev/v1/org/agynio/suite/codex/responses"
+	testLLMEndpointAgn    = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
+	testLLMEndpointClaude = "https://testllm.dev/v1/org/agynio/suite/claude/messages"
 
 	labelManagedBy = "managed-by"
 	labelAgentID   = "agent-id"
@@ -46,16 +47,17 @@ const (
 )
 
 var (
-	agentsAddr     = envOrDefault("AGENTS_ADDRESS", "agents:50051")
-	threadsAddr    = envOrDefault("THREADS_ADDRESS", "threads:50051")
-	llmAddr        = envOrDefault("LLM_ADDRESS", "llm:50051")
-	usersAddr      = envOrDefault("USERS_ADDRESS", "users:50051")
-	orgsAddr       = envOrDefault("ORGANIZATIONS_ADDRESS", "tenants:50051")
-	runnerAddr     = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")
-	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
-	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:mcp-host-20260412-3")
-	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:mcp-host-20260412-6")
+	agentsAddr      = envOrDefault("AGENTS_ADDRESS", "agents:50051")
+	threadsAddr     = envOrDefault("THREADS_ADDRESS", "threads:50051")
+	llmAddr         = envOrDefault("LLM_ADDRESS", "llm:50051")
+	usersAddr       = envOrDefault("USERS_ADDRESS", "users:50051")
+	orgsAddr        = envOrDefault("ORGANIZATIONS_ADDRESS", "tenants:50051")
+	runnerAddr      = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")
+	secretsAddr     = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
+	tracingAddr     = envOrDefault("TRACING_ADDRESS", "tracing:50051")
+	codexInitImage  = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:mcp-host-20260412-3")
+	agnInitImage    = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:mcp-host-20260412-6")
+	claudeInitImage = envOrDefault("CLAUDE_INIT_IMAGE", "ghcr.io/agynio/agent-init-claude:latest")
 )
 
 type pipelineRun struct {
@@ -104,6 +106,8 @@ func newUserID() string {
 	return uuid.New().String()
 }
 
+type llmProviderCreator func(t *testing.T, ctx context.Context, client llmv1.LLMServiceClient, endpoint, orgID string) *llmv1.LLMProvider
+
 func createLLMProvider(t *testing.T, ctx context.Context, client llmv1.LLMServiceClient, endpoint, orgID string) *llmv1.LLMProvider {
 	t.Helper()
 	resp, err := client.CreateLLMProvider(ctx, &llmv1.CreateLLMProviderRequest{
@@ -111,6 +115,26 @@ func createLLMProvider(t *testing.T, ctx context.Context, client llmv1.LLMServic
 		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
 		Token:          "test-token",
 		OrganizationId: orgID,
+		Protocol:       llmv1.Protocol_PROTOCOL_RESPONSES,
+	})
+	if err != nil {
+		t.Fatalf("create llm provider: %v", err)
+	}
+	provider := resp.GetProvider()
+	if provider == nil || provider.GetMeta() == nil {
+		t.Fatal("create llm provider: nil response")
+	}
+	return provider
+}
+
+func createLLMProviderAnthropic(t *testing.T, ctx context.Context, client llmv1.LLMServiceClient, endpoint, orgID string) *llmv1.LLMProvider {
+	t.Helper()
+	resp, err := client.CreateLLMProvider(ctx, &llmv1.CreateLLMProviderRequest{
+		Endpoint:       endpoint,
+		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_X_API_KEY,
+		Token:          "test-token",
+		OrganizationId: orgID,
+		Protocol:       llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES,
 	})
 	if err != nil {
 		t.Fatalf("create llm provider: %v", err)

--- a/test/e2e/mcp_test.go
+++ b/test/e2e/mcp_test.go
@@ -17,14 +17,18 @@ import (
 )
 
 func TestMCPToolsE2E(t *testing.T) {
-	runMCPToolsE2E(t, testLLMEndpointCodex, codexInitImage)
+	runMCPToolsE2E(t, testLLMEndpointCodex, codexInitImage, createLLMProvider)
 }
 
 func TestMCPToolsAgnE2E(t *testing.T) {
-	runMCPToolsE2E(t, testLLMEndpointAgn, agnInitImage)
+	runMCPToolsE2E(t, testLLMEndpointAgn, agnInitImage, createLLMProvider)
 }
 
-func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
+func TestMCPToolsClaudeE2E(t *testing.T) {
+	runMCPToolsE2E(t, testLLMEndpointClaude, claudeInitImage, createLLMProviderAnthropic)
+}
+
+func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string, createProvider llmProviderCreator) pipelineRun {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
@@ -48,7 +52,7 @@ func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, llmEndpoint, orgID)
+	provider := createProvider(t, ctx, llmClient, llmEndpoint, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")

--- a/test/e2e/pipeline_test.go
+++ b/test/e2e/pipeline_test.go
@@ -93,11 +93,22 @@ func TestClaudeRestoreSession(t *testing.T) {
 		}
 	})
 
-	sendMessage(t, ctx, threadsClient, threadID, identityID, "hello")
+	firstMessage := sendMessage(t, ctx, threadsClient, threadID, identityID, "hello")
+	firstMessageTime := messageCreatedAt(t, firstMessage)
 
 	firstPollCtx, firstPollCancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer firstPollCancel()
-	firstBody, err := pollForAgentResponse(t, firstPollCtx, threadsClient, runnerClient, threadID, agentID, labels)
+	firstBody, err := pollForAgentResponse(
+		t,
+		firstPollCtx,
+		threadsClient,
+		runnerClient,
+		threadID,
+		agentID,
+		labels,
+		firstMessageTime,
+		"Hi! How are you?",
+	)
 	if err != nil {
 		t.Fatalf("wait for agent response: %v", err)
 	}
@@ -105,7 +116,8 @@ func TestClaudeRestoreSession(t *testing.T) {
 		t.Fatalf("expected agent response %q, got %q", "Hi! How are you?", firstBody)
 	}
 
-	sendMessage(t, ctx, threadsClient, threadID, identityID, "fine")
+	secondMessage := sendMessage(t, ctx, threadsClient, threadID, identityID, "fine")
+	secondMessageTime := messageCreatedAt(t, secondMessage)
 
 	secondPollCtx, secondPollCancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer secondPollCancel()
@@ -120,12 +132,17 @@ func TestClaudeRestoreSession(t *testing.T) {
 		}
 		agentMessages := 0
 		for _, msg := range resp.GetMessages() {
-			if msg.GetSenderId() == agentID {
-				agentMessages++
-				if agentMessages == 2 {
-					secondBody = msg.GetBody()
-					return nil
+			if msg.GetSenderId() != agentID {
+				continue
+			}
+			agentMessages++
+			if agentMessages == 2 {
+				createdAt := msg.GetCreatedAt()
+				if createdAt == nil || createdAt.AsTime().Before(secondMessageTime) {
+					return fmt.Errorf("agent response not found")
 				}
+				secondBody = msg.GetBody()
+				return nil
 			}
 		}
 		return fmt.Errorf("agent response not found")
@@ -137,7 +154,14 @@ func TestClaudeRestoreSession(t *testing.T) {
 	}
 }
 
-func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, message, expectedResponse string, createProvider llmProviderCreator) pipelineRun {
+func runFullPipelineMessageResponse(
+	t *testing.T,
+	llmEndpoint,
+	initImage,
+	message,
+	expectedResponse string,
+	createProvider llmProviderCreator,
+) pipelineRun {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)

--- a/test/e2e/pipeline_test.go
+++ b/test/e2e/pipeline_test.go
@@ -18,14 +18,126 @@ import (
 )
 
 func TestFullPipelineMessageResponse(t *testing.T) {
-	runFullPipelineMessageResponse(t, testLLMEndpointCodex, codexInitImage, "hello", "Hi! How are you?")
+	runFullPipelineMessageResponse(t, testLLMEndpointCodex, codexInitImage, "hello", "Hi! How are you?", createLLMProvider)
 }
 
 func TestFullPipelineAgnMessageResponse(t *testing.T) {
-	runFullPipelineMessageResponse(t, testLLMEndpointAgn, agnInitImage, "hi", "Hi! How are you?")
+	runFullPipelineMessageResponse(t, testLLMEndpointAgn, agnInitImage, "hi", "Hi! How are you?", createLLMProvider)
 }
 
-func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, message, expectedResponse string) pipelineRun {
+func TestFullPipelineClaudeMessageResponse(t *testing.T) {
+	runFullPipelineMessageResponse(t, testLLMEndpointClaude, claudeInitImage, "hello", "Hi! How are you?", createLLMProviderAnthropic)
+}
+
+func TestClaudeRestoreSession(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Minute)
+	t.Cleanup(cancel)
+
+	agentsConn := dialGRPC(t, agentsAddr)
+	threadsConn := dialGRPC(t, threadsAddr)
+	runnerConn := dialRunnerGRPC(t, runnerAddr)
+	usersConn := dialGRPC(t, usersAddr)
+	orgsConn := dialGRPC(t, orgsAddr)
+
+	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
+	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
+	llmConn := dialGRPC(t, llmAddr)
+	llmClient := llmv1.NewLLMServiceClient(llmConn)
+	usersClient := usersv1.NewUsersServiceClient(usersConn)
+	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
+	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
+
+	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	token := createAPIToken(t, ctx, usersClient, identityID)
+	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+
+	provider := createLLMProviderAnthropic(t, ctx, llmClient, testLLMEndpointClaude, orgID)
+	providerID := provider.GetMeta().GetId()
+	if providerID == "" {
+		t.Fatal("create llm provider: missing id")
+	}
+	model := createModel(t, ctx, llmClient, "e2e-model-"+uuid.NewString(), providerID, "simple-state", orgID)
+	modelID := model.GetMeta().GetId()
+	if modelID == "" {
+		t.Fatal("create model: missing id")
+	}
+
+	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-claude-restore-%s", uuid.NewString()), modelID, orgID, claudeInitImage)
+	agentID := agent.GetMeta().GetId()
+	if agentID == "" {
+		t.Fatal("create agent: missing id")
+	}
+	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
+	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+
+	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	threadID := thread.GetId()
+	if threadID == "" {
+		t.Fatal("create thread: missing id")
+	}
+	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
+
+	labels := map[string]string{
+		labelManagedBy: managedByValue,
+		labelAgentID:   agentID,
+		labelThreadID:  threadID,
+	}
+	t.Cleanup(func() {
+		ids, err := findWorkloadsByLabels(ctx, runnerClient, labels)
+		if err != nil {
+			t.Logf("cleanup: find workloads: %v", err)
+			return
+		}
+		for _, workloadID := range ids {
+			cleanupWorkload(t, ctx, runnerClient, workloadID)
+		}
+	})
+
+	sendMessage(t, ctx, threadsClient, threadID, identityID, "hello")
+
+	firstPollCtx, firstPollCancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer firstPollCancel()
+	firstBody, err := pollForAgentResponse(t, firstPollCtx, threadsClient, runnerClient, threadID, agentID, labels)
+	if err != nil {
+		t.Fatalf("wait for agent response: %v", err)
+	}
+	if firstBody != "Hi! How are you?" {
+		t.Fatalf("expected agent response %q, got %q", "Hi! How are you?", firstBody)
+	}
+
+	sendMessage(t, ctx, threadsClient, threadID, identityID, "fine")
+
+	secondPollCtx, secondPollCancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer secondPollCancel()
+	secondBody := ""
+	if err := pollUntil(secondPollCtx, pollInterval, func(ctx context.Context) error {
+		resp, err := threadsClient.GetMessages(ctx, &threadsv1.GetMessagesRequest{
+			ThreadId: threadID,
+			PageSize: 50,
+		})
+		if err != nil {
+			return fmt.Errorf("get messages: %w", err)
+		}
+		agentMessages := 0
+		for _, msg := range resp.GetMessages() {
+			if msg.GetSenderId() == agentID {
+				agentMessages++
+				if agentMessages == 2 {
+					secondBody = msg.GetBody()
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("agent response not found")
+	}); err != nil {
+		t.Fatalf("wait for agent response: %v", err)
+	}
+	if secondBody != "How can I help you?" {
+		t.Fatalf("expected agent response %q, got %q", "How can I help you?", secondBody)
+	}
+}
+
+func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, message, expectedResponse string, createProvider llmProviderCreator) pipelineRun {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
@@ -49,7 +161,7 @@ func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, messag
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
-	provider := createLLMProvider(t, ctx, llmClient, llmEndpoint, orgID)
+	provider := createProvider(t, ctx, llmClient, llmEndpoint, orgID)
 	providerID := provider.GetMeta().GetId()
 	if providerID == "" {
 		t.Fatal("create llm provider: missing id")

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -11,7 +11,7 @@ import (
 func TestAgentSimpleHelloProducesTrace(t *testing.T) {
 	requireTracingAvailable(t)
 	expectedResponse := "Hi! How are you?"
-	result := runFullPipelineMessageResponse(t, testLLMEndpointAgn, agnInitImage, "hi", expectedResponse)
+	result := runFullPipelineMessageResponse(t, testLLMEndpointAgn, agnInitImage, "hi", expectedResponse, createLLMProvider)
 
 	ctx := context.Background()
 	tracingClient := newTracingClient(t)
@@ -38,7 +38,7 @@ func TestAgentSimpleHelloProducesTrace(t *testing.T) {
 
 func TestAgentMCPToolsProducesTrace(t *testing.T) {
 	requireTracingAvailable(t)
-	result := runMCPToolsE2E(t, testLLMEndpointAgn, agnInitImage)
+	result := runMCPToolsE2E(t, testLLMEndpointAgn, agnInitImage, createLLMProvider)
 
 	ctx := context.Background()
 	tracingClient := newTracingClient(t)


### PR DESCRIPTION
## Summary
- regenerate LLM protos for protocol/auth updates
- add Claude provider helpers plus pipeline/restore/MCP e2e cases
- update Ziti management test fakes for new client methods

## Testing
- go build ./...
- GOMAXPROCS=2 go vet -p 1 ./...
- GOMAXPROCS=2 go test -p 1 ./...

Closes #116