### PR TITLE
Add Ziti default for tracing address

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,13 @@ func FromEnv() (Config, error) {
 		}
 	}
 	cfg.AgentTracingAddress = os.Getenv("AGENT_TRACING_ADDRESS")
+	if cfg.AgentTracingAddress == "" {
+		if cfg.ZitiEnabled {
+			cfg.AgentTracingAddress = "tracing.ziti:443"
+		} else {
+			cfg.AgentTracingAddress = "tracing:50051"
+		}
+	}
 	cfg.AgentLLMBaseURL = os.Getenv("AGENT_LLM_BASE_URL")
 	if cfg.AgentLLMBaseURL == "" {
 		if cfg.ZitiEnabled {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,9 @@ func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	if cfg.AgentGatewayAddress != "gateway:8080" {
 		t.Fatalf("expected gateway address %q, got %q", "gateway:8080", cfg.AgentGatewayAddress)
 	}
+	if cfg.AgentTracingAddress != "tracing:50051" {
+		t.Fatalf("expected tracing address %q, got %q", "tracing:50051", cfg.AgentTracingAddress)
+	}
 	if cfg.AgentLLMBaseURL != "http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080/v1" {
 		t.Fatalf("expected llm base url %q, got %q", "http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080/v1", cfg.AgentLLMBaseURL)
 	}
@@ -52,6 +55,9 @@ func TestFromEnvDefaultsZiti(t *testing.T) {
 	}
 	if cfg.AgentGatewayAddress != "gateway.ziti:443" {
 		t.Fatalf("expected gateway address %q, got %q", "gateway.ziti:443", cfg.AgentGatewayAddress)
+	}
+	if cfg.AgentTracingAddress != "tracing.ziti:443" {
+		t.Fatalf("expected tracing address %q, got %q", "tracing.ziti:443", cfg.AgentTracingAddress)
 	}
 	if cfg.AgentLLMBaseURL != "http://llm-proxy.ziti/v1" {
 		t.Fatalf("expected llm base url %q, got %q", "http://llm-proxy.ziti/v1", cfg.AgentLLMBaseURL)


### PR DESCRIPTION
## Summary
- add Ziti-aware default for the agent tracing address config
- update config defaults tests to cover tracing address behavior

## Testing
- GOMAXPROCS=2 go vet -p 1 ./...
- GOMAXPROCS=2 go test -p 1 ./...

Refs #10