### PR TITLE
fix(reconciler): ignore missing workloads

### DIFF
--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -570,6 +570,56 @@ func TestStopWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 	}
 }
 
+func TestStopRunnerWorkloadIgnoresNotFound(t *testing.T) {
+	ctx := context.Background()
+	instanceID := "runner-workload-1"
+	called := false
+
+	runner := &fakeRunnerClient{
+		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+			called = true
+			if req.GetWorkloadId() != instanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			if req.GetTimeoutSec() != 30 {
+				return nil, errors.New("unexpected timeout")
+			}
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+	}
+
+	reconciler := newTestReconciler(Config{})
+	if err := reconciler.stopRunnerWorkload(ctx, runner, instanceID); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !called {
+		t.Fatal("expected stop workload call")
+	}
+}
+
+func TestStopRunnerWorkloadReturnsErrorOnFailure(t *testing.T) {
+	ctx := context.Background()
+	instanceID := "runner-workload-1"
+
+	runner := &fakeRunnerClient{
+		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+			if req.GetWorkloadId() != instanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return nil, status.Error(codes.Internal, "stop failed")
+		},
+	}
+
+	reconciler := newTestReconciler(Config{})
+	err := reconciler.stopRunnerWorkload(ctx, runner, instanceID)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("expected internal error, got %v", err)
+	}
+}
+
 func TestReconcileOrphanIdentitiesDeletesOrphans(t *testing.T) {
 	ctx := context.Background()
 	agentID := uuid.New()

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -571,6 +571,61 @@ func TestStopWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 	}
 }
 
+func TestStopRunnerWorkloadIgnoresNotFoundForUUID(t *testing.T) {
+	ctx := context.Background()
+	instanceID := uuid.New().String()
+	called := false
+
+	runner := &fakeRunnerClient{
+		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+			called = true
+			if req.GetWorkloadId() != instanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			if req.GetTimeoutSec() != 30 {
+				return nil, errors.New("unexpected timeout")
+			}
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+	}
+
+	reconciler := newTestReconciler(Config{})
+	if err := reconciler.stopRunnerWorkload(ctx, runner, instanceID); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !called {
+		t.Fatal("expected stop workload call")
+	}
+}
+
+func TestStopRunnerWorkloadReturnsNotFoundForInvalidID(t *testing.T) {
+	ctx := context.Background()
+	instanceID := "workload-" + uuid.New().String()
+	called := false
+
+	runner := &fakeRunnerClient{
+		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+			called = true
+			if req.GetWorkloadId() != instanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+	}
+
+	reconciler := newTestReconciler(Config{})
+	err := reconciler.stopRunnerWorkload(ctx, runner, instanceID)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+	if !called {
+		t.Fatal("expected stop workload call")
+	}
+}
+
 func TestStopRunnerWorkloadReturnsErrorOnFailure(t *testing.T) {
 	ctx := context.Background()
 	instanceID := "runner-workload-1"

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -415,14 +415,15 @@ func TestStopWorkloadDeletesIdentityAfterStop(t *testing.T) {
 	testAssembler := newTestAssembler(agentID, true)
 	runnerID := "runner-1"
 	zitiID := "ziti-identity"
-	instanceID := "runner-workload-1"
+	rawInstanceID := uuid.New().String()
+	instanceID := "workload-" + rawInstanceID
 
 	var calls []string
 	var updateStatuses []runnersv1.WorkloadStatus
 	runner := &fakeRunnerClient{
 		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
 			calls = append(calls, "stop")
-			if req.GetWorkloadId() != instanceID {
+			if req.GetWorkloadId() != rawInstanceID {
 				return nil, errors.New("unexpected workload id")
 			}
 			return &runnerv1.StopWorkloadResponse{}, nil
@@ -567,33 +568,6 @@ func TestStopWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 
 	if !reflect.DeepEqual(calls, []string{"dial", "update-workload", "stop", "update-workload"}) {
 		t.Fatalf("unexpected call order: %v", calls)
-	}
-}
-
-func TestStopRunnerWorkloadIgnoresNotFound(t *testing.T) {
-	ctx := context.Background()
-	instanceID := "runner-workload-1"
-	called := false
-
-	runner := &fakeRunnerClient{
-		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
-			called = true
-			if req.GetWorkloadId() != instanceID {
-				return nil, errors.New("unexpected workload id")
-			}
-			if req.GetTimeoutSec() != 30 {
-				return nil, errors.New("unexpected timeout")
-			}
-			return nil, status.Error(codes.NotFound, "not found")
-		},
-	}
-
-	reconciler := newTestReconciler(Config{})
-	if err := reconciler.stopRunnerWorkload(ctx, runner, instanceID); err != nil {
-		t.Fatalf("expected nil error, got %v", err)
-	}
-	if !called {
-		t.Fatal("expected stop workload call")
 	}
 }
 

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -19,7 +19,8 @@ func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 	ctx := context.Background()
 	runnerID := "runner-1"
 	workloadKey := "workload-1"
-	instanceID := "instance-1"
+	rawInstanceID := uuid.New().String()
+	instanceID := "workload-" + rawInstanceID
 
 	var updateReq *runnersv1.UpdateWorkloadRequest
 	runners := &fakeRunnersClient{
@@ -69,7 +70,7 @@ func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
 		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
 	}
-	if updateReq.GetInstanceId() != instanceID {
+	if updateReq.GetInstanceId() != rawInstanceID {
 		t.Fatalf("unexpected instance id: %v", updateReq.GetInstanceId())
 	}
 }
@@ -77,7 +78,8 @@ func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 func TestReconcileWorkloadsStopsOrphan(t *testing.T) {
 	ctx := context.Background()
 	runnerID := "runner-1"
-	instanceID := "instance-1"
+	rawInstanceID := uuid.New().String()
+	instanceID := "workload-" + rawInstanceID
 
 	stopCalled := false
 	runners := &fakeRunnersClient{
@@ -96,7 +98,7 @@ func TestReconcileWorkloadsStopsOrphan(t *testing.T) {
 			}}, nil
 		},
 		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
-			if req.GetWorkloadId() != instanceID {
+			if req.GetWorkloadId() != rawInstanceID {
 				return nil, errors.New("unexpected workload id")
 			}
 			stopCalled = true

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -14,6 +14,8 @@ import (
 	"github.com/agynio/agents-orchestrator/internal/assembler"
 	"github.com/agynio/agents-orchestrator/internal/runnerdial"
 	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -239,9 +241,10 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		r.compensateIdentity(ctx, zitiIdentityID, "start failure")
 		return
 	}
+	rawInstanceID := resp.GetId()
+	instanceID := normalizeRunnerWorkloadID(rawInstanceID)
 	if resp.GetStatus() == runnerv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
 		log.Printf("reconciler: workload failed for agent %s thread %s: %s", target.AgentID.String(), target.ThreadID.String(), failureSummary(resp.GetFailure()))
-		instanceID := resp.GetId()
 		if instanceID != "" {
 			if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
 				log.Printf("reconciler: stop workload %s after failure: %v", instanceID, err)
@@ -252,7 +255,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		r.compensateIdentity(ctx, zitiIdentityID, "workload failure")
 		return
 	}
-	if resp.GetId() == "" {
+	if rawInstanceID == "" {
 		log.Printf("reconciler: workload started without id for agent %s thread %s", target.AgentID.String(), target.ThreadID.String())
 		r.markWorkloadFailed(ctx, workloadKey, nil)
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
@@ -261,8 +264,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 	}
 	status, err := runnerStatus(resp.GetStatus())
 	if err != nil {
-		log.Printf("reconciler: map workload status for workload %s: %v", resp.GetId(), err)
-		instanceID := resp.GetId()
+		log.Printf("reconciler: map workload status for workload %s: %v", rawInstanceID, err)
 		if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
 			log.Printf("reconciler: stop workload %s after status map failure: %v", instanceID, err)
 		}
@@ -272,7 +274,6 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		return
 	}
 	containers := buildContainers(request, resp)
-	instanceID := resp.GetId()
 	updateReq := &runnersv1.UpdateWorkloadRequest{
 		Id:         workloadKey,
 		Status:     workloadStatusPtr(status),
@@ -338,7 +339,16 @@ func (r *Reconciler) stopRunnerWorkload(ctx context.Context, runnerClient runner
 		WorkloadId: instanceID,
 		TimeoutSec: r.stopSec,
 	})
-	return err
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) != codes.NotFound {
+		return err
+	}
+	if _, parseErr := uuid.Parse(instanceID); parseErr != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *Reconciler) deleteIdentity(ctx context.Context, identityID string) error {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -14,8 +14,6 @@ import (
 	"github.com/agynio/agents-orchestrator/internal/assembler"
 	"github.com/agynio/agents-orchestrator/internal/runnerdial"
 	"github.com/google/uuid"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -294,7 +292,7 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 		log.Printf("reconciler: workload missing id")
 		return
 	}
-	instanceID := workload.GetInstanceId()
+	instanceID := normalizeRunnerWorkloadID(workload.GetInstanceId())
 	if instanceID == "" {
 		log.Printf("reconciler: workload %s missing instance id", workloadID)
 		return
@@ -340,12 +338,6 @@ func (r *Reconciler) stopRunnerWorkload(ctx context.Context, runnerClient runner
 		WorkloadId: instanceID,
 		TimeoutSec: r.stopSec,
 	})
-	if err == nil {
-		return nil
-	}
-	if status.Code(err) == codes.NotFound {
-		return nil
-	}
 	return err
 }
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -14,6 +14,8 @@ import (
 	"github.com/agynio/agents-orchestrator/internal/assembler"
 	"github.com/agynio/agents-orchestrator/internal/runnerdial"
 	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -338,6 +340,12 @@ func (r *Reconciler) stopRunnerWorkload(ctx context.Context, runnerClient runner
 		WorkloadId: instanceID,
 		TimeoutSec: r.stopSec,
 	})
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) == codes.NotFound {
+		return nil
+	}
 	return err
 }
 

--- a/internal/reconciler/workload_id.go
+++ b/internal/reconciler/workload_id.go
@@ -1,0 +1,23 @@
+package reconciler
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const runnerWorkloadPrefix = "workload-"
+
+func normalizeRunnerWorkloadID(instanceID string) string {
+	if !strings.HasPrefix(instanceID, runnerWorkloadPrefix) {
+		return instanceID
+	}
+	trimmed := strings.TrimPrefix(instanceID, runnerWorkloadPrefix)
+	if trimmed == "" {
+		return instanceID
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return instanceID
+	}
+	return trimmed
+}

--- a/internal/reconciler/workload_id_test.go
+++ b/internal/reconciler/workload_id_test.go
@@ -1,0 +1,58 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestNormalizeRunnerWorkloadID(t *testing.T) {
+	validID := uuid.New().String()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "prefixed-uuid",
+			input: "workload-" + validID,
+			want:  validID,
+		},
+		{
+			name:  "uuid",
+			input: validID,
+			want:  validID,
+		},
+		{
+			name:  "prefixed-non-uuid",
+			input: "workload-not-a-uuid",
+			want:  "workload-not-a-uuid",
+		},
+		{
+			name:  "prefix-only",
+			input: "workload-",
+			want:  "workload-",
+		},
+		{
+			name:  "empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "other-prefix",
+			input: "task-" + validID,
+			want:  "task-" + validID,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got := normalizeRunnerWorkloadID(test.input)
+			if got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+		})
+	}
+}

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -93,7 +93,7 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 		}
 
 		for _, item := range runnerWorkloads {
-			instanceID := item.GetInstanceId()
+			instanceID := normalizeRunnerWorkloadID(item.GetInstanceId())
 			if instanceID == "" {
 				log.Printf("reconciler: warn: runner %s orphan workload missing instance id", runnerID)
 				continue
@@ -140,7 +140,7 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 	if workloadID == "" {
 		return nil
 	}
-	instanceID := item.GetInstanceId()
+	instanceID := normalizeRunnerWorkloadID(item.GetInstanceId())
 	if instanceID == "" {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- normalize runner workload instance IDs at start/stop boundaries
- treat StopWorkload NotFound as success only for valid UUIDs
- add tests for normalization and NotFound handling

## Testing
- GOMAXPROCS=2 go vet -p 1 ./...
- GOMAXPROCS=2 go test -p 1 ./...

Fixes #130