### PR TITLE
Fix reconciler stop handling

### DIFF
--- a/internal/reconciler/diff.go
+++ b/internal/reconciler/diff.go
@@ -25,6 +25,7 @@ func ComputeActions(desired []AgentThread, actual []*runnersv1.Workload, idleTim
 		desiredSet[item] = struct{}{}
 	}
 	actualSet := make(map[AgentThread]workloadEntry, len(actual))
+	var duplicates []*runnersv1.Workload
 	for _, workload := range actual {
 		agentID, err := uuidutil.ParseUUID(workload.GetAgentId(), "workload.agent_id")
 		if err != nil {
@@ -39,9 +40,19 @@ func ComputeActions(desired []AgentThread, actual []*runnersv1.Workload, idleTim
 			return Actions{}, err
 		}
 		key := AgentThread{AgentID: agentID, ThreadID: threadID}
-		actualSet[key] = workloadEntry{workload: workload, activityAt: activityAt}
+		entry := workloadEntry{workload: workload, activityAt: activityAt}
+		if existing, ok := actualSet[key]; ok {
+			if entry.activityAt.Before(existing.activityAt) {
+				duplicates = append(duplicates, existing.workload)
+				actualSet[key] = entry
+			} else {
+				duplicates = append(duplicates, entry.workload)
+			}
+			continue
+		}
+		actualSet[key] = entry
 	}
-	result := Actions{}
+	result := Actions{ToStop: duplicates}
 	for _, item := range desired {
 		if _, ok := actualSet[item]; !ok {
 			result.ToStart = append(result.ToStart, item)
@@ -49,6 +60,10 @@ func ComputeActions(desired []AgentThread, actual []*runnersv1.Workload, idleTim
 	}
 	for key, entry := range actualSet {
 		if _, ok := desiredSet[key]; ok {
+			continue
+		}
+		if entry.workload.GetStatus() == runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING {
+			result.ToStop = append(result.ToStop, entry.workload)
 			continue
 		}
 		idleTimeout, ok := idleTimeouts[key.AgentID]

--- a/internal/reconciler/diff_test.go
+++ b/internal/reconciler/diff_test.go
@@ -37,6 +37,12 @@ func TestComputeActions(t *testing.T) {
 	workload4 := makeWorkload(agent1, thread1, now.Add(-5*time.Minute), nil)
 	workload5 := makeWorkload(agent2, thread2, now.Add(-20*time.Minute), nil)
 	workload6 := makeWorkload(missingAgent, missingThread, now.Add(-20*time.Minute), nil)
+	duplicateOldActivity := now.Add(-2 * time.Minute)
+	duplicateNewActivity := now.Add(-1 * time.Minute)
+	workloadDuplicateOld := makeWorkload(agent1, thread1, now, &duplicateOldActivity)
+	workloadDuplicateNew := makeWorkload(agent1, thread1, now, &duplicateNewActivity)
+	workloadStopping := makeWorkload(agent2, thread2, now, nil)
+	workloadStopping.Status = runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING
 
 	cases := []struct {
 		name     string
@@ -82,6 +88,28 @@ func TestComputeActions(t *testing.T) {
 		{
 			name:   "keep recent",
 			actual: []*runnersv1.Workload{workload4},
+		},
+		{
+			name:   "stop duplicates within idle",
+			actual: []*runnersv1.Workload{workloadDuplicateNew, workloadDuplicateOld},
+			expected: Actions{
+				ToStop: []*runnersv1.Workload{workloadDuplicateNew},
+			},
+		},
+		{
+			name:    "stop duplicates with desired",
+			desired: []AgentThread{{AgentID: agent1, ThreadID: thread1}},
+			actual:  []*runnersv1.Workload{workloadDuplicateNew, workloadDuplicateOld},
+			expected: Actions{
+				ToStop: []*runnersv1.Workload{workloadDuplicateNew},
+			},
+		},
+		{
+			name:   "stop stopping workload",
+			actual: []*runnersv1.Workload{workloadStopping},
+			expected: Actions{
+				ToStop: []*runnersv1.Workload{workloadStopping},
+			},
 		},
 		{
 			name:    "match",

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -609,6 +609,57 @@ func TestStopWorkloadDeletesIdentityAfterStop(t *testing.T) {
 	}
 }
 
+func TestStopWorkloadMarksFailedWhenInstanceMissing(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	testAssembler := newTestAssembler(agentID, true)
+	runnerID := "runner-1"
+
+	updateCalled := false
+	var updateRequest *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateCalled = true
+			updateRequest = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	dialCalled := false
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, _ string) (runnerv1.RunnerServiceClient, error) {
+			dialCalled = true
+			return nil, errors.New("unexpected dial")
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Assembler:    testAssembler,
+	})
+	reconciler.stopWorkload(ctx, &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID})
+
+	if dialCalled {
+		t.Fatal("expected no dial call")
+	}
+	if !updateCalled {
+		t.Fatal("expected update workload call")
+	}
+	if updateRequest.GetId() != "workload-1" {
+		t.Fatalf("unexpected workload id: %s", updateRequest.GetId())
+	}
+	if updateRequest.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
+		t.Fatalf("unexpected workload status: %v", updateRequest.GetStatus())
+	}
+	if updateRequest.GetRemovedAt() == nil {
+		t.Fatal("expected removed_at")
+	}
+	if updateRequest.GetInstanceId() != "" {
+		t.Fatalf("expected empty instance id, got %q", updateRequest.GetInstanceId())
+	}
+}
+
 func TestStopWorkloadSkipsIdentityWhenNil(t *testing.T) {
 	ctx := context.Background()
 	agentID := uuid.New()

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -322,6 +322,7 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 	instanceID := normalizeRunnerWorkloadID(workload.GetInstanceId())
 	if instanceID == "" {
 		log.Printf("reconciler: workload %s missing instance id", workloadID)
+		r.markWorkloadFailed(ctx, workloadID, nil)
 		return
 	}
 	runnerID := workload.GetRunnerId()

--- a/test/e2e/idle_test.go
+++ b/test/e2e/idle_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && short_idle
+//go:build e2e
 
 package e2e
 
@@ -50,7 +50,8 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 		t.Fatal("create model: missing id")
 	}
 
-	agent := createAgent(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-idle-%s", uuid.NewString()), modelID, orgID, codexInitImage)
+	idleTimeout := "30s"
+	agent := createAgentWithIdleTimeout(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-idle-%s", uuid.NewString()), modelID, orgID, codexInitImage, idleTimeout)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
@@ -103,7 +104,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 
 	ackMessages(t, ctx, threadsClient, agentID, []string{messageID})
 
-	idleCtx, idleCancel := context.WithTimeout(ctx, 50*time.Second)
+	idleCtx, idleCancel := context.WithTimeout(ctx, 90*time.Second)
 	defer idleCancel()
 	if err := pollUntil(idleCtx, pollInterval, func(ctx context.Context) error {
 		ids, err := findWorkloadsByLabels(ctx, runnerClient, labels)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -144,14 +144,23 @@ func createModel(t *testing.T, ctx context.Context, client llmv1.LLMServiceClien
 
 func createAgent(t *testing.T, ctx context.Context, client agentsv1.AgentsServiceClient, name, model, organizationID, initImage string) *agentsv1.Agent {
 	t.Helper()
-	resp, err := client.CreateAgent(ctx, &agentsv1.CreateAgentRequest{
+	return createAgentWithIdleTimeout(t, ctx, client, name, model, organizationID, initImage, "")
+}
+
+func createAgentWithIdleTimeout(t *testing.T, ctx context.Context, client agentsv1.AgentsServiceClient, name, model, organizationID, initImage, idleTimeout string) *agentsv1.Agent {
+	t.Helper()
+	request := &agentsv1.CreateAgentRequest{
 		Name:           name,
 		Role:           "assistant",
 		Model:          model,
 		Image:          "alpine:3.21",
 		InitImage:      initImage,
 		OrganizationId: organizationID,
-	})
+	}
+	if idleTimeout != "" {
+		request.IdleTimeout = &idleTimeout
+	}
+	resp, err := client.CreateAgent(ctx, request)
 	if err != nil {
 		t.Fatalf("create agent %q: %v", name, err)
 	}


### PR DESCRIPTION
## Summary
- handle duplicate workloads and STOPPING gating in ComputeActions
- mark workloads failed when instance_id is missing
- add unit tests for duplicate and missing instance_id behavior

## Testing
- go test ./...
- go vet -p 1 ./...

Closes #142