### PR TITLE
Fix Dockerfile metering proto path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN buf generate buf.build/agynio/api \
     --path agynio/api/llm/v1 \
     --path agynio/api/users/v1 \
     --path agynio/api/organizations/v1 \
-    --path agynio/api/tracing/v1
+    --path agynio/api/tracing/v1 \
+    --path agynio/api/metering/v1
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- add metering/v1 to the Dockerfile buf generate paths

## Testing
- GOMAXPROCS=2 go vet -p 1 ./...
- GOMAXPROCS=2 go test -p 1 ./...

Refs #136