### PR TITLE
feat: add gateway url env and exec test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,10 +72,12 @@ require (
 	github.com/miekg/pkcs11 v1.1.2 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/muhlemmer/gu v0.3.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/openziti/channel/v4 v4.3.9 // indirect
 	github.com/openziti/foundation/v2 v2.0.90 // indirect

--- a/go.sum
+++ b/go.sum
@@ -319,6 +319,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -333,6 +335,8 @@ github.com/muhlemmer/httpforwarded v0.1.0 h1:x4DLrzXdliq8mprgUMR0olDvHGkou5BJsK/
 github.com/muhlemmer/httpforwarded v0.1.0/go.mod h1:yo9czKedo2pdZhoXe+yDkGVbU0TJ0q9oQ90BVoDEtw0=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -537,8 +537,10 @@ func (a *Assembler) buildMcpSidecar(ctx context.Context, resolver *envResolver, 
 	if err != nil {
 		return nil, err
 	}
+	gatewayURL := buildGatewayURL(a.cfg.AgentGatewayAddress)
 	envVars = append(envVars, &runnerv1.EnvVar{Name: "MCP_PORT", Value: strconv.Itoa(port)})
 	envVars = append(envVars, &runnerv1.EnvVar{Name: "GATEWAY_ADDRESS", Value: a.cfg.AgentGatewayAddress})
+	envVars = append(envVars, &runnerv1.EnvVar{Name: "AGYN_GATEWAY_URL", Value: gatewayURL})
 	return &runnerv1.ContainerSpec{
 		Image:  mcp.GetImage(),
 		Name:   fmt.Sprintf("mcp-%s", mcpID.String()[:8]),
@@ -569,7 +571,15 @@ func (a *Assembler) buildHookSidecar(ctx context.Context, resolver *envResolver,
 	}, nil
 }
 
+func buildGatewayURL(address string) string {
+	if strings.Contains(address, "://") {
+		return address
+	}
+	return "http://" + address
+}
+
 func (a *Assembler) baseAgentEnvVars(ctx context.Context, agent *agentsv1.Agent, agentID, threadID uuid.UUID, skillsJSON, initScript string) []*runnerv1.EnvVar {
+	gatewayURL := buildGatewayURL(a.cfg.AgentGatewayAddress)
 	vars := []*runnerv1.EnvVar{
 		{Name: "AGENT_ID", Value: agentID.String()},
 		{Name: "AGENT_NAME", Value: agent.GetName()},
@@ -578,6 +588,7 @@ func (a *Assembler) baseAgentEnvVars(ctx context.Context, agent *agentsv1.Agent,
 		{Name: "AGENT_CONFIG", Value: agent.GetConfiguration()},
 		{Name: "THREAD_ID", Value: threadID.String()},
 		{Name: "GATEWAY_ADDRESS", Value: a.cfg.AgentGatewayAddress},
+		{Name: "AGYN_GATEWAY_URL", Value: gatewayURL},
 		{Name: "LLM_BASE_URL", Value: a.cfg.AgentLLMBaseURL},
 		{Name: "WORKSPACE_DIR", Value: agentWorkspaceDir},
 		{Name: "HOME", Value: agentHomeDir},

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -173,6 +173,7 @@ func TestAssemblerMainContainer(t *testing.T) {
 	assertEnv(t, envs, "AGENT_CONFIG", agent.GetConfiguration())
 	assertEnv(t, envs, "THREAD_ID", threadID.String())
 	assertEnv(t, envs, "GATEWAY_ADDRESS", cfg.AgentGatewayAddress)
+	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://"+cfg.AgentGatewayAddress)
 	assertEnv(t, envs, "LLM_BASE_URL", cfg.AgentLLMBaseURL)
 	assertEnv(t, envs, "TRACING_ADDRESS", cfg.AgentTracingAddress)
 	assertEnv(t, envs, "WORKSPACE_DIR", agentWorkspaceDir)
@@ -353,6 +354,7 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 	assembler := New(&testutil.FakeAgentsClient{}, &testutil.FakeSecretsClient{}, &cfg)
 	envs := envMap(assembler.baseAgentEnvVars(ctx, agent, agentID, threadID, "[]", ""))
 	assertEnv(t, envs, "GATEWAY_ADDRESS", "gateway.ziti:443")
+	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://gateway.ziti:443")
 	assertEnv(t, envs, "LLM_BASE_URL", "http://llm-proxy.ziti/v1")
 }
 
@@ -661,6 +663,7 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 	assertEnv(t, envs, "MCP_ENV", "enabled")
 	assertEnv(t, envs, "INIT_SCRIPT", "echo mcp")
 	assertEnv(t, envs, "GATEWAY_ADDRESS", cfg.AgentGatewayAddress)
+	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://"+cfg.AgentGatewayAddress)
 }
 
 func TestAssemblerMcpPortAllocation(t *testing.T) {
@@ -725,6 +728,7 @@ func TestAssemblerMcpPortAllocation(t *testing.T) {
 			t.Fatalf("missing MCP_PORT for sidecar %s", sidecar.Name)
 		}
 		assertEnv(t, envs, "GATEWAY_ADDRESS", cfg.AgentGatewayAddress)
+		assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://"+cfg.AgentGatewayAddress)
 		ports[sidecar.Name] = port
 	}
 	expectedMemoryName := "mcp-" + lowID[:8]

--- a/test/e2e/expose_test.go
+++ b/test/e2e/expose_test.go
@@ -1,0 +1,148 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	llmv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/llm/v1"
+	organizationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/organizations/v1"
+	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
+	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
+	usersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/users/v1"
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAgentExposeListExec(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	t.Cleanup(cancel)
+
+	agentsConn := dialGRPC(t, agentsAddr)
+	threadsConn := dialGRPC(t, threadsAddr)
+	runnerConn := dialRunnerGRPC(t, runnerAddr)
+	usersConn := dialGRPC(t, usersAddr)
+	orgsConn := dialGRPC(t, orgsAddr)
+
+	agentsClient := agentsv1.NewAgentsServiceClient(agentsConn)
+	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
+	llmConn := dialGRPC(t, llmAddr)
+	llmClient := llmv1.NewLLMServiceClient(llmConn)
+	usersClient := usersv1.NewUsersServiceClient(usersConn)
+	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
+	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
+
+	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	token := createAPIToken(t, ctx, usersClient, identityID)
+	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
+
+	provider := createLLMProvider(t, ctx, llmClient, testLLMEndpointAgn, orgID)
+	providerID := provider.GetMeta().GetId()
+	if providerID == "" {
+		t.Fatal("create llm provider: missing id")
+	}
+	model := createModel(t, ctx, llmClient, "e2e-expose-model-"+uuid.NewString(), providerID, "simple-hello", orgID)
+	modelID := model.GetMeta().GetId()
+	if modelID == "" {
+		t.Fatal("create model: missing id")
+	}
+
+	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-expose-%s", uuid.NewString()), modelID, orgID, agnInitImage)
+	agentID := agent.GetMeta().GetId()
+	if agentID == "" {
+		t.Fatal("create agent: missing id")
+	}
+	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
+	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
+
+	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	threadID := thread.GetId()
+	if threadID == "" {
+		t.Fatal("create thread: missing id")
+	}
+	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
+
+	labels := map[string]string{
+		labelManagedBy: managedByValue,
+		labelAgentID:   agentID,
+		labelThreadID:  threadID,
+	}
+	t.Cleanup(func() {
+		ids, err := findWorkloadsByLabels(ctx, runnerClient, labels)
+		if err != nil {
+			t.Logf("cleanup: find workloads: %v", err)
+			return
+		}
+		for _, workloadID := range ids {
+			cleanupWorkload(t, ctx, runnerClient, workloadID)
+		}
+	})
+
+	expectedResponse := "Hi! How are you?"
+	sentMessage := sendMessage(t, ctx, threadsClient, threadID, identityID, "hi")
+	sentMessageTime := messageCreatedAt(t, sentMessage)
+
+	pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer pollCancel()
+	agentBody, err := pollForAgentResponse(t, pollCtx, threadsClient, runnerClient, threadID, agentID, labels, sentMessageTime, expectedResponse)
+	if err != nil {
+		t.Fatalf("wait for agent response: %v", err)
+	}
+	if agentBody != expectedResponse {
+		t.Fatalf("expected agent response %q, got %q", expectedResponse, agentBody)
+	}
+
+	workloadIDs, err := findWorkloadsByLabels(ctx, runnerClient, labels)
+	if err != nil {
+		t.Fatalf("find workloads: %v", err)
+	}
+	if len(workloadIDs) == 0 {
+		t.Fatal("expected workload id")
+	}
+
+	execCtx, execCancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer execCancel()
+	podName, containerName, err := waitForWorkloadAgentContainerReady(t, execCtx, workloadIDs[0])
+	if err != nil {
+		t.Fatalf("wait for agent container: %v", err)
+	}
+	result := execPodCommand(t, execCtx, workloadNamespace(t), podName, containerName, []string{"/agyn-bin/cli/agyn", "expose", "list"})
+	if result.exitCode != 0 {
+		t.Fatalf("expected expose list exit code 0, got %d stdout=%q stderr=%q", result.exitCode, result.stdout, result.stderr)
+	}
+}
+
+func waitForWorkloadAgentContainerReady(t *testing.T, ctx context.Context, workloadID string) (string, string, error) {
+	t.Helper()
+	namespace := workloadNamespace(t)
+	podName := fmt.Sprintf("workload-%s", workloadID)
+	clientset := kubeClientset(t)
+	containerName := ""
+	err := pollUntil(ctx, pollInterval, func(ctx context.Context) error {
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("get pod %s: %w", podName, err)
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			return fmt.Errorf("pod %s not running", pod.Name)
+		}
+		name, err := agentContainerName(pod)
+		if err != nil {
+			return err
+		}
+		if !containerReady(pod, name) {
+			return fmt.Errorf("container %s not ready", name)
+		}
+		containerName = name
+		return nil
+	})
+	if err != nil {
+		return "", "", err
+	}
+	return podName, containerName, nil
+}

--- a/test/e2e/expose_test.go
+++ b/test/e2e/expose_test.go
@@ -36,6 +36,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
+	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.3.3")
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	token := createAPIToken(t, ctx, usersClient, identityID)
@@ -52,7 +53,7 @@ func TestAgentExposeListExec(t *testing.T) {
 		t.Fatal("create model: missing id")
 	}
 
-	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-expose-%s", uuid.NewString()), modelID, orgID, agnInitImage)
+	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-expose-%s", uuid.NewString()), modelID, orgID, exposeInitImage)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")

--- a/test/e2e/expose_test.go
+++ b/test/e2e/expose_test.go
@@ -36,7 +36,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
-	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.3.3")
+	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.3.5")
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	token := createAPIToken(t, ctx, usersClient, identityID)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -54,8 +54,8 @@ var (
 	runnerAddr     = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:mcp-host-20260412-3")
-	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:mcp-host-20260412-6")
+	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.4")
+	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.3.3")
 )
 
 type pipelineRun struct {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -54,8 +54,8 @@ var (
 	runnerAddr     = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.4")
-	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.3.3")
+	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:mcp-host-20260412-3")
+	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:mcp-host-20260412-6")
 )
 
 type pipelineRun struct {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,7 +4,9 @@ package e2e
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -20,7 +22,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	clientexec "k8s.io/client-go/util/exec"
 )
 
 const (
@@ -360,17 +365,77 @@ func ackMessages(t *testing.T, ctx context.Context, client threadsv1.ThreadsServ
 	}
 }
 
-func kubeClientset(t *testing.T) *kubernetes.Clientset {
+type podExecResult struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+func kubeRestConfig(t *testing.T) *rest.Config {
 	t.Helper()
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		t.Fatalf("load in-cluster config: %v", err)
 	}
-	clientset, err := kubernetes.NewForConfig(config)
+	return config
+}
+
+func kubeClientset(t *testing.T) *kubernetes.Clientset {
+	t.Helper()
+	clientset, err := kubernetes.NewForConfig(kubeRestConfig(t))
 	if err != nil {
 		t.Fatalf("create kubernetes clientset: %v", err)
 	}
 	return clientset
+}
+
+func execPodCommand(
+	t *testing.T,
+	ctx context.Context,
+	namespace string,
+	podName string,
+	containerName string,
+	command []string,
+) podExecResult {
+	t.Helper()
+	config := kubeRestConfig(t)
+	req := kubeClientset(t).CoreV1().RESTClient().Post().
+		Namespace(namespace).
+		Resource("pods").
+		Name(podName).
+		SubResource("exec")
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: containerName,
+		Command:   command,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		t.Fatalf("create exec pod=%s container=%s: %v", podName, containerName, err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	exitCode := 0
+	if err != nil {
+		var exitErr clientexec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitStatus()
+		} else {
+			t.Fatalf("exec pod=%s container=%s: %v", podName, containerName, err)
+		}
+	}
+
+	return podExecResult{stdout: stdout.String(), stderr: stderr.String(), exitCode: exitCode}
 }
 
 func currentNamespace(t *testing.T) string {
@@ -581,6 +646,30 @@ func mcpContainerNames(pod *corev1.Pod) []string {
 		}
 	}
 	return containers
+}
+
+func agentContainerName(pod *corev1.Pod) (string, error) {
+	if pod == nil {
+		return "", fmt.Errorf("pod is nil")
+	}
+	for _, container := range pod.Spec.Containers {
+		if strings.HasPrefix(container.Name, "agent-") {
+			return container.Name, nil
+		}
+	}
+	return "", fmt.Errorf("pod %s has no agent container", pod.Name)
+}
+
+func containerReady(pod *corev1.Pod, containerName string) bool {
+	if pod == nil {
+		return false
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == containerName {
+			return status.Ready
+		}
+	}
+	return false
 }
 
 func containerLogsContain(

--- a/test/e2e/rbac/workloads-role.yaml
+++ b/test/e2e/rbac/workloads-role.yaml
@@ -9,3 +9,6 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "secrets"]
     verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]

--- a/test/e2e/tracing_availability_test.go
+++ b/test/e2e/tracing_availability_test.go
@@ -23,12 +23,19 @@ import (
 )
 
 var (
+	e2eSkipReason            string
 	tracingAvailable         bool
 	tracingUnavailableReason string
 	tracingSkipReason        string
 )
 
 func TestMain(m *testing.M) {
+	e2eSkipReason = skipE2EReason()
+	if e2eSkipReason != "" {
+		log.Printf("e2e skipped: %s", e2eSkipReason)
+		os.Exit(0)
+	}
+
 	tracingSkipReason = skipTracingReason()
 	if tracingSkipReason != "" {
 		log.Printf("tracing e2e skipped: %s", tracingSkipReason)
@@ -125,6 +132,23 @@ func skipTracingReason() string {
 				return "SKIP_TRACING_E2E set"
 			}
 			return fmt.Sprintf("SKIP_TRACING_E2E=%s", trimmed)
+		}
+	}
+	return ""
+}
+
+func skipE2EReason() string {
+	if strings.TrimSpace(os.Getenv("KUBERNETES_SERVICE_HOST")) == "" {
+		return "KUBERNETES_SERVICE_HOST not set"
+	}
+	serviceAccountPaths := []string{
+		"/var/run/secrets/kubernetes.io/serviceaccount/token",
+		"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+		"/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+	}
+	for _, path := range serviceAccountPaths {
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Sprintf("service account file missing: %s", path)
 		}
 	}
 	return ""


### PR DESCRIPTION
## Summary
- inject AGYN_GATEWAY_URL for workload containers derived from GATEWAY_ADDRESS
- add pod exec helper, RBAC update, and agn expose list e2e test
- extend test fakes for updated runner/runners interfaces

## Testing
- GOMAXPROCS=2 go vet -p 1 ./...
- GOMAXPROCS=2 go test -p 1 ./...

Fixes #122