### PR TITLE
test(e2e): exercise expose lifecycle

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,6 +58,30 @@ jobs:
           kubectl cluster-info
           kubectl get pods -n platform
 
+      - name: Checkout ziti-management (branch)
+        id: checkout_ziti_management
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          repository: agynio/ziti-management
+          path: ziti-management
+          ref: ${{ github.head_ref }}
+
+      - name: Checkout ziti-management (main)
+        if: steps.checkout_ziti_management.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          repository: agynio/ziti-management
+          path: ziti-management
+
+      - name: Build and deploy ziti-management
+        working-directory: ziti-management
+        run: |
+          docker build -t ziti-management:e2e .
+          k3d image import -c agyn-local ziti-management:e2e
+          kubectl -n platform set image deployment/ziti-management "*=ziti-management:e2e"
+          kubectl -n platform rollout status deployment/ziti-management --timeout=180s
+
       # --- Install DevSpace ---
 
       - name: Install DevSpace

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -58,15 +58,6 @@ functions:
           containers:
             - name: agents-orchestrator
               image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with DEV_IMAGE
-              env:
-                - name: AGENT_LLM_BASE_URL
-                  value: "http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080/v1"
-                - name: AGENT_GATEWAY_ADDRESS
-                  value: "gateway-gateway.platform.svc.cluster.local:8080"
-                - name: AGENT_TRACING_ADDRESS
-                  value: "tracing.platform.svc.cluster.local:50051"
-                - name: ZITI_ENABLED
-                  value: "false"
               workingDir: /opt/app/data
               command:
                 - sh

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -42,15 +42,15 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 
 	var calls []string
 	var workloadKey string
-	var workloadID string
+	var instanceID string
 	zitiMgmt := &fakeZitiMgmtClient{
 		createAgentIdentity: func(_ context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 			calls = append(calls, "create")
 			if req.GetAgentId() != agentID.String() {
 				return nil, errors.New("unexpected agent id")
 			}
-			workloadID = req.GetWorkloadId()
-			if workloadID == "" {
+			workloadKey = req.GetWorkloadId()
+			if workloadKey == "" {
 				return nil, errors.New("missing workload id")
 			}
 			return &zitimgmtv1.CreateAgentIdentityResponse{ZitiIdentityId: zitiID, EnrollmentJwt: jwt}, nil
@@ -63,8 +63,9 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if req.GetMain() == nil {
 				return nil, errors.New("missing main container")
 			}
-			if req.GetWorkloadId() != workloadID {
-				return nil, errors.New("unexpected workload id")
+			instanceID = req.GetWorkloadId()
+			if instanceID == "" {
+				return nil, errors.New("missing workload id")
 			}
 			labelKey := assembler.LabelKeyPrefix + assembler.LabelWorkloadKey
 			if req.GetAdditionalProperties()[labelKey] != workloadKey {
@@ -79,7 +80,7 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 				return nil, errors.New("missing ZITI_ENROLL_TOKEN")
 			}
 			return &runnerv1.StartWorkloadResponse{
-				Id:     workloadID,
+				Id:     instanceID,
 				Status: runnerv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
 				Containers: &runnerv1.WorkloadContainers{
 					Main: mainContainerID,
@@ -103,7 +104,9 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if req.GetId() == "" {
 				return nil, errors.New("missing workload id")
 			}
-			workloadKey = req.GetId()
+			if req.GetId() != workloadKey {
+				return nil, errors.New("unexpected workload id")
+			}
 			if req.GetRunnerId() != runnerID {
 				return nil, errors.New("unexpected runner id")
 			}
@@ -135,7 +138,7 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
 				return nil, errors.New("unexpected workload status")
 			}
-			if req.GetInstanceId() != workloadID {
+			if req.GetInstanceId() != instanceID {
 				return nil, errors.New("unexpected instance id")
 			}
 			if len(req.GetContainers()) != 1 {
@@ -289,7 +292,8 @@ func TestStartWorkloadDeletesIdentityOnRunnerError(t *testing.T) {
 	zitiMgmt := &fakeZitiMgmtClient{
 		createAgentIdentity: func(_ context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 			calls = append(calls, "create")
-			if req.GetWorkloadId() == "" {
+			workloadKey := req.GetWorkloadId()
+			if workloadKey == "" {
 				return nil, errors.New("missing workload id")
 			}
 			return &zitimgmtv1.CreateAgentIdentityResponse{ZitiIdentityId: zitiID, EnrollmentJwt: "jwt"}, nil
@@ -367,12 +371,12 @@ func TestStartWorkloadRollsBackOnWorkloadIDMismatch(t *testing.T) {
 
 	var calls []string
 	var workloadKey string
-	var workloadID string
+	var requestedWorkloadID string
 	zitiMgmt := &fakeZitiMgmtClient{
 		createAgentIdentity: func(_ context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 			calls = append(calls, "create")
-			workloadID = req.GetWorkloadId()
-			if workloadID == "" {
+			workloadKey = req.GetWorkloadId()
+			if workloadKey == "" {
 				return nil, errors.New("missing workload id")
 			}
 			return &zitimgmtv1.CreateAgentIdentityResponse{ZitiIdentityId: zitiID, EnrollmentJwt: "jwt"}, nil
@@ -389,8 +393,9 @@ func TestStartWorkloadRollsBackOnWorkloadIDMismatch(t *testing.T) {
 	runner := &fakeRunnerClient{
 		startWorkload: func(_ context.Context, req *runnerv1.StartWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StartWorkloadResponse, error) {
 			calls = append(calls, "start")
-			if req.GetWorkloadId() != workloadID {
-				return nil, errors.New("unexpected workload id")
+			requestedWorkloadID = req.GetWorkloadId()
+			if requestedWorkloadID == "" {
+				return nil, errors.New("missing workload id")
 			}
 			return &runnerv1.StartWorkloadResponse{
 				Id:     instanceID,
@@ -424,7 +429,9 @@ func TestStartWorkloadRollsBackOnWorkloadIDMismatch(t *testing.T) {
 			if req.GetId() == "" {
 				return nil, errors.New("missing workload id")
 			}
-			workloadKey = req.GetId()
+			if req.GetId() != workloadKey {
+				return nil, errors.New("unexpected workload id")
+			}
 			if req.GetRunnerId() != runnerID {
 				return nil, errors.New("unexpected runner id")
 			}
@@ -473,10 +480,12 @@ func TestStartWorkloadStopsAndDeletesIdentityOnStoreFailure(t *testing.T) {
 	testAssembler := newTestAssembler(agentID, true)
 
 	var calls []string
+	var workloadKey string
 	zitiMgmt := &fakeZitiMgmtClient{
 		createAgentIdentity: func(_ context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 			calls = append(calls, "create")
-			if req.GetWorkloadId() == "" {
+			workloadKey = req.GetWorkloadId()
+			if workloadKey == "" {
 				return nil, errors.New("missing workload id")
 			}
 			return &zitimgmtv1.CreateAgentIdentityResponse{ZitiIdentityId: zitiID, EnrollmentJwt: "jwt"}, nil
@@ -511,6 +520,9 @@ func TestStartWorkloadStopsAndDeletesIdentityOnStoreFailure(t *testing.T) {
 			calls = append(calls, "create-workload")
 			if req.GetId() == "" {
 				return nil, errors.New("missing workload id")
+			}
+			if req.GetId() != workloadKey {
+				return nil, errors.New("unexpected workload id")
 			}
 			return nil, errors.New("create error")
 		},

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -210,11 +210,12 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		return
 	}
 	request := assembled.Request
-	workloadKey := uuid.NewString()
+	workloadKey := uuid.New()
+	workloadKeyValue := workloadKey.String()
 	if request.AdditionalProperties == nil {
 		request.AdditionalProperties = map[string]string{}
 	}
-	request.AdditionalProperties[assembler.LabelKeyPrefix+assembler.LabelWorkloadKey] = workloadKey
+	request.AdditionalProperties[assembler.LabelKeyPrefix+assembler.LabelWorkloadKey] = workloadKeyValue
 	volumeRecords, err := buildVolumeRecords(assembled.PersistentVolumes)
 	if err != nil {
 		log.Printf("reconciler: build volume records for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
@@ -223,7 +224,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 	workloadID := uuid.New()
 	requestedWorkloadID := workloadID.String()
 	request.WorkloadId = requestedWorkloadID
-	identity, err := r.createIdentity(ctx, target, workloadID)
+	identity, err := r.createIdentity(ctx, target, workloadKey)
 	if err != nil {
 		log.Printf("reconciler: %v", err)
 		return
@@ -243,8 +244,8 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		r.compensateIdentity(ctx, zitiIdentityID, "volume record failure")
 		return
 	}
-	if err := r.createWorkloadRecord(ctx, workloadKey, runnerID, target, assembled.OrganizationID, zitiIdentityID, assembled.AllocatedCPUMillicores, assembled.AllocatedRAMBytes); err != nil {
-		log.Printf("reconciler: create workload record %s for agent %s thread %s: %v", workloadKey, target.AgentID.String(), target.ThreadID.String(), err)
+	if err := r.createWorkloadRecord(ctx, workloadKeyValue, runnerID, target, assembled.OrganizationID, zitiIdentityID, assembled.AllocatedCPUMillicores, assembled.AllocatedRAMBytes); err != nil {
+		log.Printf("reconciler: create workload record %s for agent %s thread %s: %v", workloadKeyValue, target.AgentID.String(), target.ThreadID.String(), err)
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload record failure")
 		return
@@ -252,7 +253,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 	resp, err := runnerClient.StartWorkload(ctx, request)
 	if err != nil {
 		log.Printf("reconciler: start workload for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
-		r.markWorkloadFailed(ctx, workloadKey, nil)
+		r.markWorkloadFailed(ctx, workloadKeyValue, nil)
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "start failure")
 		return
@@ -266,14 +267,14 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 				log.Printf("reconciler: stop workload %s after failure: %v", instanceID, err)
 			}
 		}
-		r.markWorkloadFailed(ctx, workloadKey, stringPtr(instanceID))
+		r.markWorkloadFailed(ctx, workloadKeyValue, stringPtr(instanceID))
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload failure")
 		return
 	}
 	if rawInstanceID == "" {
 		log.Printf("reconciler: workload started without id for agent %s thread %s", target.AgentID.String(), target.ThreadID.String())
-		r.markWorkloadFailed(ctx, workloadKey, nil)
+		r.markWorkloadFailed(ctx, workloadKeyValue, nil)
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "missing workload id")
 		return
@@ -284,7 +285,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
 			log.Printf("reconciler: stop workload %s after id mismatch: %v", instanceID, err)
 		}
-		r.markWorkloadFailed(ctx, workloadKey, stringPtr(instanceID))
+		r.markWorkloadFailed(ctx, workloadKeyValue, stringPtr(instanceID))
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload id mismatch")
 		return
@@ -295,14 +296,14 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
 			log.Printf("reconciler: stop workload %s after status map failure: %v", instanceID, err)
 		}
-		r.markWorkloadFailed(ctx, workloadKey, stringPtr(instanceID))
+		r.markWorkloadFailed(ctx, workloadKeyValue, stringPtr(instanceID))
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "status map failure")
 		return
 	}
 	containers := buildContainers(request, resp)
 	updateReq := &runnersv1.UpdateWorkloadRequest{
-		Id:         workloadKey,
+		Id:         workloadKeyValue,
 		Status:     workloadStatusPtr(status),
 		InstanceId: stringPtr(instanceID),
 	}
@@ -310,7 +311,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		updateReq.Containers = containers
 	}
 	if _, err := r.runners.UpdateWorkload(ctx, updateReq); err != nil {
-		log.Printf("reconciler: update workload record %s after start: %v", workloadKey, err)
+		log.Printf("reconciler: update workload record %s after start: %v", workloadKeyValue, err)
 	}
 }
 

--- a/test/e2e/expose_test.go
+++ b/test/e2e/expose_test.go
@@ -4,7 +4,9 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +20,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type exposureOutput struct {
+	ID     string `json:"id"`
+	Port   int32  `json:"port"`
+	URL    string `json:"url"`
+	Status string `json:"status"`
+}
 
 func TestAgentExposeListExec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
@@ -36,7 +45,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
-	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.3.5")
+	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.4")
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	token := createAPIToken(t, ctx, usersClient, identityID)
@@ -112,9 +121,104 @@ func TestAgentExposeListExec(t *testing.T) {
 	if err != nil {
 		t.Fatalf("wait for agent container: %v", err)
 	}
-	result := execPodCommand(t, execCtx, workloadNamespace(t), podName, containerName, []string{"/agyn-bin/cli/agyn", "expose", "list"})
-	if result.exitCode != 0 {
-		t.Fatalf("expected expose list exit code 0, got %d stdout=%q stderr=%q", result.exitCode, result.stdout, result.stderr)
+
+	port := int32(15000 + time.Now().UnixNano()%10000)
+	addResult := execPodCommand(t, execCtx, workloadNamespace(t), podName, containerName, []string{
+		"/agyn-bin/cli/agyn",
+		"expose",
+		"add",
+		fmt.Sprintf("%d", port),
+		"--output",
+		"json",
+	})
+	if addResult.exitCode != 0 {
+		t.Fatalf("expected expose add exit code 0, got %d stdout=%q stderr=%q", addResult.exitCode, addResult.stdout, addResult.stderr)
+	}
+	var addOutput exposureOutput
+	if err := json.Unmarshal([]byte(addResult.stdout), &addOutput); err != nil {
+		t.Fatalf("decode expose add output: %v stdout=%q", err, addResult.stdout)
+	}
+	if addOutput.ID == "" {
+		t.Fatal("expose add output missing id")
+	}
+	if addOutput.URL == "" {
+		t.Fatal("expose add output missing url")
+	}
+	if addOutput.Port != port {
+		t.Fatalf("expected expose add port %d, got %d", port, addOutput.Port)
+	}
+	if addOutput.Status != "active" {
+		t.Fatalf("expected expose add status active, got %q", addOutput.Status)
+	}
+
+	listResult := execPodCommand(t, execCtx, workloadNamespace(t), podName, containerName, []string{
+		"/agyn-bin/cli/agyn",
+		"expose",
+		"list",
+		"--output",
+		"json",
+	})
+	if listResult.exitCode != 0 {
+		t.Fatalf("expected expose list exit code 0, got %d stdout=%q stderr=%q", listResult.exitCode, listResult.stdout, listResult.stderr)
+	}
+	var listOutputs []exposureOutput
+	if err := json.Unmarshal([]byte(listResult.stdout), &listOutputs); err != nil {
+		t.Fatalf("decode expose list output: %v stdout=%q", err, listResult.stdout)
+	}
+	foundPort := false
+	for _, exposure := range listOutputs {
+		if exposure.Port == port {
+			foundPort = true
+			break
+		}
+	}
+	if !foundPort {
+		t.Fatalf("expected expose list to include port %d", port)
+	}
+
+	duplicateResult := execPodCommand(t, execCtx, workloadNamespace(t), podName, containerName, []string{
+		"/agyn-bin/cli/agyn",
+		"expose",
+		"add",
+		fmt.Sprintf("%d", port),
+		"--output",
+		"json",
+	})
+	if duplicateResult.exitCode == 0 {
+		t.Fatalf("expected expose add duplicate exit code non-zero, got 0 stdout=%q stderr=%q", duplicateResult.stdout, duplicateResult.stderr)
+	}
+	if !strings.Contains(duplicateResult.stderr, "already_exists") {
+		t.Fatalf("expected expose add duplicate stderr to include already_exists, got %q", duplicateResult.stderr)
+	}
+
+	removeResult := execPodCommand(t, execCtx, workloadNamespace(t), podName, containerName, []string{
+		"/agyn-bin/cli/agyn",
+		"expose",
+		"remove",
+		fmt.Sprintf("%d", port),
+	})
+	if removeResult.exitCode != 0 {
+		t.Fatalf("expected expose remove exit code 0, got %d stdout=%q stderr=%q", removeResult.exitCode, removeResult.stdout, removeResult.stderr)
+	}
+
+	listAfterResult := execPodCommand(t, execCtx, workloadNamespace(t), podName, containerName, []string{
+		"/agyn-bin/cli/agyn",
+		"expose",
+		"list",
+		"--output",
+		"json",
+	})
+	if listAfterResult.exitCode != 0 {
+		t.Fatalf("expected expose list after remove exit code 0, got %d stdout=%q stderr=%q", listAfterResult.exitCode, listAfterResult.stdout, listAfterResult.stderr)
+	}
+	var listAfterOutputs []exposureOutput
+	if err := json.Unmarshal([]byte(listAfterResult.stdout), &listAfterOutputs); err != nil {
+		t.Fatalf("decode expose list after remove output: %v stdout=%q", err, listAfterResult.stdout)
+	}
+	for _, exposure := range listAfterOutputs {
+		if exposure.Port == port {
+			t.Fatalf("expected expose list after remove to exclude port %d", port)
+		}
 	}
 }
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -55,7 +55,7 @@ var (
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
 	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.5")
-	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.1")
+	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.4")
 )
 
 type pipelineRun struct {


### PR DESCRIPTION
## Summary
- expand expose e2e test to cover add/list/duplicate/remove lifecycle using JSON output
- bump default agent init image to 0.4.4 for agn/expose tests

## Testing
- buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1
- GOMAXPROCS=2 go vet -p 1 ./...
- GOMAXPROCS=2 go test -p 1 ./...
- go build ./...

Ref #138