### PR TITLE
feat: add agyn cli to PATH

### DIFF
--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -24,6 +24,7 @@ const (
 	agynBinVolumeName                    = "agyn-bin"
 	agynBinMountPath                     = "/agyn-bin"
 	agynBinBinaryPath                    = "/agyn-bin/agynd"
+	agynBinCLIDir                        = "/agyn-bin/cli"
 	agentWorkspaceDir                    = "/tmp"
 	agentHomeDir                         = "/root"
 	mcpBasePort                          = 8100
@@ -115,6 +116,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 
 	mainEnv := a.baseAgentEnvVars(ctx, agent, agentID, threadID, skillsJSON, agentInitScript)
 	mainEnv = append(mainEnv, agentEnvVars...)
+	mainEnv = ensureAgynCLIPath(mainEnv)
 
 	initImage := agent.GetInitImage()
 	if initImage == "" {
@@ -576,6 +578,40 @@ func buildGatewayURL(address string) string {
 		return address
 	}
 	return "http://" + address
+}
+
+func ensureAgynCLIPath(envs []*runnerv1.EnvVar) []*runnerv1.EnvVar {
+	const pathEnvName = "PATH"
+	lastIndex := -1
+	for i, env := range envs {
+		if env == nil {
+			continue
+		}
+		if env.Name == pathEnvName {
+			lastIndex = i
+		}
+	}
+	if lastIndex == -1 {
+		return append(envs, &runnerv1.EnvVar{Name: pathEnvName, Value: fmt.Sprintf("$(PATH):%s", agynBinCLIDir)})
+	}
+	env := envs[lastIndex]
+	env.Value = appendPathSegment(env.Value, agynBinCLIDir)
+	envs[lastIndex] = env
+	return envs
+}
+
+func appendPathSegment(value, segment string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return segment
+	}
+	parts := strings.Split(trimmed, ":")
+	for _, part := range parts {
+		if strings.TrimSpace(part) == segment {
+			return trimmed
+		}
+	}
+	return trimmed + ":" + segment
 }
 
 func (a *Assembler) baseAgentEnvVars(ctx context.Context, agent *agentsv1.Agent, agentID, threadID uuid.UUID, skillsJSON, initScript string) []*runnerv1.EnvVar {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -180,6 +180,7 @@ func TestAssemblerMainContainer(t *testing.T) {
 	assertEnv(t, envs, "HOME", agentHomeDir)
 	assertEnv(t, envs, "CUSTOM_ENV", "custom")
 	assertEnv(t, envs, "INIT_SCRIPT", "echo ready")
+	assertPathContains(t, envs, agynBinCLIDir)
 	var parsedSkills []skillPayload
 	if err := json.Unmarshal([]byte(envs["AGENT_SKILLS"]), &parsedSkills); err != nil {
 		t.Fatalf("unmarshal skills: %v", err)
@@ -356,6 +357,28 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 	assertEnv(t, envs, "GATEWAY_ADDRESS", "gateway.ziti:443")
 	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://gateway.ziti:443")
 	assertEnv(t, envs, "LLM_BASE_URL", "http://llm-proxy.ziti/v1")
+}
+
+func TestEnsureAgynCLIPathAddsDefault(t *testing.T) {
+	envs := []*runnerv1.EnvVar{{Name: "FOO", Value: "bar"}}
+
+	got := ensureAgynCLIPath(envs)
+	values := envMap(got)
+	pathValue := values["PATH"]
+	if pathValue != "$(PATH):"+agynBinCLIDir {
+		t.Fatalf("expected PATH %q, got %q", "$(PATH):"+agynBinCLIDir, pathValue)
+	}
+}
+
+func TestEnsureAgynCLIPathAppendsCustomPath(t *testing.T) {
+	envs := []*runnerv1.EnvVar{{Name: "PATH", Value: "/custom/bin"}}
+
+	got := ensureAgynCLIPath(envs)
+	values := envMap(got)
+	pathValue := values["PATH"]
+	if pathValue != "/custom/bin:"+agynBinCLIDir {
+		t.Fatalf("expected PATH %q, got %q", "/custom/bin:"+agynBinCLIDir, pathValue)
+	}
 }
 
 func TestAssemblerInitImageOverride(t *testing.T) {
@@ -1130,6 +1153,21 @@ func envMap(envs []*runnerv1.EnvVar) map[string]string {
 		result[env.Name] = env.Value
 	}
 	return result
+}
+
+func assertPathContains(t *testing.T, envs map[string]string, segment string) {
+	t.Helper()
+	pathValue, ok := envs["PATH"]
+	if !ok {
+		t.Fatalf("expected PATH env var")
+	}
+	parts := strings.Split(pathValue, ":")
+	for _, part := range parts {
+		if strings.TrimSpace(part) == segment {
+			return
+		}
+	}
+	t.Fatalf("expected PATH to include %q, got %q", segment, pathValue)
 }
 
 func findVolumeSpec(volumes []*runnerv1.VolumeSpec, name string) *runnerv1.VolumeSpec {

--- a/test/e2e/expose_test.go
+++ b/test/e2e/expose_test.go
@@ -112,7 +112,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	if err != nil {
 		t.Fatalf("wait for agent container: %v", err)
 	}
-	result := execPodCommand(t, execCtx, workloadNamespace(t), podName, containerName, []string{"/agyn-bin/cli/agyn", "expose", "list"})
+	result := execPodCommand(t, execCtx, workloadNamespace(t), podName, containerName, []string{"agyn", "expose", "list"})
 	if result.exitCode != 0 {
 		t.Fatalf("expected expose list exit code 0, got %d stdout=%q stderr=%q", result.exitCode, result.stdout, result.stderr)
 	}


### PR DESCRIPTION
## Summary
- append /agyn-bin/cli to agent PATH for exec sessions
- validate PATH handling and CLI availability with unit coverage
- run expose e2e exec using agyn from PATH

## Testing
- GOMAXPROCS=2 go vet -p 1 ./...
- GOMAXPROCS=2 go test -p 1 ./...
- GOMAXPROCS=2 go test -tags e2e ./test/e2e/...

## Related
- #127