### PR TITLE
feat(orchestrator): enforce runner capabilities

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: 3f78babcf0f741578516997fa1df2258
-    digest: shake256:db3e541006986820d4a3fe910278577daa43be1c4f132b63741095df16f5e6145c4ec0c41728e4685671ed4078cde755aa973d828ef5465cfbb0db5e247cb093
+    commit: f3017f9d17f34204bb16b2d4965e8e58
+    digest: shake256:d7a844b0d81eb46525351d250d8b7df473f5dd907aa1b1e26273cf27fab84f0edde9844c07924e86f1f7583ed5204371aa1647f7d09165563973b0228206c086
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -132,18 +132,19 @@ func run() error {
 	subscriber := subscriber.New(notificationsClient)
 	assembler := assembler.New(agentsClient, secretsClient, &cfg)
 	reconciler := reconciler.New(reconciler.Config{
-		Threads:                threadsClient,
-		Agents:                 agentsClient,
-		RunnerDialer:           runnerDialer,
-		ZitiMgmt:               zitiMgmtClient,
-		Runners:                runnersClient,
-		Metering:               meteringClient,
-		Assembler:              assembler,
-		Wake:                   subscriber.Wake(),
-		Poll:                   cfg.PollInterval,
-		Idle:                   cfg.IdleTimeout,
-		StopSec:                cfg.StopTimeoutSec,
-		MeteringSampleInterval: cfg.MeteringSampleInterval,
+		Threads:                   threadsClient,
+		Agents:                    agentsClient,
+		RunnerDialer:              runnerDialer,
+		ZitiMgmt:                  zitiMgmtClient,
+		Runners:                   runnersClient,
+		Metering:                  meteringClient,
+		Assembler:                 assembler,
+		Wake:                      subscriber.Wake(),
+		Poll:                      cfg.PollInterval,
+		WorkloadReconcileInterval: cfg.WorkloadReconcileInterval,
+		Idle:                      cfg.IdleTimeout,
+		StopSec:                   cfg.StopTimeoutSec,
+		MeteringSampleInterval:    cfg.MeteringSampleInterval,
 	})
 
 	start := func(leadCtx context.Context) {

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -43,6 +43,9 @@ functions:
             - name: agents-orchestrator
               image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with DEV_IMAGE
               workingDir: /opt/app/data
+              env:
+                - name: POLL_INTERVAL
+                  value: "10s"
               command:
                 - sh
                 - -c

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -27,22 +27,6 @@ functions:
       echo "WARNING: ArgoCD Application 'agents-orchestrator' not found in argocd namespace."
     fi
   patch_deployment: |-
-    echo "Registering k8s-runner with runners service..."
-    kubectl run register-runner --rm -i --restart=Never \
-      --image=ghcr.io/agynio/devcontainer-go:1 \
-      -n ${ORCHESTRATOR_NAMESPACE} \
-      --override-type=strategic \
-      --overrides='{"spec":{"securityContext":{"runAsUser":1000,"fsGroup":1000}}}' \
-      -- buf curl \
-        --schema buf.build/agynio/api \
-        --protocol grpc \
-        --http2-prior-knowledge \
-        -d '{"name":"k8s-runner"}' \
-        http://runners:50051/agynio.api.runners.v1.RunnersService/RegisterRunner 2>&1 || true
-    echo "Updating runner status to enrolled..."
-    kubectl exec -n ${ORCHESTRATOR_NAMESPACE} runners-db-0 -- \
-      psql -U runners -d runners -c "UPDATE runners SET status = 'enrolled' WHERE name = 'k8s-runner'" || true
-    echo "Runner setup complete."
     echo "Patching agents-orchestrator deployment for DevSpace..."
     kubectl patch deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -146,6 +146,8 @@ deployments:
                 value: "tenants:50051"
               - name: RUNNER_ADDRESS
                 value: "k8s-runner:50051"
+              - name: RUNNERS_ADDRESS
+                value: "runners:50051"
               - name: SECRETS_ADDRESS
                 value: "secrets:50051"
               - name: TRACING_ADDRESS

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -46,6 +46,8 @@ functions:
               env:
                 - name: POLL_INTERVAL
                   value: "10s"
+                - name: WORKLOAD_RECONCILE_INTERVAL
+                  value: "10s"
               command:
                 - sh
                 - -c

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -236,6 +236,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		Volumes:              volumes,
 		InitContainers:       initContainers,
 		ImagePullCredentials: imagePullCredentials,
+		Capabilities:         append([]string(nil), agent.GetCapabilities()...),
 		AdditionalProperties: map[string]string{
 			LabelKeyPrefix + LabelManagedBy: ManagedByValue,
 			LabelKeyPrefix + LabelAgentID:   agentID.String(),

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -34,6 +34,7 @@ func TestAssemblerMainContainer(t *testing.T) {
 		InitImage:      "agent-init-image",
 		Description:    "test agent",
 		Configuration:  "{\"mode\":\"test\"}",
+		Capabilities:   []string{"privileged", "dind"},
 	}
 
 	skills := []*agentsv1.Skill{{Name: "skill-a", Body: "do-a"}}
@@ -164,6 +165,9 @@ func TestAssemblerMainContainer(t *testing.T) {
 	}
 	if !equalStringMap(labels, expectedLabels) {
 		t.Fatalf("expected labels %+v, got %+v", expectedLabels, labels)
+	}
+	if !equalStringSlice(request.Capabilities, agent.GetCapabilities()) {
+		t.Fatalf("expected capabilities %+v, got %+v", agent.GetCapabilities(), request.Capabilities)
 	}
 	envs := envMap(request.Main.Env)
 	assertEnv(t, envs, "AGENT_ID", agentID.String())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,28 +8,29 @@ import (
 )
 
 type Config struct {
-	ThreadsAddress           string
-	NotificationsAddress     string
-	AgentsAddress            string
-	SecretsAddress           string
-	RunnerAddress            string
-	RunnersAddress           string
-	MeteringServiceAddress   string
-	MeteringSampleInterval   time.Duration
-	ZitiEnabled              bool
-	ZitiManagementAddress    string
-	ZitiLeaseRenewalInterval time.Duration
-	ZitiEnrollmentTimeout    time.Duration
-	ZitiSidecarImage         string
-	ClusterDNS               string
-	AgentGatewayAddress      string
-	AgentTracingAddress      string
-	AgentLLMBaseURL          string
-	PollInterval             time.Duration
-	IdleTimeout              time.Duration
-	StopTimeoutSec           uint32
-	LeaseName                string
-	LeaseNamespace           string
+	ThreadsAddress            string
+	NotificationsAddress      string
+	AgentsAddress             string
+	SecretsAddress            string
+	RunnerAddress             string
+	RunnersAddress            string
+	MeteringServiceAddress    string
+	MeteringSampleInterval    time.Duration
+	ZitiEnabled               bool
+	ZitiManagementAddress     string
+	ZitiLeaseRenewalInterval  time.Duration
+	ZitiEnrollmentTimeout     time.Duration
+	ZitiSidecarImage          string
+	ClusterDNS                string
+	AgentGatewayAddress       string
+	AgentTracingAddress       string
+	AgentLLMBaseURL           string
+	PollInterval              time.Duration
+	WorkloadReconcileInterval time.Duration
+	IdleTimeout               time.Duration
+	StopTimeoutSec            uint32
+	LeaseName                 string
+	LeaseNamespace            string
 }
 
 func FromEnv() (Config, error) {
@@ -154,6 +155,20 @@ func FromEnv() (Config, error) {
 			return Config{}, fmt.Errorf("parse POLL_INTERVAL: %w", err)
 		}
 		cfg.PollInterval = parsed
+	}
+
+	workloadReconcileInterval := os.Getenv("WORKLOAD_RECONCILE_INTERVAL")
+	if workloadReconcileInterval == "" {
+		cfg.WorkloadReconcileInterval = time.Minute
+	} else {
+		parsed, err := time.ParseDuration(workloadReconcileInterval)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse WORKLOAD_RECONCILE_INTERVAL: %w", err)
+		}
+		cfg.WorkloadReconcileInterval = parsed
+	}
+	if cfg.WorkloadReconcileInterval <= 0 {
+		return Config{}, fmt.Errorf("WORKLOAD_RECONCILE_INTERVAL must be greater than 0")
 	}
 
 	idleTimeout := os.Getenv("IDLE_TIMEOUT")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,9 @@ func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	if cfg.MeteringSampleInterval != time.Minute {
 		t.Fatalf("expected metering sample interval %q, got %q", time.Minute, cfg.MeteringSampleInterval)
 	}
+	if cfg.WorkloadReconcileInterval != time.Minute {
+		t.Fatalf("expected workload reconcile interval %q, got %q", time.Minute, cfg.WorkloadReconcileInterval)
+	}
 }
 
 func TestFromEnvDefaultsZiti(t *testing.T) {
@@ -100,6 +103,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("AGENT_TRACING_ADDRESS", "")
 	t.Setenv("AGENT_LLM_BASE_URL", "")
 	t.Setenv("POLL_INTERVAL", "")
+	t.Setenv("WORKLOAD_RECONCILE_INTERVAL", "")
 	t.Setenv("IDLE_TIMEOUT", "")
 	t.Setenv("STOP_TIMEOUT_SEC", "")
 	t.Setenv("LEASE_NAME", "")

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -761,14 +761,11 @@ func TestStopWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 func TestStopRunnerWorkloadIgnoresNotFoundForUUID(t *testing.T) {
 	ctx := context.Background()
 	instanceID := uuid.New().String()
-	called := false
+	calls := []string{}
 
 	runner := &fakeRunnerClient{
 		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
-			called = true
-			if req.GetWorkloadId() != instanceID {
-				return nil, errors.New("unexpected workload id")
-			}
+			calls = append(calls, req.GetWorkloadId())
 			if req.GetTimeoutSec() != 30 {
 				return nil, errors.New("unexpected timeout")
 			}
@@ -780,8 +777,41 @@ func TestStopRunnerWorkloadIgnoresNotFoundForUUID(t *testing.T) {
 	if err := reconciler.stopRunnerWorkload(ctx, runner, instanceID); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
-	if !called {
-		t.Fatal("expected stop workload call")
+	expected := []string{instanceID, "workload-" + instanceID}
+	if !reflect.DeepEqual(calls, expected) {
+		t.Fatalf("expected calls %v, got %v", expected, calls)
+	}
+}
+
+func TestStopRunnerWorkloadRetriesWithPrefixedID(t *testing.T) {
+	ctx := context.Background()
+	instanceID := uuid.New().String()
+	calls := []string{}
+
+	runner := &fakeRunnerClient{
+		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+			calls = append(calls, req.GetWorkloadId())
+			if req.GetTimeoutSec() != 30 {
+				return nil, errors.New("unexpected timeout")
+			}
+			switch req.GetWorkloadId() {
+			case instanceID:
+				return nil, status.Error(codes.NotFound, "not found")
+			case "workload-" + instanceID:
+				return &runnerv1.StopWorkloadResponse{}, nil
+			default:
+				return nil, errors.New("unexpected workload id")
+			}
+		},
+	}
+
+	reconciler := newTestReconciler(Config{})
+	if err := reconciler.stopRunnerWorkload(ctx, runner, instanceID); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	expected := []string{instanceID, "workload-" + instanceID}
+	if !reflect.DeepEqual(calls, expected) {
+		t.Fatalf("expected calls %v, got %v", expected, calls)
 	}
 }
 

--- a/internal/reconciler/reconcile_loops.go
+++ b/internal/reconciler/reconcile_loops.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (r *Reconciler) runWorkloadReconcileLoop(ctx context.Context) {
-	ticker := time.NewTicker(workloadReconcileInterval)
+	ticker := time.NewTicker(r.workloadReconcileInterval)
 	defer ticker.Stop()
 	r.runWorkloadReconcileCycle(ctx)
 	for {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -362,17 +362,29 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 }
 
 func (r *Reconciler) stopRunnerWorkload(ctx context.Context, runnerClient runnerv1.RunnerServiceClient, instanceID string) error {
-	_, err := runnerClient.StopWorkload(ctx, &runnerv1.StopWorkloadRequest{
-		WorkloadId: instanceID,
-		TimeoutSec: r.stopSec,
-	})
-	if err == nil {
+	if err := r.stopRunnerWorkloadID(ctx, runnerClient, instanceID); err == nil {
 		return nil
-	}
-	if status.Code(err) != codes.NotFound {
+	} else if status.Code(err) != codes.NotFound {
+		return err
+	} else if _, parseErr := uuid.Parse(instanceID); parseErr != nil {
 		return err
 	}
-	if _, parseErr := uuid.Parse(instanceID); parseErr != nil {
+	return r.stopRunnerWorkloadWithPrefix(ctx, runnerClient, instanceID)
+}
+
+func (r *Reconciler) stopRunnerWorkloadID(ctx context.Context, runnerClient runnerv1.RunnerServiceClient, workloadID string) error {
+	_, err := runnerClient.StopWorkload(ctx, &runnerv1.StopWorkloadRequest{
+		WorkloadId: workloadID,
+		TimeoutSec: r.stopSec,
+	})
+	return err
+}
+
+func (r *Reconciler) stopRunnerWorkloadWithPrefix(ctx context.Context, runnerClient runnerv1.RunnerServiceClient, instanceID string) error {
+	prefixedID := runnerWorkloadPrefix + instanceID
+	if err := r.stopRunnerWorkloadID(ctx, runnerClient, prefixedID); err == nil {
+		return nil
+	} else if status.Code(err) != codes.NotFound {
 		return err
 	}
 	return nil

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -21,55 +21,57 @@ import (
 )
 
 const (
-	reconcileTimeout          = 30 * time.Second
-	workloadReconcileInterval = time.Minute
-	volumeReconcileInterval   = time.Minute
+	reconcileTimeout        = 30 * time.Second
+	volumeReconcileInterval = time.Minute
 )
 
 type Reconciler struct {
-	threads                threadsv1.ThreadsServiceClient
-	agents                 agentsv1.AgentsServiceClient
-	runnerDialer           runnerdial.RunnerDialer
-	runners                runnersv1.RunnersServiceClient
-	metering               meteringv1.MeteringServiceClient
-	meteringSampleInterval time.Duration
-	zitiMgmt               zitimgmtv1.ZitiManagementServiceClient
-	assembler              *assembler.Assembler
-	wake                   <-chan struct{}
-	poll                   time.Duration
-	idle                   time.Duration
-	stopSec                uint32
+	threads                   threadsv1.ThreadsServiceClient
+	agents                    agentsv1.AgentsServiceClient
+	runnerDialer              runnerdial.RunnerDialer
+	runners                   runnersv1.RunnersServiceClient
+	metering                  meteringv1.MeteringServiceClient
+	meteringSampleInterval    time.Duration
+	zitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
+	assembler                 *assembler.Assembler
+	wake                      <-chan struct{}
+	poll                      time.Duration
+	workloadReconcileInterval time.Duration
+	idle                      time.Duration
+	stopSec                   uint32
 }
 
 type Config struct {
-	Threads                threadsv1.ThreadsServiceClient
-	Agents                 agentsv1.AgentsServiceClient
-	RunnerDialer           runnerdial.RunnerDialer
-	Runners                runnersv1.RunnersServiceClient
-	Metering               meteringv1.MeteringServiceClient
-	ZitiMgmt               zitimgmtv1.ZitiManagementServiceClient
-	Assembler              *assembler.Assembler
-	Wake                   <-chan struct{}
-	Poll                   time.Duration
-	Idle                   time.Duration
-	StopSec                uint32
-	MeteringSampleInterval time.Duration
+	Threads                   threadsv1.ThreadsServiceClient
+	Agents                    agentsv1.AgentsServiceClient
+	RunnerDialer              runnerdial.RunnerDialer
+	Runners                   runnersv1.RunnersServiceClient
+	Metering                  meteringv1.MeteringServiceClient
+	ZitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
+	Assembler                 *assembler.Assembler
+	Wake                      <-chan struct{}
+	Poll                      time.Duration
+	WorkloadReconcileInterval time.Duration
+	Idle                      time.Duration
+	StopSec                   uint32
+	MeteringSampleInterval    time.Duration
 }
 
 func New(cfg Config) *Reconciler {
 	return &Reconciler{
-		threads:                cfg.Threads,
-		agents:                 cfg.Agents,
-		runnerDialer:           cfg.RunnerDialer,
-		runners:                cfg.Runners,
-		metering:               cfg.Metering,
-		meteringSampleInterval: cfg.MeteringSampleInterval,
-		zitiMgmt:               cfg.ZitiMgmt,
-		assembler:              cfg.Assembler,
-		wake:                   cfg.Wake,
-		poll:                   cfg.Poll,
-		idle:                   cfg.Idle,
-		stopSec:                cfg.StopSec,
+		threads:                   cfg.Threads,
+		agents:                    cfg.Agents,
+		runnerDialer:              cfg.RunnerDialer,
+		runners:                   cfg.Runners,
+		metering:                  cfg.Metering,
+		meteringSampleInterval:    cfg.MeteringSampleInterval,
+		zitiMgmt:                  cfg.ZitiMgmt,
+		assembler:                 cfg.Assembler,
+		wake:                      cfg.Wake,
+		poll:                      cfg.Poll,
+		workloadReconcileInterval: cfg.WorkloadReconcileInterval,
+		idle:                      cfg.Idle,
+		stopSec:                   cfg.StopSec,
 	}
 }
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -194,7 +194,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
 		log.Printf("reconciler: assemble workload for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 		return
 	}
-	selectedRunner, err := r.selectRunner(ctx, assembled.OrganizationID, assembled.RunnerLabels)
+	selectedRunner, err := r.selectRunner(ctx, assembled.OrganizationID, assembled.RunnerLabels, assembled.Request.GetCapabilities())
 	if err != nil {
 		log.Printf("reconciler: select runner for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 		return

--- a/internal/reconciler/runners.go
+++ b/internal/reconciler/runners.go
@@ -10,12 +10,12 @@ import (
 
 const runnerPageSize int32 = 100
 
-func (r *Reconciler) selectRunner(ctx context.Context, organizationID string, runnerLabels map[string]string) (*runnersv1.Runner, error) {
+func (r *Reconciler) selectRunner(ctx context.Context, organizationID string, runnerLabels map[string]string, requiredCapabilities []string) (*runnersv1.Runner, error) {
 	runners, err := r.listRunners(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return runnerselect.Select(runners, organizationID, runnerLabels)
+	return runnerselect.Select(runners, organizationID, runnerLabels, requiredCapabilities)
 }
 
 func (r *Reconciler) listRunners(ctx context.Context) ([]*runnersv1.Runner, error) {

--- a/internal/runnerselect/select.go
+++ b/internal/runnerselect/select.go
@@ -5,15 +5,19 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
+	"strings"
 
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 )
 
-func Select(runners []*runnersv1.Runner, organizationID string, agentRunnerLabels map[string]string) (*runnersv1.Runner, error) {
+func Select(runners []*runnersv1.Runner, organizationID string, agentRunnerLabels map[string]string, requiredCapabilities []string) (*runnersv1.Runner, error) {
 	if len(runners) == 0 {
 		return nil, errors.New("no runners available")
 	}
+	normalizedRequired := normalizeCapabilities(requiredCapabilities)
 	eligible := make([]*runnersv1.Runner, 0, len(runners))
+	missingByRunner := map[string][]string{}
 	for _, runner := range runners {
 		if runner == nil {
 			return nil, errors.New("runner entry is nil")
@@ -31,9 +35,17 @@ func Select(runners []*runnersv1.Runner, organizationID string, agentRunnerLabel
 		if !labelsMatch(agentRunnerLabels, runner.GetLabels()) {
 			continue
 		}
+		missing := missingCapabilities(normalizedRequired, runner.GetCapabilities())
+		if len(missing) > 0 {
+			missingByRunner[meta.GetId()] = missing
+			continue
+		}
 		eligible = append(eligible, runner)
 	}
 	if len(eligible) == 0 {
+		if len(normalizedRequired) > 0 && len(missingByRunner) > 0 {
+			return nil, fmt.Errorf("no eligible runners found (required capabilities: %v, missing capabilities: %s)", normalizedRequired, formatMissingCapabilities(missingByRunner))
+		}
 		return nil, errors.New("no eligible runners found")
 	}
 	idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(eligible))))
@@ -64,4 +76,53 @@ func labelsMatch(required, provided map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func normalizeCapabilities(capabilities []string) []string {
+	if len(capabilities) == 0 {
+		return nil
+	}
+	unique := make(map[string]struct{}, len(capabilities))
+	for _, capability := range capabilities {
+		unique[capability] = struct{}{}
+	}
+	normalized := make([]string, 0, len(unique))
+	for capability := range unique {
+		normalized = append(normalized, capability)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func missingCapabilities(required, provided []string) []string {
+	if len(required) == 0 {
+		return nil
+	}
+	providedSet := make(map[string]struct{}, len(provided))
+	for _, capability := range provided {
+		providedSet[capability] = struct{}{}
+	}
+	missing := make([]string, 0, len(required))
+	for _, capability := range required {
+		if _, ok := providedSet[capability]; !ok {
+			missing = append(missing, capability)
+		}
+	}
+	return missing
+}
+
+func formatMissingCapabilities(missingByRunner map[string][]string) string {
+	if len(missingByRunner) == 0 {
+		return ""
+	}
+	runnerIDs := make([]string, 0, len(missingByRunner))
+	for runnerID := range missingByRunner {
+		runnerIDs = append(runnerIDs, runnerID)
+	}
+	sort.Strings(runnerIDs)
+	parts := make([]string, 0, len(runnerIDs))
+	for _, runnerID := range runnerIDs {
+		parts = append(parts, fmt.Sprintf("%s:%v", runnerID, missingByRunner[runnerID]))
+	}
+	return strings.Join(parts, ", ")
 }

--- a/internal/runnerselect/select_test.go
+++ b/internal/runnerselect/select_test.go
@@ -1,13 +1,14 @@
 package runnerselect
 
 import (
+	"strings"
 	"testing"
 
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 )
 
 func TestSelectReturnsErrorWhenNoRunners(t *testing.T) {
-	if _, err := Select(nil, "org-1", nil); err == nil {
+	if _, err := Select(nil, "org-1", nil, nil); err == nil {
 		t.Fatal("expected error for empty runner list")
 	}
 }
@@ -15,12 +16,12 @@ func TestSelectReturnsErrorWhenNoRunners(t *testing.T) {
 func TestSelectFiltersByScopeStatusAndLabels(t *testing.T) {
 	orgID := "org-1"
 	runners := []*runnersv1.Runner{
-		buildRunner("runner-a", orgID, runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, map[string]string{"region": "us"}),
-		buildRunner("runner-b", "org-2", runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, map[string]string{"region": "us"}),
-		buildRunner("runner-c", orgID, runnersv1.RunnerStatus_RUNNER_STATUS_PENDING, map[string]string{"region": "us"}),
-		buildRunner("runner-d", "", runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, map[string]string{"region": "eu"}),
+		buildRunner("runner-a", orgID, runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, map[string]string{"region": "us"}, nil),
+		buildRunner("runner-b", "org-2", runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, map[string]string{"region": "us"}, nil),
+		buildRunner("runner-c", orgID, runnersv1.RunnerStatus_RUNNER_STATUS_PENDING, map[string]string{"region": "us"}, nil),
+		buildRunner("runner-d", "", runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, map[string]string{"region": "eu"}, nil),
 	}
-	selected, err := Select(runners, orgID, map[string]string{"region": "us"})
+	selected, err := Select(runners, orgID, map[string]string{"region": "us"}, nil)
 	if err != nil {
 		t.Fatalf("select runner: %v", err)
 	}
@@ -33,9 +34,9 @@ func TestSelectFiltersByScopeStatusAndLabels(t *testing.T) {
 func TestSelectAllowsClusterScopedRunner(t *testing.T) {
 	orgID := "org-1"
 	runners := []*runnersv1.Runner{
-		buildRunner("runner-a", "", runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, nil),
+		buildRunner("runner-a", "", runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, nil, nil),
 	}
-	selected, err := Select(runners, orgID, nil)
+	selected, err := Select(runners, orgID, nil, nil)
 	if err != nil {
 		t.Fatalf("select runner: %v", err)
 	}
@@ -47,14 +48,49 @@ func TestSelectAllowsClusterScopedRunner(t *testing.T) {
 func TestSelectErrorsWhenNoLabelsMatch(t *testing.T) {
 	orgID := "org-1"
 	runners := []*runnersv1.Runner{
-		buildRunner("runner-a", orgID, runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, map[string]string{"tier": "cpu"}),
+		buildRunner("runner-a", orgID, runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, map[string]string{"tier": "cpu"}, nil),
 	}
-	if _, err := Select(runners, orgID, map[string]string{"tier": "gpu"}); err == nil {
+	if _, err := Select(runners, orgID, map[string]string{"tier": "gpu"}, nil); err == nil {
 		t.Fatal("expected error when labels do not match")
 	}
 }
 
-func buildRunner(id, orgID string, status runnersv1.RunnerStatus, labels map[string]string) *runnersv1.Runner {
+func TestSelectFiltersByCapabilities(t *testing.T) {
+	orgID := "org-1"
+	runners := []*runnersv1.Runner{
+		buildRunner("runner-a", orgID, runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, nil, []string{"privileged", "dind"}),
+	}
+	selected, err := Select(runners, orgID, nil, []string{"privileged"})
+	if err != nil {
+		t.Fatalf("select runner: %v", err)
+	}
+	if selected.GetMeta().GetId() != "runner-a" {
+		t.Fatalf("expected runner-a, got %s", selected.GetMeta().GetId())
+	}
+}
+
+func TestSelectErrorsWhenCapabilitiesMissing(t *testing.T) {
+	orgID := "org-1"
+	runners := []*runnersv1.Runner{
+		buildRunner("runner-a", orgID, runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED, nil, []string{"privileged"}),
+	}
+	_, err := Select(runners, orgID, nil, []string{"dind"})
+	if err == nil {
+		t.Fatal("expected error when capabilities do not match")
+	}
+	message := err.Error()
+	if !strings.Contains(message, "required capabilities") {
+		t.Fatalf("expected required capabilities error, got %q", message)
+	}
+	if !strings.Contains(message, "runner-a") {
+		t.Fatalf("expected missing capabilities to list runner, got %q", message)
+	}
+	if !strings.Contains(message, "dind") {
+		t.Fatalf("expected missing capability in error, got %q", message)
+	}
+}
+
+func buildRunner(id, orgID string, status runnersv1.RunnerStatus, labels map[string]string, capabilities []string) *runnersv1.Runner {
 	var orgPtr *string
 	if orgID != "" {
 		orgPtr = &orgID
@@ -64,5 +100,6 @@ func buildRunner(id, orgID string, status runnersv1.RunnerStatus, labels map[str
 		OrganizationId: orgPtr,
 		Status:         status,
 		Labels:         labels,
+		Capabilities:   capabilities,
 	}
 }

--- a/test/e2e/dedup_test.go
+++ b/test/e2e/dedup_test.go
@@ -74,11 +74,18 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 		labelAgentID:   agentID,
 		labelThreadID:  threadID,
 	}
-
-	workloadIDs := []string{}
 	t.Cleanup(func() {
-		for _, workloadID := range workloadIDs {
-			cleanupWorkload(t, ctx, runnerClient, workloadID)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		ackAllUnackedMessagesBestEffort(t, cleanupCtx, threadsClient, agentID)
+		ids, err := findWorkloadsByLabels(cleanupCtx, runnerClient, labels)
+		if err != nil {
+			t.Logf("cleanup: find workloads: %v", err)
+			return
+		}
+		for _, workloadID := range ids {
+			cleanupWorkload(t, cleanupCtx, runnerClient, workloadID)
 		}
 	})
 
@@ -92,7 +99,6 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 		if len(ids) < 1 {
 			return fmt.Errorf("expected at least 1 workload, got %d", len(ids))
 		}
-		workloadIDs = ids
 		return nil
 	}); err != nil {
 		t.Fatalf("wait for workload: %v", err)
@@ -110,9 +116,6 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 		}
 		if len(ids) > 1 {
 			t.Fatalf("expected at most 1 workload, got %d", len(ids))
-		}
-		if len(ids) > 0 {
-			workloadIDs = ids
 		}
 		select {
 		case <-dedupTimer.C:

--- a/test/e2e/idle_test.go
+++ b/test/e2e/idle_test.go
@@ -12,6 +12,7 @@ import (
 	llmv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	usersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/users/v1"
 	"github.com/google/uuid"
@@ -30,6 +31,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	agentsConn := dialGRPC(t, agentsAddr)
 	threadsConn := dialGRPC(t, threadsAddr)
 	runnerConn := dialRunnerGRPC(t, runnerAddr)
+	runnersConn := dialGRPC(t, runnersAddr)
 	usersConn := dialGRPC(t, usersAddr)
 	orgsConn := dialGRPC(t, orgsAddr)
 
@@ -40,6 +42,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	usersClient := usersv1.NewUsersServiceClient(usersConn)
 	orgsClient := organizationsv1.NewOrganizationsServiceClient(orgsConn)
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
+	runnersClient := runnersv1.NewRunnersServiceClient(runnersConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
 	token := createAPIToken(t, ctx, usersClient, identityID)
@@ -63,6 +66,19 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 		t.Fatal("create agent: missing id")
 	}
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
+	agentInfoResp, err := agentsClient.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID})
+	if err != nil {
+		t.Fatalf("get agent %s: %v", agentID, err)
+	}
+	agentInfo := agentInfoResp.GetAgent()
+	if agentInfo == nil || agentInfo.GetMeta() == nil {
+		t.Fatal("get agent: nil response")
+	}
+	if agentInfo.IdleTimeout == nil {
+		t.Logf("diagnostics: agent idle_timeout is nil (value=%q)", agentInfo.GetIdleTimeout())
+	} else {
+		t.Logf("diagnostics: agent idle_timeout=%q", agentInfo.GetIdleTimeout())
+	}
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
 	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
@@ -135,6 +151,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	idleCtx, idleCancel := context.WithTimeout(ctx, idleStopTimeout)
 	defer idleCancel()
 	if err := pollUntil(idleCtx, pollInterval, func(ctx context.Context) error {
+		logRunnersWorkloadState(t, ctx, runnersClient, workloadID)
 		ids, err := findWorkloadsByLabels(ctx, runnerClient, labels)
 		if err != nil {
 			return err
@@ -144,6 +161,52 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 		}
 		return nil
 	}); err != nil {
+		diagCtx, cancelDiag := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancelDiag()
+		logRunnersWorkloadState(t, diagCtx, runnersClient, workloadID)
 		t.Fatalf("wait for workload stop: %v", err)
 	}
+}
+
+func logRunnersWorkloadState(t *testing.T, ctx context.Context, client runnersv1.RunnersServiceClient, workloadID string) {
+	t.Helper()
+	if workloadID == "" {
+		t.Log("diagnostics: runners workload id is empty")
+		return
+	}
+	resp, err := client.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID})
+	if err != nil {
+		t.Logf("diagnostics: runners get workload %s: %v", workloadID, err)
+		return
+	}
+	workload := resp.GetWorkload()
+	if workload == nil {
+		t.Logf("diagnostics: runners workload %s missing in response", workloadID)
+		return
+	}
+	now := time.Now()
+	createdAt := "-"
+	meta := workload.GetMeta()
+	if meta != nil {
+		created := meta.GetCreatedAt()
+		if created != nil {
+			createdAt = created.AsTime().Format(time.RFC3339Nano)
+		}
+	}
+	lastActivityAt := "-"
+	lastActivityAge := "-"
+	if lastActivity := workload.GetLastActivityAt(); lastActivity != nil {
+		lastActivityTime := lastActivity.AsTime()
+		lastActivityAt = lastActivityTime.Format(time.RFC3339Nano)
+		lastActivityAge = now.Sub(lastActivityTime).String()
+	}
+
+	t.Logf(
+		"diagnostics: runners workload=%s status=%s created_at=%s last_activity_at=%s now-last_activity_at=%s",
+		workloadID,
+		workload.GetStatus().String(),
+		createdAt,
+		lastActivityAt,
+		lastActivityAge,
+	)
 }

--- a/test/e2e/idle_test.go
+++ b/test/e2e/idle_test.go
@@ -18,7 +18,12 @@ import (
 )
 
 func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	idleTestTimeout := 6 * time.Minute
+	workloadWaitTimeout := 90 * time.Second
+	agentResponseTimeout := 2 * time.Minute
+	idleStopTimeout := 120 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), idleTestTimeout)
 	t.Cleanup(cancel)
 
 	agentsConn := dialGRPC(t, agentsAddr)
@@ -71,6 +76,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	if messageID == "" {
 		t.Fatal("send message: missing id")
 	}
+	sentMessageTime := messageCreatedAt(t, message)
 
 	labels := map[string]string{
 		labelManagedBy: managedByValue,
@@ -86,7 +92,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 		cleanupWorkload(t, ctx, runnerClient, workloadID)
 	})
 
-	pollCtx, pollCancel := context.WithTimeout(ctx, 90*time.Second)
+	pollCtx, pollCancel := context.WithTimeout(ctx, workloadWaitTimeout)
 	defer pollCancel()
 	if err := pollUntil(pollCtx, pollInterval, func(ctx context.Context) error {
 		ids, err := findWorkloadsByLabels(ctx, runnerClient, labels)
@@ -102,9 +108,15 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 		t.Fatalf("wait for workload: %v", err)
 	}
 
+	responseCtx, responseCancel := context.WithTimeout(ctx, agentResponseTimeout)
+	defer responseCancel()
+	if _, err := pollForAgentResponse(t, responseCtx, threadsClient, runnerClient, threadID, agentID, labels, sentMessageTime, ""); err != nil {
+		t.Fatalf("wait for agent response: %v", err)
+	}
+
 	ackAllUnackedMessages(t, ctx, threadsClient, agentID)
 
-	idleCtx, idleCancel := context.WithTimeout(ctx, 90*time.Second)
+	idleCtx, idleCancel := context.WithTimeout(ctx, idleStopTimeout)
 	defer idleCancel()
 	if err := pollUntil(idleCtx, pollInterval, func(ctx context.Context) error {
 		ids, err := findWorkloadsByLabels(ctx, runnerClient, labels)

--- a/test/e2e/idle_test.go
+++ b/test/e2e/idle_test.go
@@ -18,10 +18,11 @@ import (
 )
 
 func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
-	idleTestTimeout := 6 * time.Minute
+	idleTestTimeout := 8 * time.Minute
 	workloadWaitTimeout := 90 * time.Second
 	agentResponseTimeout := 2 * time.Minute
-	idleStopTimeout := 120 * time.Second
+	unackedDrainTimeout := 2 * time.Minute
+	idleStopTimeout := 180 * time.Second
 
 	ctx, cancel := context.WithTimeout(context.Background(), idleTestTimeout)
 	t.Cleanup(cancel)
@@ -55,7 +56,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 		t.Fatal("create model: missing id")
 	}
 
-	idleTimeout := "30s"
+	idleTimeout := "15s"
 	agent := createAgentWithIdleTimeout(t, ctx, agentsClient, fmt.Sprintf("e2e-test-agent-idle-%s", uuid.NewString()), modelID, orgID, codexInitImage, idleTimeout)
 	agentID := agent.GetMeta().GetId()
 	if agentID == "" {
@@ -115,6 +116,21 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	}
 
 	ackAllUnackedMessages(t, ctx, threadsClient, agentID)
+	unackedCtx, unackedCancel := context.WithTimeout(ctx, unackedDrainTimeout)
+	defer unackedCancel()
+	if err := pollUntil(unackedCtx, pollInterval, func(ctx context.Context) error {
+		messageIDs, err := listUnackedMessageIDs(ctx, threadsClient, agentID)
+		if err != nil {
+			return err
+		}
+		if len(messageIDs) == 0 {
+			return nil
+		}
+		ackMessages(t, ctx, threadsClient, agentID, messageIDs)
+		return fmt.Errorf("expected 0 unacked messages, got %d", len(messageIDs))
+	}); err != nil {
+		t.Fatalf("wait for unacked messages to drain: %v", err)
+	}
 
 	idleCtx, idleCancel := context.WithTimeout(ctx, idleStopTimeout)
 	defer idleCancel()

--- a/test/e2e/idle_test.go
+++ b/test/e2e/idle_test.go
@@ -102,7 +102,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 		t.Fatalf("wait for workload: %v", err)
 	}
 
-	ackMessages(t, ctx, threadsClient, agentID, []string{messageID})
+	ackAllUnackedMessages(t, ctx, threadsClient, agentID)
 
 	idleCtx, idleCancel := context.WithTimeout(ctx, 90*time.Second)
 	defer idleCancel()

--- a/test/e2e/idle_test.go
+++ b/test/e2e/idle_test.go
@@ -71,7 +71,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	}
 	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
 
-	message := sendMessage(t, ctx, threadsClient, threadID, identityID, "e2e idle message")
+	message := sendMessage(t, ctx, threadsClient, threadID, identityID, "hello")
 	messageID := message.GetId()
 	if messageID == "" {
 		t.Fatal("send message: missing id")

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -29,8 +29,9 @@ import (
 )
 
 const (
-	pollInterval = 2 * time.Second
-	testTimeout  = 120 * time.Second
+	pollInterval          = 2 * time.Second
+	testTimeout           = 120 * time.Second
+	unackedPageSize int32 = 100
 
 	tracingDiscoverTimeout = 2 * time.Minute
 	tracingSummaryTimeout  = 2 * time.Minute
@@ -371,6 +372,49 @@ func ackMessages(t *testing.T, ctx context.Context, client threadsv1.ThreadsServ
 	})
 	if err != nil {
 		t.Fatalf("ack messages for %s: %v", participantID, err)
+	}
+}
+
+func ackAllUnackedMessages(t *testing.T, ctx context.Context, client threadsv1.ThreadsServiceClient, participantID string) {
+	t.Helper()
+	for {
+		messageIDs, err := listUnackedMessageIDs(ctx, client, participantID)
+		if err != nil {
+			t.Fatalf("list unacked messages for %s: %v", participantID, err)
+		}
+		if len(messageIDs) == 0 {
+			return
+		}
+		ackMessages(t, ctx, client, participantID, messageIDs)
+	}
+}
+
+func listUnackedMessageIDs(ctx context.Context, client threadsv1.ThreadsServiceClient, participantID string) ([]string, error) {
+	messageIDs := make([]string, 0, unackedPageSize)
+	token := ""
+	for {
+		page, err := client.GetUnackedMessages(ctx, &threadsv1.GetUnackedMessagesRequest{
+			ParticipantId: participantID,
+			PageSize:      unackedPageSize,
+			PageToken:     token,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, message := range page.GetMessages() {
+			if message == nil {
+				return nil, fmt.Errorf("unacked message is nil")
+			}
+			messageID := message.GetId()
+			if messageID == "" {
+				return nil, fmt.Errorf("unacked message missing id")
+			}
+			messageIDs = append(messageIDs, messageID)
+		}
+		token = page.GetNextPageToken()
+		if token == "" {
+			return messageIDs, nil
+		}
 	}
 }
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -53,6 +53,7 @@ var (
 	usersAddr      = envOrDefault("USERS_ADDRESS", "users:50051")
 	orgsAddr       = envOrDefault("ORGANIZATIONS_ADDRESS", "tenants:50051")
 	runnerAddr     = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")
+	runnersAddr    = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
 	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.5")
@@ -386,6 +387,40 @@ func ackAllUnackedMessages(t *testing.T, ctx context.Context, client threadsv1.T
 			return
 		}
 		ackMessages(t, ctx, client, participantID, messageIDs)
+	}
+}
+
+func ackAllUnackedMessagesBestEffort(t *testing.T, ctx context.Context, client threadsv1.ThreadsServiceClient, participantID string) {
+	t.Helper()
+	drainCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		messageIDs, err := listUnackedMessageIDs(drainCtx, client, participantID)
+		if err != nil {
+			t.Logf("cleanup: list unacked messages for %s: %v", participantID, err)
+			return
+		}
+		if len(messageIDs) == 0 {
+			return
+		}
+		_, err = client.AckMessages(drainCtx, &threadsv1.AckMessagesRequest{
+			ParticipantId: participantID,
+			MessageIds:    messageIDs,
+		})
+		if err != nil {
+			t.Logf("cleanup: ack messages for %s: %v", participantID, err)
+			return
+		}
+		select {
+		case <-drainCtx.Done():
+			t.Logf("cleanup: unacked message drain timeout for %s", participantID)
+			return
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -56,7 +56,7 @@ var (
 	runnersAddr    = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")
 	tracingAddr    = envOrDefault("TRACING_ADDRESS", "tracing:50051")
-	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.5")
+	codexInitImage = envOrDefault("CODEX_INIT_IMAGE", "ghcr.io/agynio/agent-init-codex:0.13.15")
 	agnInitImage   = envOrDefault("AGN_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.1")
 )
 


### PR DESCRIPTION
## Summary
- update buf.lock to api commit f3017f9
- pass agent capabilities into StartWorkloadRequest and runner selection
- enforce runner capability superset matching with improved errors and tests

## Testing
- go test ./...
- go build ./...
- go vet ./...

Relates to #133