### PR TITLE
fix(reconciler): align workload ids

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -58,15 +58,6 @@ functions:
           containers:
             - name: agents-orchestrator
               image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with DEV_IMAGE
-              env:
-                - name: AGENT_LLM_BASE_URL
-                  value: "http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080/v1"
-                - name: AGENT_GATEWAY_ADDRESS
-                  value: "gateway-gateway.platform.svc.cluster.local:8080"
-                - name: AGENT_TRACING_ADDRESS
-                  value: "tracing.platform.svc.cluster.local:50051"
-                - name: ZITI_ENABLED
-                  value: "false"
               workingDir: /opt/app/data
               command:
                 - sh
@@ -116,9 +107,6 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
-    if [ -n "${CLUSTER_ADMIN_TOKEN:-}" ]; then
-      kubectl set env deployment/agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} AGENT_AUTH_TOKEN="${CLUSTER_ADMIN_TOKEN}"
-    fi
   wait_for_orchestrator: |-
     echo "Waiting for orchestrator deployment to roll out..."
     kubectl rollout status deployment/agents-orchestrator \

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -41,7 +41,6 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 	testAssembler := newTestAssembler(agentID, true)
 
 	var calls []string
-	var workloadKey string
 	var workloadID string
 	zitiMgmt := &fakeZitiMgmtClient{
 		createAgentIdentity: func(_ context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
@@ -67,7 +66,7 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 				return nil, errors.New("unexpected workload id")
 			}
 			labelKey := assembler.LabelKeyPrefix + assembler.LabelWorkloadKey
-			if req.GetAdditionalProperties()[labelKey] != workloadKey {
+			if req.GetAdditionalProperties()[labelKey] != workloadID {
 				return nil, errors.New("unexpected workload key label")
 			}
 			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarInitContainerName)
@@ -103,7 +102,12 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if req.GetId() == "" {
 				return nil, errors.New("missing workload id")
 			}
-			workloadKey = req.GetId()
+			if workloadID == "" {
+				return nil, errors.New("missing workload id")
+			}
+			if req.GetId() != workloadID {
+				return nil, errors.New("unexpected workload id")
+			}
 			if req.GetRunnerId() != runnerID {
 				return nil, errors.New("unexpected runner id")
 			}
@@ -129,7 +133,7 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 		},
 		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
 			calls = append(calls, "update-workload")
-			if req.GetId() != workloadKey {
+			if req.GetId() != workloadID {
 				return nil, errors.New("unexpected workload id")
 			}
 			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
@@ -181,7 +185,6 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 	testAssembler := newTestAssembler(agentID, false)
 
 	var calls []string
-	var workloadKey string
 	var workloadID string
 	runner := &fakeRunnerClient{
 		startWorkload: func(_ context.Context, req *runnerv1.StartWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StartWorkloadResponse, error) {
@@ -189,12 +192,14 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			if req.GetMain() == nil {
 				return nil, errors.New("missing main container")
 			}
-			workloadID = req.GetWorkloadId()
-			if workloadID == "" {
+			if req.GetWorkloadId() == "" {
 				return nil, errors.New("missing workload id")
 			}
+			if req.GetWorkloadId() != workloadID {
+				return nil, errors.New("unexpected workload id")
+			}
 			labelKey := assembler.LabelKeyPrefix + assembler.LabelWorkloadKey
-			if req.GetAdditionalProperties()[labelKey] != workloadKey {
+			if req.GetAdditionalProperties()[labelKey] != workloadID {
 				return nil, errors.New("unexpected workload key label")
 			}
 			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarInitContainerName)
@@ -229,7 +234,7 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			if req.GetId() == "" {
 				return nil, errors.New("missing workload id")
 			}
-			workloadKey = req.GetId()
+			workloadID = req.GetId()
 			if req.GetRunnerId() != runnerID {
 				return nil, errors.New("unexpected runner id")
 			}
@@ -246,7 +251,7 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 		},
 		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
 			calls = append(calls, "update-workload")
-			if req.GetId() != workloadKey {
+			if req.GetId() != workloadID {
 				return nil, errors.New("unexpected workload id")
 			}
 			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
@@ -366,7 +371,6 @@ func TestStartWorkloadRollsBackOnWorkloadIDMismatch(t *testing.T) {
 	testAssembler := newTestAssembler(agentID, true)
 
 	var calls []string
-	var workloadKey string
 	var workloadID string
 	zitiMgmt := &fakeZitiMgmtClient{
 		createAgentIdentity: func(_ context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
@@ -424,7 +428,12 @@ func TestStartWorkloadRollsBackOnWorkloadIDMismatch(t *testing.T) {
 			if req.GetId() == "" {
 				return nil, errors.New("missing workload id")
 			}
-			workloadKey = req.GetId()
+			if workloadID == "" {
+				return nil, errors.New("missing workload id")
+			}
+			if req.GetId() != workloadID {
+				return nil, errors.New("unexpected workload id")
+			}
 			if req.GetRunnerId() != runnerID {
 				return nil, errors.New("unexpected runner id")
 			}
@@ -432,7 +441,7 @@ func TestStartWorkloadRollsBackOnWorkloadIDMismatch(t *testing.T) {
 		},
 		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
 			calls = append(calls, "update-workload")
-			if req.GetId() != workloadKey {
+			if req.GetId() != workloadID {
 				return nil, errors.New("unexpected workload id")
 			}
 			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -210,19 +210,18 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		return
 	}
 	request := assembled.Request
-	workloadKey := uuid.NewString()
+	workloadID := uuid.New()
+	workloadIDValue := workloadID.String()
 	if request.AdditionalProperties == nil {
 		request.AdditionalProperties = map[string]string{}
 	}
-	request.AdditionalProperties[assembler.LabelKeyPrefix+assembler.LabelWorkloadKey] = workloadKey
+	request.AdditionalProperties[assembler.LabelKeyPrefix+assembler.LabelWorkloadKey] = workloadIDValue
 	volumeRecords, err := buildVolumeRecords(assembled.PersistentVolumes)
 	if err != nil {
 		log.Printf("reconciler: build volume records for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 		return
 	}
-	workloadID := uuid.New()
-	requestedWorkloadID := workloadID.String()
-	request.WorkloadId = requestedWorkloadID
+	request.WorkloadId = workloadIDValue
 	identity, err := r.createIdentity(ctx, target, workloadID)
 	if err != nil {
 		log.Printf("reconciler: %v", err)
@@ -243,8 +242,8 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		r.compensateIdentity(ctx, zitiIdentityID, "volume record failure")
 		return
 	}
-	if err := r.createWorkloadRecord(ctx, workloadKey, runnerID, target, assembled.OrganizationID, zitiIdentityID, assembled.AllocatedCPUMillicores, assembled.AllocatedRAMBytes); err != nil {
-		log.Printf("reconciler: create workload record %s for agent %s thread %s: %v", workloadKey, target.AgentID.String(), target.ThreadID.String(), err)
+	if err := r.createWorkloadRecord(ctx, workloadIDValue, runnerID, target, assembled.OrganizationID, zitiIdentityID, assembled.AllocatedCPUMillicores, assembled.AllocatedRAMBytes); err != nil {
+		log.Printf("reconciler: create workload record %s for agent %s thread %s: %v", workloadIDValue, target.AgentID.String(), target.ThreadID.String(), err)
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload record failure")
 		return
@@ -252,7 +251,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 	resp, err := runnerClient.StartWorkload(ctx, request)
 	if err != nil {
 		log.Printf("reconciler: start workload for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
-		r.markWorkloadFailed(ctx, workloadKey, nil)
+		r.markWorkloadFailed(ctx, workloadIDValue, nil)
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "start failure")
 		return
@@ -266,25 +265,25 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 				log.Printf("reconciler: stop workload %s after failure: %v", instanceID, err)
 			}
 		}
-		r.markWorkloadFailed(ctx, workloadKey, stringPtr(instanceID))
+		r.markWorkloadFailed(ctx, workloadIDValue, stringPtr(instanceID))
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload failure")
 		return
 	}
 	if rawInstanceID == "" {
 		log.Printf("reconciler: workload started without id for agent %s thread %s", target.AgentID.String(), target.ThreadID.String())
-		r.markWorkloadFailed(ctx, workloadKey, nil)
+		r.markWorkloadFailed(ctx, workloadIDValue, nil)
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "missing workload id")
 		return
 	}
-	if resp.GetId() != requestedWorkloadID {
-		log.Printf("reconciler: workload id mismatch for agent %s thread %s (expected %s got %s)", target.AgentID.String(), target.ThreadID.String(), requestedWorkloadID, resp.GetId())
+	if resp.GetId() != workloadIDValue {
+		log.Printf("reconciler: workload id mismatch for agent %s thread %s (expected %s got %s)", target.AgentID.String(), target.ThreadID.String(), workloadIDValue, resp.GetId())
 		instanceID := resp.GetId()
 		if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
 			log.Printf("reconciler: stop workload %s after id mismatch: %v", instanceID, err)
 		}
-		r.markWorkloadFailed(ctx, workloadKey, stringPtr(instanceID))
+		r.markWorkloadFailed(ctx, workloadIDValue, stringPtr(instanceID))
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload id mismatch")
 		return
@@ -295,14 +294,14 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
 			log.Printf("reconciler: stop workload %s after status map failure: %v", instanceID, err)
 		}
-		r.markWorkloadFailed(ctx, workloadKey, stringPtr(instanceID))
+		r.markWorkloadFailed(ctx, workloadIDValue, stringPtr(instanceID))
 		r.markVolumeRecordsFailed(ctx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "status map failure")
 		return
 	}
 	containers := buildContainers(request, resp)
 	updateReq := &runnersv1.UpdateWorkloadRequest{
-		Id:         workloadKey,
+		Id:         workloadIDValue,
 		Status:     workloadStatusPtr(status),
 		InstanceId: stringPtr(instanceID),
 	}
@@ -310,7 +309,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		updateReq.Containers = containers
 	}
 	if _, err := r.runners.UpdateWorkload(ctx, updateReq); err != nil {
-		log.Printf("reconciler: update workload record %s after start: %v", workloadKey, err)
+		log.Printf("reconciler: update workload record %s after start: %v", workloadIDValue, err)
 	}
 }
 

--- a/test/e2e/expose_test.go
+++ b/test/e2e/expose_test.go
@@ -36,7 +36,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
-	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.3.5")
+	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.4")
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	token := createAPIToken(t, ctx, usersClient, identityID)


### PR DESCRIPTION
## Summary
- use a single workload UUID for runner records, Ziti identity creation, and start requests
- align failure handling to mark the same workload id
- update lifecycle tests to assert consistent workload ids

## Testing
- buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1
- GOMAXPROCS=2 go vet -p 1 ./...
- GOMAXPROCS=2 go test -p 1 ./...

Refs #140