### PR TITLE
feat(reconciler): apply per-agent idle timeouts

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,7 +132,7 @@ func FromEnv() (Config, error) {
 
 	idleTimeout := os.Getenv("IDLE_TIMEOUT")
 	if idleTimeout == "" {
-		cfg.IdleTimeout = 10 * time.Minute
+		cfg.IdleTimeout = 5 * time.Minute
 	} else {
 		parsed, err := time.ParseDuration(idleTimeout)
 		if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,6 +28,9 @@ func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	if cfg.ZitiEnrollmentTimeout != 2*time.Minute {
 		t.Fatalf("expected ziti enrollment timeout %q, got %q", 2*time.Minute, cfg.ZitiEnrollmentTimeout)
 	}
+	if cfg.IdleTimeout != 5*time.Minute {
+		t.Fatalf("expected idle timeout %q, got %q", 5*time.Minute, cfg.IdleTimeout)
+	}
 }
 
 func TestFromEnvDefaultsZiti(t *testing.T) {

--- a/internal/reconciler/desired.go
+++ b/internal/reconciler/desired.go
@@ -3,6 +3,7 @@ package reconciler
 import (
 	"context"
 	"fmt"
+	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
@@ -17,27 +18,33 @@ type AgentThread struct {
 	ThreadID uuid.UUID
 }
 
-func (r *Reconciler) fetchDesired(ctx context.Context) ([]AgentThread, error) {
+func (r *Reconciler) fetchDesired(ctx context.Context) ([]AgentThread, map[uuid.UUID]time.Duration, error) {
 	agents, err := r.listAgents(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	unique := make(map[AgentThread]struct{})
+	idleTimeouts := make(map[uuid.UUID]time.Duration, len(agents))
 	for _, agent := range agents {
 		if agent == nil {
-			return nil, fmt.Errorf("agent is nil")
+			return nil, nil, fmt.Errorf("agent is nil")
 		}
 		meta := agent.GetMeta()
 		if meta == nil {
-			return nil, fmt.Errorf("agent meta missing")
+			return nil, nil, fmt.Errorf("agent meta missing")
 		}
 		agentID, err := uuidutil.ParseUUID(meta.GetId(), "agent.meta.id")
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		idleTimeout, err := agentIdleTimeout(agent, agentID, r.idle)
+		if err != nil {
+			return nil, nil, err
+		}
+		idleTimeouts[agentID] = idleTimeout
 		threadIDs, err := r.listUnackedThreads(ctx, agentID)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if len(threadIDs) == 0 {
 			continue
@@ -57,7 +64,22 @@ func (r *Reconciler) fetchDesired(ctx context.Context) ([]AgentThread, error) {
 	for key := range unique {
 		result = append(result, key)
 	}
-	return result, nil
+	return result, idleTimeouts, nil
+}
+
+func agentIdleTimeout(agent *agentsv1.Agent, agentID uuid.UUID, fallback time.Duration) (time.Duration, error) {
+	if agent.IdleTimeout == nil {
+		return fallback, nil
+	}
+	value := agent.GetIdleTimeout()
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse agent %s idle_timeout: %w", agentID, err)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("agent %s idle_timeout must be greater than 0", agentID)
+	}
+	return parsed, nil
 }
 
 func (r *Reconciler) listAgents(ctx context.Context) ([]*agentsv1.Agent, error) {

--- a/internal/reconciler/desired.go
+++ b/internal/reconciler/desired.go
@@ -51,7 +51,7 @@ func (r *Reconciler) fetchDesired(ctx context.Context) ([]AgentThread, map[uuid.
 		}
 		passiveThreads, err := r.fetchPassiveThreads(ctx, agentID)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		for _, threadID := range threadIDs {
 			if _, ok := passiveThreads[threadID]; ok {

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -117,7 +117,7 @@ func TestFetchDesiredSkipsPassiveThreads(t *testing.T) {
 	}
 
 	reconciler := New(Config{Agents: agents, Threads: threads})
-	result, err := reconciler.fetchDesired(ctx)
+	result, _, err := reconciler.fetchDesired(ctx)
 	if err != nil {
 		t.Fatalf("fetch desired: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestFetchDesiredSkipsPassiveLookupWithoutMessages(t *testing.T) {
 	}
 
 	reconciler := New(Config{Agents: agents, Threads: threads})
-	result, err := reconciler.fetchDesired(ctx)
+	result, _, err := reconciler.fetchDesired(ctx)
 	if err != nil {
 		t.Fatalf("fetch desired: %v", err)
 	}

--- a/internal/reconciler/diff.go
+++ b/internal/reconciler/diff.go
@@ -6,6 +6,7 @@ import (
 
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
+	"github.com/google/uuid"
 )
 
 type Actions struct {
@@ -14,11 +15,11 @@ type Actions struct {
 }
 
 type workloadEntry struct {
-	workload  *runnersv1.Workload
-	startedAt time.Time
+	workload   *runnersv1.Workload
+	activityAt time.Time
 }
 
-func ComputeActions(desired []AgentThread, actual []*runnersv1.Workload, idleTimeout time.Duration, now time.Time) (Actions, error) {
+func ComputeActions(desired []AgentThread, actual []*runnersv1.Workload, idleTimeouts map[uuid.UUID]time.Duration, fallbackIdleTimeout time.Duration, now time.Time) (Actions, error) {
 	desiredSet := make(map[AgentThread]struct{}, len(desired))
 	for _, item := range desired {
 		desiredSet[item] = struct{}{}
@@ -33,17 +34,12 @@ func ComputeActions(desired []AgentThread, actual []*runnersv1.Workload, idleTim
 		if err != nil {
 			return Actions{}, err
 		}
-		meta := workload.GetMeta()
-		createdAt := meta.GetCreatedAt()
-		if createdAt == nil {
-			return Actions{}, fmt.Errorf("workload meta created_at missing")
-		}
-		activityAt := workload.GetLastActivityAt()
-		if activityAt == nil {
-			activityAt = createdAt
+		activityAt, err := workloadActivityAt(workload)
+		if err != nil {
+			return Actions{}, err
 		}
 		key := AgentThread{AgentID: agentID, ThreadID: threadID}
-		actualSet[key] = workloadEntry{workload: workload, startedAt: activityAt.AsTime()}
+		actualSet[key] = workloadEntry{workload: workload, activityAt: activityAt}
 	}
 	result := Actions{}
 	for _, item := range desired {
@@ -55,9 +51,28 @@ func ComputeActions(desired []AgentThread, actual []*runnersv1.Workload, idleTim
 		if _, ok := desiredSet[key]; ok {
 			continue
 		}
-		if now.Sub(entry.startedAt) > idleTimeout {
+		idleTimeout, ok := idleTimeouts[key.AgentID]
+		if !ok {
+			idleTimeout = fallbackIdleTimeout
+		}
+		if now.Sub(entry.activityAt) > idleTimeout {
 			result.ToStop = append(result.ToStop, entry.workload)
 		}
 	}
 	return result, nil
+}
+
+func workloadActivityAt(workload *runnersv1.Workload) (time.Time, error) {
+	meta := workload.GetMeta()
+	if meta == nil {
+		return time.Time{}, fmt.Errorf("workload meta missing")
+	}
+	if lastActivity := workload.GetLastActivityAt(); lastActivity != nil {
+		return lastActivity.AsTime(), nil
+	}
+	createdAt := meta.GetCreatedAt()
+	if createdAt == nil {
+		return time.Time{}, fmt.Errorf("workload meta created_at missing")
+	}
+	return createdAt.AsTime(), nil
 }

--- a/internal/reconciler/diff_test.go
+++ b/internal/reconciler/diff_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestComputeActions(t *testing.T) {
 	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
-	idleTimeout := 10 * time.Minute
 
 	agent1 := uuid.New()
 	thread1 := uuid.New()
@@ -21,13 +20,23 @@ func TestComputeActions(t *testing.T) {
 	thread2 := uuid.New()
 	agent3 := uuid.New()
 	thread3 := uuid.New()
+	missingAgent := uuid.New()
+	missingThread := uuid.New()
+	idleTimeouts := map[uuid.UUID]time.Duration{
+		agent1: 30 * time.Minute,
+		agent2: 15 * time.Minute,
+		agent3: 10 * time.Minute,
+	}
+	idleFallback := 12 * time.Minute
 
-	workload1 := makeWorkload(agent1, thread1, now)
-	workload2 := makeWorkload(agent3, thread3, now.Add(-20*time.Minute))
-	workload3 := makeWorkload(agent1, thread1, now.Add(-20*time.Minute))
-	workload4 := makeWorkload(agent1, thread1, now.Add(-5*time.Minute))
-	workload5 := makeWorkload(agent2, thread2, now.Add(-30*time.Minute))
-	workload5.LastActivityAt = timestamppb.New(now.Add(-5 * time.Minute))
+	activityOld := now.Add(-20 * time.Minute)
+
+	workload1 := makeWorkload(agent1, thread1, now, nil)
+	workload2 := makeWorkload(agent3, thread3, now.Add(-1*time.Minute), &activityOld)
+	workload3 := makeWorkload(agent1, thread1, now.Add(-20*time.Minute), nil)
+	workload4 := makeWorkload(agent1, thread1, now.Add(-5*time.Minute), nil)
+	workload5 := makeWorkload(agent2, thread2, now.Add(-20*time.Minute), nil)
+	workload6 := makeWorkload(missingAgent, missingThread, now.Add(-20*time.Minute), nil)
 
 	cases := []struct {
 		name     string
@@ -50,19 +59,29 @@ func TestComputeActions(t *testing.T) {
 			},
 		},
 		{
-			name:   "stop idle",
+			name:   "stop idle by activity",
 			actual: []*runnersv1.Workload{workload2},
 			expected: Actions{
 				ToStop: []*runnersv1.Workload{workload2},
 			},
 		},
 		{
-			name:   "keep recent",
-			actual: []*runnersv1.Workload{workload4},
+			name:   "stop idle by created_at",
+			actual: []*runnersv1.Workload{workload5},
+			expected: Actions{
+				ToStop: []*runnersv1.Workload{workload5},
+			},
 		},
 		{
-			name:   "idle uses last activity",
-			actual: []*runnersv1.Workload{workload5},
+			name:   "stop idle with fallback",
+			actual: []*runnersv1.Workload{workload6},
+			expected: Actions{
+				ToStop: []*runnersv1.Workload{workload6},
+			},
+		},
+		{
+			name:   "keep recent",
+			actual: []*runnersv1.Workload{workload4},
 		},
 		{
 			name:    "match",
@@ -85,7 +104,7 @@ func TestComputeActions(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			result, err := ComputeActions(testCase.desired, testCase.actual, idleTimeout, now)
+			result, err := ComputeActions(testCase.desired, testCase.actual, idleTimeouts, idleFallback, now)
 			if err != nil {
 				t.Fatalf("compute actions: %v", err)
 			}
@@ -100,15 +119,19 @@ func TestComputeActions(t *testing.T) {
 	}
 }
 
-func makeWorkload(agentID, threadID uuid.UUID, startedAt time.Time) *runnersv1.Workload {
-	return &runnersv1.Workload{
+func makeWorkload(agentID, threadID uuid.UUID, createdAt time.Time, lastActivityAt *time.Time) *runnersv1.Workload {
+	workload := &runnersv1.Workload{
 		Meta: &runnersv1.EntityMeta{
 			Id:        uuid.NewString(),
-			CreatedAt: timestamppb.New(startedAt),
+			CreatedAt: timestamppb.New(createdAt),
 		},
 		AgentId:  agentID.String(),
 		ThreadId: threadID.String(),
 	}
+	if lastActivityAt != nil {
+		workload.LastActivityAt = timestamppb.New(*lastActivityAt)
+	}
+	return workload
 }
 
 func sortAgentThreads(values []AgentThread) {

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -826,6 +826,10 @@ func (f *fakeRunnersClient) UpdateWorkloadStatus(ctx context.Context, req *runne
 	return nil, errNotImplemented
 }
 
+func (f *fakeRunnersClient) TouchWorkload(context.Context, *runnersv1.TouchWorkloadRequest, ...grpc.CallOption) (*runnersv1.TouchWorkloadResponse, error) {
+	return nil, errNotImplemented
+}
+
 func (f *fakeRunnersClient) DeleteWorkload(ctx context.Context, req *runnersv1.DeleteWorkloadRequest, opts ...grpc.CallOption) (*runnersv1.DeleteWorkloadResponse, error) {
 	if f.deleteWorkload != nil {
 		return f.deleteWorkload(ctx, req, opts...)
@@ -845,6 +849,26 @@ func (f *fakeRunnersClient) ListWorkloadsByThread(ctx context.Context, req *runn
 	if f.listWorkloadsByThread != nil {
 		return f.listWorkloadsByThread(ctx, req, opts...)
 	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeRunnersClient) CreateVolume(context.Context, *runnersv1.CreateVolumeRequest, ...grpc.CallOption) (*runnersv1.CreateVolumeResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeRunnersClient) UpdateVolume(context.Context, *runnersv1.UpdateVolumeRequest, ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeRunnersClient) GetVolume(context.Context, *runnersv1.GetVolumeRequest, ...grpc.CallOption) (*runnersv1.GetVolumeResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeRunnersClient) ListVolumes(context.Context, *runnersv1.ListVolumesRequest, ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeRunnersClient) ListVolumesByThread(context.Context, *runnersv1.ListVolumesByThreadRequest, ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error) {
 	return nil, errNotImplemented
 }
 

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -826,10 +826,6 @@ func (f *fakeRunnersClient) UpdateWorkloadStatus(ctx context.Context, req *runne
 	return nil, errNotImplemented
 }
 
-func (f *fakeRunnersClient) TouchWorkload(context.Context, *runnersv1.TouchWorkloadRequest, ...grpc.CallOption) (*runnersv1.TouchWorkloadResponse, error) {
-	return nil, errNotImplemented
-}
-
 func (f *fakeRunnersClient) DeleteWorkload(ctx context.Context, req *runnersv1.DeleteWorkloadRequest, opts ...grpc.CallOption) (*runnersv1.DeleteWorkloadResponse, error) {
 	if f.deleteWorkload != nil {
 		return f.deleteWorkload(ctx, req, opts...)
@@ -849,26 +845,6 @@ func (f *fakeRunnersClient) ListWorkloadsByThread(ctx context.Context, req *runn
 	if f.listWorkloadsByThread != nil {
 		return f.listWorkloadsByThread(ctx, req, opts...)
 	}
-	return nil, errNotImplemented
-}
-
-func (f *fakeRunnersClient) CreateVolume(context.Context, *runnersv1.CreateVolumeRequest, ...grpc.CallOption) (*runnersv1.CreateVolumeResponse, error) {
-	return nil, errNotImplemented
-}
-
-func (f *fakeRunnersClient) UpdateVolume(context.Context, *runnersv1.UpdateVolumeRequest, ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error) {
-	return nil, errNotImplemented
-}
-
-func (f *fakeRunnersClient) GetVolume(context.Context, *runnersv1.GetVolumeRequest, ...grpc.CallOption) (*runnersv1.GetVolumeResponse, error) {
-	return nil, errNotImplemented
-}
-
-func (f *fakeRunnersClient) ListVolumes(context.Context, *runnersv1.ListVolumesRequest, ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
-	return nil, errNotImplemented
-}
-
-func (f *fakeRunnersClient) ListVolumesByThread(context.Context, *runnersv1.ListVolumesByThreadRequest, ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error) {
 	return nil, errNotImplemented
 }
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -94,7 +94,7 @@ func (r *Reconciler) runCycle(ctx context.Context) {
 }
 
 func (r *Reconciler) reconcile(ctx context.Context) error {
-	desired, err := r.fetchDesired(ctx)
+	desired, idleTimeouts, err := r.fetchDesired(ctx)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	actions, err := ComputeActions(desired, actual, r.idle, time.Now().UTC())
+	actions, err := ComputeActions(desired, actual, idleTimeouts, r.idle, time.Now().UTC())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- apply per-agent idle timeouts with last_activity_at fallback
- default idle timeout to 5m and assert in config tests
- extend reconciler fakes for runner volume/workload methods

## Testing
- GOMAXPROCS=2 go test -p 1 ./...
- GOMAXPROCS=2 go vet -p 1 ./...

## Issue
- #119