### PR TITLE
feat(reconciler): skip passive threads

### DIFF
--- a/internal/reconciler/desired.go
+++ b/internal/reconciler/desired.go
@@ -39,7 +39,17 @@ func (r *Reconciler) fetchDesired(ctx context.Context) ([]AgentThread, error) {
 		if err != nil {
 			return nil, err
 		}
+		if len(threadIDs) == 0 {
+			continue
+		}
+		passiveThreads, err := r.fetchPassiveThreads(ctx, agentID)
+		if err != nil {
+			return nil, err
+		}
 		for _, threadID := range threadIDs {
+			if _, ok := passiveThreads[threadID]; ok {
+				continue
+			}
 			unique[AgentThread{AgentID: agentID, ThreadID: threadID}] = struct{}{}
 		}
 	}
@@ -93,4 +103,60 @@ func (r *Reconciler) listUnackedThreads(ctx context.Context, agentID uuid.UUID) 
 			return threadIDs, nil
 		}
 	}
+}
+
+func (r *Reconciler) fetchPassiveThreads(ctx context.Context, agentID uuid.UUID) (map[uuid.UUID]struct{}, error) {
+	passiveThreads := make(map[uuid.UUID]struct{})
+	token := ""
+	agentIDString := agentID.String()
+	for {
+		page, err := r.threads.GetThreads(ctx, &threadsv1.GetThreadsRequest{
+			ParticipantId: agentIDString,
+			PageSize:      desiredPageSize,
+			PageToken:     token,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("get threads for agent %s: %w", agentIDString, err)
+		}
+		for _, thread := range page.GetThreads() {
+			if thread == nil {
+				return nil, fmt.Errorf("thread is nil")
+			}
+			threadID, err := uuidutil.ParseUUID(thread.GetId(), "thread.id")
+			if err != nil {
+				return nil, err
+			}
+			participant, err := findThreadParticipant(thread, agentID, threadID)
+			if err != nil {
+				return nil, err
+			}
+			if participant.GetPassive() {
+				passiveThreads[threadID] = struct{}{}
+			}
+		}
+		token = page.GetNextPageToken()
+		if token == "" {
+			return passiveThreads, nil
+		}
+	}
+}
+
+func findThreadParticipant(thread *threadsv1.Thread, agentID uuid.UUID, threadID uuid.UUID) (*threadsv1.Participant, error) {
+	participants := thread.GetParticipants()
+	if len(participants) == 0 {
+		return nil, fmt.Errorf("thread %s has no participants", threadID.String())
+	}
+	for _, participant := range participants {
+		if participant == nil {
+			return nil, fmt.Errorf("thread %s has nil participant", threadID.String())
+		}
+		participantID, err := uuidutil.ParseUUID(participant.GetId(), "participant.id")
+		if err != nil {
+			return nil, err
+		}
+		if participantID == agentID {
+			return participant, nil
+		}
+	}
+	return nil, fmt.Errorf("thread %s missing participant %s", threadID.String(), agentID.String())
 }

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -1,0 +1,171 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
+	"github.com/agynio/agents-orchestrator/internal/testutil"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+type fakeAgentsClient struct {
+	testutil.FakeAgentsClient
+	listAgents func(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error)
+}
+
+func (f *fakeAgentsClient) ListAgents(ctx context.Context, req *agentsv1.ListAgentsRequest, opts ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+	if f.listAgents != nil {
+		return f.listAgents(ctx, req, opts...)
+	}
+	return nil, testutil.ErrNotImplemented
+}
+
+type fakeThreadsClient struct {
+	getThreads         func(context.Context, *threadsv1.GetThreadsRequest, ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error)
+	getUnackedMessages func(context.Context, *threadsv1.GetUnackedMessagesRequest, ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error)
+}
+
+func (f *fakeThreadsClient) CreateThread(context.Context, *threadsv1.CreateThreadRequest, ...grpc.CallOption) (*threadsv1.CreateThreadResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
+
+func (f *fakeThreadsClient) ArchiveThread(context.Context, *threadsv1.ArchiveThreadRequest, ...grpc.CallOption) (*threadsv1.ArchiveThreadResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
+
+func (f *fakeThreadsClient) AddParticipant(context.Context, *threadsv1.AddParticipantRequest, ...grpc.CallOption) (*threadsv1.AddParticipantResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
+
+func (f *fakeThreadsClient) SendMessage(context.Context, *threadsv1.SendMessageRequest, ...grpc.CallOption) (*threadsv1.SendMessageResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
+
+func (f *fakeThreadsClient) GetThreads(ctx context.Context, req *threadsv1.GetThreadsRequest, opts ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error) {
+	if f.getThreads != nil {
+		return f.getThreads(ctx, req, opts...)
+	}
+	return nil, testutil.ErrNotImplemented
+}
+
+func (f *fakeThreadsClient) GetMessages(context.Context, *threadsv1.GetMessagesRequest, ...grpc.CallOption) (*threadsv1.GetMessagesResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
+
+func (f *fakeThreadsClient) GetUnackedMessages(ctx context.Context, req *threadsv1.GetUnackedMessagesRequest, opts ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error) {
+	if f.getUnackedMessages != nil {
+		return f.getUnackedMessages(ctx, req, opts...)
+	}
+	return nil, testutil.ErrNotImplemented
+}
+
+func (f *fakeThreadsClient) AckMessages(context.Context, *threadsv1.AckMessagesRequest, ...grpc.CallOption) (*threadsv1.AckMessagesResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
+
+func TestFetchDesiredSkipsPassiveThreads(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	activeThreadID := uuid.New()
+	passiveThreadID := uuid.New()
+	otherParticipantID := uuid.New()
+
+	agents := &fakeAgentsClient{
+		listAgents: func(_ context.Context, _ *agentsv1.ListAgentsRequest, _ ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+			return &agentsv1.ListAgentsResponse{Agents: []*agentsv1.Agent{
+				{Meta: &agentsv1.EntityMeta{Id: agentID.String()}},
+			}}, nil
+		},
+	}
+
+	threads := &fakeThreadsClient{
+		getUnackedMessages: func(_ context.Context, req *threadsv1.GetUnackedMessagesRequest, _ ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error) {
+			if req.GetParticipantId() != agentID.String() {
+				return nil, errors.New("unexpected participant id")
+			}
+			return &threadsv1.GetUnackedMessagesResponse{Messages: []*threadsv1.Message{
+				{Id: uuid.NewString(), ThreadId: activeThreadID.String()},
+				{Id: uuid.NewString(), ThreadId: passiveThreadID.String()},
+			}}, nil
+		},
+		getThreads: func(_ context.Context, req *threadsv1.GetThreadsRequest, _ ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error) {
+			if req.GetParticipantId() != agentID.String() {
+				return nil, errors.New("unexpected participant id")
+			}
+			return &threadsv1.GetThreadsResponse{Threads: []*threadsv1.Thread{
+				{
+					Id: activeThreadID.String(),
+					Participants: []*threadsv1.Participant{
+						{Id: agentID.String(), Passive: false},
+						{Id: otherParticipantID.String(), Passive: false},
+					},
+				},
+				{
+					Id: passiveThreadID.String(),
+					Participants: []*threadsv1.Participant{
+						{Id: agentID.String(), Passive: true},
+						{Id: otherParticipantID.String(), Passive: false},
+					},
+				},
+			}}, nil
+		},
+	}
+
+	reconciler := New(Config{Agents: agents, Threads: threads})
+	result, err := reconciler.fetchDesired(ctx)
+	if err != nil {
+		t.Fatalf("fetch desired: %v", err)
+	}
+
+	expected := []AgentThread{{AgentID: agentID, ThreadID: activeThreadID}}
+	sortAgentThreads(result)
+	sortAgentThreads(expected)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestFetchDesiredSkipsPassiveLookupWithoutMessages(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	getThreadsCalled := false
+
+	agents := &fakeAgentsClient{
+		listAgents: func(_ context.Context, _ *agentsv1.ListAgentsRequest, _ ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+			return &agentsv1.ListAgentsResponse{Agents: []*agentsv1.Agent{
+				{Meta: &agentsv1.EntityMeta{Id: agentID.String()}},
+			}}, nil
+		},
+	}
+
+	threads := &fakeThreadsClient{
+		getUnackedMessages: func(_ context.Context, req *threadsv1.GetUnackedMessagesRequest, _ ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error) {
+			if req.GetParticipantId() != agentID.String() {
+				return nil, errors.New("unexpected participant id")
+			}
+			return &threadsv1.GetUnackedMessagesResponse{}, nil
+		},
+		getThreads: func(context.Context, *threadsv1.GetThreadsRequest, ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error) {
+			getThreadsCalled = true
+			return nil, errors.New("unexpected get threads")
+		},
+	}
+
+	reconciler := New(Config{Agents: agents, Threads: threads})
+	result, err := reconciler.fetchDesired(ctx)
+	if err != nil {
+		t.Fatalf("fetch desired: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected no desired workloads, got %+v", result)
+	}
+	if getThreadsCalled {
+		t.Fatalf("expected no get threads call")
+	}
+}


### PR DESCRIPTION
## Summary
- filter desired workload starts using passive thread participants
- add passive participant tests for desired workload selection
- update reconciler fakes for new runner/runners client methods

## Testing
- GOMAXPROCS=2 go test -p 1 ./...
- GOMAXPROCS=2 go vet -p 1 ./...

Closes #132