### PR TITLE
fix(ziti): pass workload id to identity

### DIFF
--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -45,6 +45,9 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if req.GetAgentId() != agentID.String() {
 				return nil, errors.New("unexpected agent id")
 			}
+			if req.GetWorkloadId() == "" {
+				return nil, errors.New("missing workload id")
+			}
 			return &zitimgmtv1.CreateAgentIdentityResponse{ZitiIdentityId: zitiID, EnrollmentJwt: jwt}, nil
 		},
 	}
@@ -266,8 +269,11 @@ func TestStartWorkloadDeletesIdentityOnRunnerError(t *testing.T) {
 
 	var calls []string
 	zitiMgmt := &fakeZitiMgmtClient{
-		createAgentIdentity: func(_ context.Context, _ *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
+		createAgentIdentity: func(_ context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 			calls = append(calls, "create")
+			if req.GetWorkloadId() == "" {
+				return nil, errors.New("missing workload id")
+			}
 			return &zitimgmtv1.CreateAgentIdentityResponse{ZitiIdentityId: zitiID, EnrollmentJwt: "jwt"}, nil
 		},
 		deleteIdentity: func(_ context.Context, req *zitimgmtv1.DeleteIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.DeleteIdentityResponse, error) {
@@ -341,8 +347,11 @@ func TestStartWorkloadStopsAndDeletesIdentityOnStoreFailure(t *testing.T) {
 
 	var calls []string
 	zitiMgmt := &fakeZitiMgmtClient{
-		createAgentIdentity: func(_ context.Context, _ *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
+		createAgentIdentity: func(_ context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 			calls = append(calls, "create")
+			if req.GetWorkloadId() == "" {
+				return nil, errors.New("missing workload id")
+			}
 			return &zitimgmtv1.CreateAgentIdentityResponse{ZitiIdentityId: zitiID, EnrollmentJwt: "jwt"}, nil
 		},
 		deleteIdentity: func(_ context.Context, req *zitimgmtv1.DeleteIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.DeleteIdentityResponse, error) {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -139,12 +139,13 @@ func (i *identityInfo) idPtr() *string {
 	return &i.id
 }
 
-func (r *Reconciler) createIdentity(ctx context.Context, target AgentThread) (*identityInfo, error) {
+func (r *Reconciler) createIdentity(ctx context.Context, target AgentThread, workloadID uuid.UUID) (*identityInfo, error) {
 	if r.zitiMgmt == nil {
 		return nil, nil
 	}
 	identityResp, err := r.zitiMgmt.CreateAgentIdentity(ctx, &zitimgmtv1.CreateAgentIdentityRequest{
-		AgentId: target.AgentID.String(),
+		AgentId:    target.AgentID.String(),
+		WorkloadId: workloadID.String(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create ziti identity for agent %s thread %s: %w", target.AgentID.String(), target.ThreadID.String(), err)
@@ -203,7 +204,8 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		log.Printf("reconciler: build volume records for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 		return
 	}
-	identity, err := r.createIdentity(ctx, target)
+	workloadID := uuid.New()
+	identity, err := r.createIdentity(ctx, target, workloadID)
 	if err != nil {
 		log.Printf("reconciler: %v", err)
 		return


### PR DESCRIPTION
## Summary
- pass workload IDs when creating agent identities in the reconciler
- generate workload IDs before requesting ziti identity creation
- assert workload IDs in ziti management test fakes

## Testing
- GOMAXPROCS=2 go vet -p 1 ./...
- GOMAXPROCS=2 go test -p 1 ./internal/reconciler/...

Related to agynio/agents-orchestrator#124.