### PR TITLE
feat: update workload env injection

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -27,7 +27,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/metadata"
 )
 
 func main() {
@@ -80,15 +79,7 @@ func run() error {
 	}
 	defer closeConn(secretsConn)
 
-	runnersConn, err := grpc.NewClient(
-		cfg.RunnersAddress,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			md, _ := metadata.FromOutgoingContext(ctx)
-			log.Printf("runners: %s x-identity-id=%v", method, md.Get("x-identity-id"))
-			return invoker(ctx, method, req, reply, cc, opts...)
-		}),
-	)
+	runnersConn, err := grpc.NewClient(cfg.RunnersAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial runners: %w", err)
 	}

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 func main() {
@@ -79,7 +80,15 @@ func run() error {
 	}
 	defer closeConn(secretsConn)
 
-	runnersConn, err := grpc.NewClient(cfg.RunnersAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	runnersConn, err := grpc.NewClient(
+		cfg.RunnersAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			md, _ := metadata.FromOutgoingContext(ctx)
+			log.Printf("runners: %s x-identity-id=%v", method, md.Get("x-identity-id"))
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}),
+	)
 	if err != nil {
 		return fmt.Errorf("dial runners: %w", err)
 	}

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -41,6 +41,26 @@ const (
 	zitiDNSSearchCluster                 = "cluster.local"
 )
 
+var reservedEnvNames = map[string]struct{}{
+	"AGENT_ID":                 {},
+	"AGENT_NAME":               {},
+	"AGENT_ROLE":               {},
+	"AGENT_MODEL":              {},
+	"AGENT_CONFIG":             {},
+	"THREAD_ID":                {},
+	"WORKLOAD_ID":              {},
+	"GATEWAY_ADDRESS":          {},
+	"AGYN_GATEWAY_URL":         {},
+	"LLM_BASE_URL":             {},
+	"TRACING_ADDRESS":          {},
+	"WORKSPACE_DIR":            {},
+	"HOME":                     {},
+	"AGENT_MCP_SERVERS":        {},
+	"MCP_PORT":                 {},
+	ZitiEnrollmentTokenEnvVar:  {},
+	ZitiIdentityBasenameEnvVar: {},
+}
+
 type Assembler struct {
 	agents  agentsv1.AgentsServiceClient
 	secrets secretsv1.SecretsServiceClient
@@ -102,8 +122,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		return nil, fmt.Errorf("resolve agent image pull secrets: %w", err)
 	}
 
-	mainEnv := a.baseAgentEnvVars(agent, agentID, threadID)
-	mainEnv = append(mainEnv, agentEnvVars...)
+	mainEnv := mergeEnvVars(a.baseAgentEnvVars(agent, agentID, threadID), agentEnvVars, fmt.Sprintf("agent %s", agentID.String()))
 
 	initImage := agent.GetInitImage()
 	if initImage == "" {
@@ -202,7 +221,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		})
 	}
 	if len(mcpServers) > 0 {
-		main.Env = append(main.Env, &runnerv1.EnvVar{Name: "AGENT_MCP_SERVERS", Value: strings.Join(mcpServers, ",")})
+		main.Env = appendPlatformEnvVar(main.Env, &runnerv1.EnvVar{Name: "AGENT_MCP_SERVERS", Value: strings.Join(mcpServers, ",")})
 	}
 	imagePullCredentials, err := imagePullResolver.Credentials()
 	if err != nil {
@@ -492,9 +511,11 @@ func (a *Assembler) buildMcpSidecar(ctx context.Context, resolver *envResolver, 
 		return nil, err
 	}
 	gatewayURL := buildGatewayURL(a.cfg.AgentGatewayAddress)
-	envVars = append(envVars, &runnerv1.EnvVar{Name: "MCP_PORT", Value: strconv.Itoa(port)})
-	envVars = append(envVars, &runnerv1.EnvVar{Name: "GATEWAY_ADDRESS", Value: a.cfg.AgentGatewayAddress})
-	envVars = append(envVars, &runnerv1.EnvVar{Name: "AGYN_GATEWAY_URL", Value: gatewayURL})
+	envVars = mergeEnvVars([]*runnerv1.EnvVar{
+		{Name: "MCP_PORT", Value: strconv.Itoa(port)},
+		{Name: "GATEWAY_ADDRESS", Value: a.cfg.AgentGatewayAddress},
+		{Name: "AGYN_GATEWAY_URL", Value: gatewayURL},
+	}, envVars, fmt.Sprintf("mcp %s", mcpID.String()))
 	return &runnerv1.ContainerSpec{
 		Image:  mcp.GetImage(),
 		Name:   fmt.Sprintf("mcp-%s", mcpID.String()[:8]),
@@ -515,6 +536,7 @@ func (a *Assembler) buildHookSidecar(ctx context.Context, resolver *envResolver,
 	if err != nil {
 		return nil, err
 	}
+	envVars = mergeEnvVars(nil, envVars, fmt.Sprintf("hook %s", assignment.id.String()))
 	return &runnerv1.ContainerSpec{
 		Image:  assignment.hook.GetImage(),
 		Name:   fmt.Sprintf("hook-%s", assignment.id.String()[:8]),
@@ -529,6 +551,44 @@ func buildGatewayURL(address string) string {
 		return address
 	}
 	return "http://" + address
+}
+
+func mergeEnvVars(platformEnv, userEnv []*runnerv1.EnvVar, owner string) []*runnerv1.EnvVar {
+	merged := make([]*runnerv1.EnvVar, 0, len(platformEnv)+len(userEnv))
+	seen := make(map[string]struct{}, len(platformEnv)+len(userEnv))
+	for _, env := range platformEnv {
+		name := env.Name
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		merged = append(merged, env)
+		seen[name] = struct{}{}
+	}
+	for _, env := range userEnv {
+		name := env.Name
+		if _, ok := reservedEnvNames[name]; ok {
+			log.Printf("assembler: warn: dropping reserved env %s for %s", name, owner)
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		merged = append(merged, env)
+		seen[name] = struct{}{}
+	}
+	return merged
+}
+
+func appendPlatformEnvVar(envs []*runnerv1.EnvVar, env *runnerv1.EnvVar) []*runnerv1.EnvVar {
+	result := make([]*runnerv1.EnvVar, 0, len(envs)+1)
+	for _, existing := range envs {
+		if existing.Name == env.Name {
+			continue
+		}
+		result = append(result, existing)
+	}
+	result = append(result, env)
+	return result
 }
 
 func (a *Assembler) baseAgentEnvVars(agent *agentsv1.Agent, agentID, threadID uuid.UUID) []*runnerv1.EnvVar {

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -30,6 +30,8 @@ const (
 	zitiIdentityVolumeName               = "ziti-identity"
 	zitiIdentityMountPath                = "/var/lib/ziti/identity"
 	ZitiIdentityBasename                 = "/var/lib/ziti/identity/agent"
+	ZitiEnrollmentJWTEnvVar              = "ZITI_ENROLLMENT_JWT"
+	ZitiIdentityBasenameEnvVar           = "ZITI_IDENTITY_BASENAME"
 	zitiDNSNameserver                    = "127.0.0.1"
 	zitiSidecarCommand                   = "tproxy"
 	zitiRequiredCapabilityNetAdmin       = "NET_ADMIN"
@@ -37,7 +39,6 @@ const (
 	zitiRestartPolicyAlways              = "Always"
 	zitiDNSSearchService                 = "svc.cluster.local"
 	zitiDNSSearchCluster                 = "cluster.local"
-	zitiIdentityBasenameEnvVar           = "ZITI_IDENTITY_BASENAME"
 )
 
 type Assembler struct {
@@ -192,7 +193,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			Name:  ZitiSidecarContainerName,
 			Cmd:   []string{zitiSidecarCommand},
 			Env: []*runnerv1.EnvVar{
-				{Name: zitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename},
+				{Name: ZitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename},
 			},
 			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -2,7 +2,6 @@ package assembler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"sort"
@@ -27,7 +26,7 @@ const (
 	agentWorkspaceDir                    = "/tmp"
 	agentHomeDir                         = "/tmp"
 	mcpBasePort                          = 8100
-	ZitiSidecarInitContainerName         = "ziti-sidecar"
+	ZitiSidecarContainerName             = "ziti-sidecar"
 	zitiIdentityVolumeName               = "ziti-identity"
 	zitiIdentityMountPath                = "/netfoundry"
 	zitiDNSNameserver                    = "127.0.0.1"
@@ -84,21 +83,6 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		return nil, fmt.Errorf("resolve agent envs: %w", err)
 	}
 
-	agentScripts, err := a.listInitScripts(ctx, &agentsv1.ListInitScriptsRequest{AgentId: agentID.String()})
-	if err != nil {
-		return nil, fmt.Errorf("list agent init scripts: %w", err)
-	}
-	agentInitScript := concatInitScripts(agentScripts)
-
-	skills, err := a.listSkills(ctx, agentID)
-	if err != nil {
-		return nil, fmt.Errorf("list skills: %w", err)
-	}
-	skillsJSON, err := buildSkillsJSON(skills)
-	if err != nil {
-		return nil, fmt.Errorf("encode skills: %w", err)
-	}
-
 	agentAttachments, err := a.listVolumeAttachments(ctx, &agentsv1.ListVolumeAttachmentsRequest{AgentId: agentID.String()})
 	if err != nil {
 		return nil, fmt.Errorf("list agent volume attachments: %w", err)
@@ -115,7 +99,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		return nil, fmt.Errorf("resolve agent image pull secrets: %w", err)
 	}
 
-	mainEnv := a.baseAgentEnvVars(ctx, agent, agentID, threadID, skillsJSON, agentInitScript)
+	mainEnv := a.baseAgentEnvVars(agent, agentID, threadID)
 	mainEnv = append(mainEnv, agentEnvVars...)
 
 	initImage := agent.GetInitImage()
@@ -141,16 +125,6 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		},
 	}
 	initContainers := []*runnerv1.ContainerSpec{initContainer}
-	if a.cfg.ZitiEnabled {
-		initContainers = append(initContainers, &runnerv1.ContainerSpec{
-			Image:                a.cfg.ZitiSidecarImage,
-			Name:                 ZitiSidecarInitContainerName,
-			Cmd:                  []string{zitiSidecarCommand},
-			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
-			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
-			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},
-		})
-	}
 
 	mcps, err := a.listMcps(ctx, agentID)
 	if err != nil {
@@ -192,7 +166,11 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		}
 	}
 
-	sidecars := make([]*runnerv1.ContainerSpec, 0, len(mcpAssignments)+len(hookAssignments))
+	sidecarCapacity := len(mcpAssignments) + len(hookAssignments)
+	if a.cfg.ZitiEnabled {
+		sidecarCapacity++
+	}
+	sidecars := make([]*runnerv1.ContainerSpec, 0, sidecarCapacity)
 	mcpServers := make([]string, 0, len(mcpAssignments))
 	for _, assignment := range mcpAssignments {
 		sidecar, err := a.buildMcpSidecar(ctx, resolver, volumeResolver, assignment.mcp, assignment.port)
@@ -208,6 +186,16 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			return nil, err
 		}
 		sidecars = append(sidecars, sidecar)
+	}
+	if a.cfg.ZitiEnabled {
+		sidecars = append(sidecars, &runnerv1.ContainerSpec{
+			Image:                a.cfg.ZitiSidecarImage,
+			Name:                 ZitiSidecarContainerName,
+			Cmd:                  []string{zitiSidecarCommand},
+			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
+			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
+			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},
+		})
 	}
 	if len(mcpServers) > 0 {
 		main.Env = append(main.Env, &runnerv1.EnvVar{Name: "AGENT_MCP_SERVERS", Value: strings.Join(mcpServers, ",")})
@@ -343,28 +331,6 @@ func (a *Assembler) listHooks(ctx context.Context, agentID uuid.UUID) ([]*agents
 	}
 }
 
-func (a *Assembler) listSkills(ctx context.Context, agentID uuid.UUID) ([]*agentsv1.Skill, error) {
-	resp := []*agentsv1.Skill{}
-	token := ""
-	for {
-		rctx, cancel := context.WithTimeout(ctx, rpcTimeout)
-		page, err := a.agents.ListSkills(rctx, &agentsv1.ListSkillsRequest{
-			AgentId:   agentID.String(),
-			PageSize:  listPageSize,
-			PageToken: token,
-		})
-		cancel()
-		if err != nil {
-			return nil, err
-		}
-		resp = append(resp, page.GetSkills()...)
-		token = page.GetNextPageToken()
-		if token == "" {
-			return resp, nil
-		}
-	}
-}
-
 func (a *Assembler) listEnvs(ctx context.Context, req *agentsv1.ListEnvsRequest) ([]*agentsv1.Env, error) {
 	resp := []*agentsv1.Env{}
 	token := ""
@@ -382,30 +348,6 @@ func (a *Assembler) listEnvs(ctx context.Context, req *agentsv1.ListEnvsRequest)
 			return nil, err
 		}
 		resp = append(resp, page.GetEnvs()...)
-		token = page.GetNextPageToken()
-		if token == "" {
-			return resp, nil
-		}
-	}
-}
-
-func (a *Assembler) listInitScripts(ctx context.Context, req *agentsv1.ListInitScriptsRequest) ([]*agentsv1.InitScript, error) {
-	resp := []*agentsv1.InitScript{}
-	token := ""
-	for {
-		rctx, cancel := context.WithTimeout(ctx, rpcTimeout)
-		page, err := a.agents.ListInitScripts(rctx, &agentsv1.ListInitScriptsRequest{
-			AgentId:   req.GetAgentId(),
-			McpId:     req.GetMcpId(),
-			HookId:    req.GetHookId(),
-			PageSize:  listPageSize,
-			PageToken: token,
-		})
-		cancel()
-		if err != nil {
-			return nil, err
-		}
-		resp = append(resp, page.GetInitScripts()...)
 		token = page.GetNextPageToken()
 		if token == "" {
 			return resp, nil
@@ -540,7 +482,6 @@ func (a *Assembler) buildMcpSidecar(ctx context.Context, resolver *envResolver, 
 		resolver,
 		volumeResolver,
 		&agentsv1.ListEnvsRequest{McpId: mcpID.String()},
-		&agentsv1.ListInitScriptsRequest{McpId: mcpID.String()},
 		&agentsv1.ListVolumeAttachmentsRequest{McpId: mcpID.String()},
 	)
 	if err != nil {
@@ -565,7 +506,6 @@ func (a *Assembler) buildHookSidecar(ctx context.Context, resolver *envResolver,
 		resolver,
 		volumeResolver,
 		&agentsv1.ListEnvsRequest{HookId: assignment.id.String()},
-		&agentsv1.ListInitScriptsRequest{HookId: assignment.id.String()},
 		&agentsv1.ListVolumeAttachmentsRequest{HookId: assignment.id.String()},
 	)
 	if err != nil {
@@ -587,7 +527,7 @@ func buildGatewayURL(address string) string {
 	return "http://" + address
 }
 
-func (a *Assembler) baseAgentEnvVars(ctx context.Context, agent *agentsv1.Agent, agentID, threadID uuid.UUID, skillsJSON, initScript string) []*runnerv1.EnvVar {
+func (a *Assembler) baseAgentEnvVars(agent *agentsv1.Agent, agentID, threadID uuid.UUID) []*runnerv1.EnvVar {
 	gatewayURL := buildGatewayURL(a.cfg.AgentGatewayAddress)
 	vars := []*runnerv1.EnvVar{
 		{Name: "AGENT_ID", Value: agentID.String()},
@@ -601,80 +541,11 @@ func (a *Assembler) baseAgentEnvVars(ctx context.Context, agent *agentsv1.Agent,
 		{Name: "LLM_BASE_URL", Value: a.cfg.AgentLLMBaseURL},
 		{Name: "WORKSPACE_DIR", Value: agentWorkspaceDir},
 		{Name: "HOME", Value: agentHomeDir},
-		{Name: "AGENT_SKILLS", Value: skillsJSON},
 	}
 	if a.cfg.AgentTracingAddress != "" {
 		vars = append(vars, &runnerv1.EnvVar{Name: "TRACING_ADDRESS", Value: a.cfg.AgentTracingAddress})
 	}
-	if initScript != "" {
-		vars = append(vars, &runnerv1.EnvVar{Name: "INIT_SCRIPT", Value: initScript})
-	}
 	return vars
-}
-
-type skillPayload struct {
-	Name string `json:"name"`
-	Body string `json:"body"`
-}
-
-func buildSkillsJSON(skills []*agentsv1.Skill) (string, error) {
-	payload := make([]skillPayload, len(skills))
-	for i, skill := range skills {
-		payload[i] = skillPayload{Name: skill.GetName(), Body: skill.GetBody()}
-	}
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
-}
-
-func concatInitScripts(scripts []*agentsv1.InitScript) string {
-	if len(scripts) == 0 {
-		return ""
-	}
-	sorted := append([]*agentsv1.InitScript(nil), scripts...)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		itime := initScriptTime(sorted[i])
-		jtime := initScriptTime(sorted[j])
-		if itime.Equal(jtime) {
-			return initScriptID(sorted[i]) < initScriptID(sorted[j])
-		}
-		return itime.Before(jtime)
-	})
-	var builder strings.Builder
-	for i, script := range sorted {
-		if i > 0 {
-			builder.WriteString("\n")
-		}
-		builder.WriteString(script.GetScript())
-	}
-	return builder.String()
-}
-
-func initScriptTime(script *agentsv1.InitScript) time.Time {
-	if script == nil {
-		return time.Time{}
-	}
-	meta := script.GetMeta()
-	if meta == nil {
-		return time.Time{}
-	}
-	if meta.GetCreatedAt() == nil {
-		return time.Time{}
-	}
-	return meta.GetCreatedAt().AsTime()
-}
-
-func initScriptID(script *agentsv1.InitScript) string {
-	if script == nil {
-		return ""
-	}
-	meta := script.GetMeta()
-	if meta == nil {
-		return ""
-	}
-	return meta.GetId()
 }
 
 type volumeResolver struct {
@@ -775,7 +646,7 @@ func (v *volumeResolver) getVolume(ctx context.Context, volumeID uuid.UUID) (*ag
 	return volume, nil
 }
 
-func (a *Assembler) resolveSidecarResources(ctx context.Context, resolver *envResolver, volumeResolver *volumeResolver, envReq *agentsv1.ListEnvsRequest, initReq *agentsv1.ListInitScriptsRequest, attachmentReq *agentsv1.ListVolumeAttachmentsRequest) ([]*runnerv1.EnvVar, []*runnerv1.VolumeMount, error) {
+func (a *Assembler) resolveSidecarResources(ctx context.Context, resolver *envResolver, volumeResolver *volumeResolver, envReq *agentsv1.ListEnvsRequest, attachmentReq *agentsv1.ListVolumeAttachmentsRequest) ([]*runnerv1.EnvVar, []*runnerv1.VolumeMount, error) {
 	vars, err := a.listEnvs(ctx, envReq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list sidecar envs: %w", err)
@@ -783,14 +654,6 @@ func (a *Assembler) resolveSidecarResources(ctx context.Context, resolver *envRe
 	envVars, err := resolver.ResolveEnvVars(ctx, vars)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve sidecar envs: %w", err)
-	}
-	scripts, err := a.listInitScripts(ctx, initReq)
-	if err != nil {
-		return nil, nil, fmt.Errorf("list sidecar init scripts: %w", err)
-	}
-	initScript := concatInitScripts(scripts)
-	if initScript != "" {
-		envVars = append(envVars, &runnerv1.EnvVar{Name: "INIT_SCRIPT", Value: initScript})
 	}
 	attachments, err := a.listVolumeAttachments(ctx, attachmentReq)
 	if err != nil {

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -170,6 +170,9 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}
 
 	sidecarCapacity := len(mcpAssignments) + len(hookAssignments)
+	if a.cfg.ZitiEnabled {
+		sidecarCapacity++
+	}
 	sidecars := make([]*runnerv1.ContainerSpec, 0, sidecarCapacity)
 	mcpServers := make([]string, 0, len(mcpAssignments))
 	for _, assignment := range mcpAssignments {
@@ -188,13 +191,10 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		sidecars = append(sidecars, sidecar)
 	}
 	if a.cfg.ZitiEnabled {
-		initContainers = append(initContainers, &runnerv1.ContainerSpec{
-			Image: a.cfg.ZitiSidecarImage,
-			Name:  ZitiSidecarContainerName,
-			Cmd:   []string{zitiSidecarCommand},
-			Env: []*runnerv1.EnvVar{
-				{Name: ZitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename},
-			},
+		sidecars = append(sidecars, &runnerv1.ContainerSpec{
+			Image:                a.cfg.ZitiSidecarImage,
+			Name:                 ZitiSidecarContainerName,
+			Cmd:                  []string{zitiSidecarCommand},
 			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
 			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -28,7 +28,8 @@ const (
 	mcpBasePort                          = 8100
 	ZitiSidecarContainerName             = "ziti-sidecar"
 	zitiIdentityVolumeName               = "ziti-identity"
-	zitiIdentityMountPath                = "/netfoundry"
+	zitiIdentityMountPath                = "/var/lib/ziti/identity"
+	ZitiIdentityBasename                 = "/var/lib/ziti/identity/agent"
 	zitiDNSNameserver                    = "127.0.0.1"
 	zitiSidecarCommand                   = "tproxy"
 	zitiRequiredCapabilityNetAdmin       = "NET_ADMIN"
@@ -36,6 +37,7 @@ const (
 	zitiRestartPolicyAlways              = "Always"
 	zitiDNSSearchService                 = "svc.cluster.local"
 	zitiDNSSearchCluster                 = "cluster.local"
+	zitiIdentityBasenameEnvVar           = "ZITI_IDENTITY_BASENAME"
 )
 
 type Assembler struct {
@@ -167,9 +169,6 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}
 
 	sidecarCapacity := len(mcpAssignments) + len(hookAssignments)
-	if a.cfg.ZitiEnabled {
-		sidecarCapacity++
-	}
 	sidecars := make([]*runnerv1.ContainerSpec, 0, sidecarCapacity)
 	mcpServers := make([]string, 0, len(mcpAssignments))
 	for _, assignment := range mcpAssignments {
@@ -188,10 +187,13 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		sidecars = append(sidecars, sidecar)
 	}
 	if a.cfg.ZitiEnabled {
-		sidecars = append(sidecars, &runnerv1.ContainerSpec{
-			Image:                a.cfg.ZitiSidecarImage,
-			Name:                 ZitiSidecarContainerName,
-			Cmd:                  []string{zitiSidecarCommand},
+		initContainers = append(initContainers, &runnerv1.ContainerSpec{
+			Image: a.cfg.ZitiSidecarImage,
+			Name:  ZitiSidecarContainerName,
+			Cmd:   []string{zitiSidecarCommand},
+			Env: []*runnerv1.EnvVar{
+				{Name: zitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename},
+			},
 			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
 			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -195,6 +195,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			Image:                a.cfg.ZitiSidecarImage,
 			Name:                 ZitiSidecarContainerName,
 			Cmd:                  []string{zitiSidecarCommand},
+			Env:                  []*runnerv1.EnvVar{{Name: ZitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename}},
 			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
 			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -28,9 +28,9 @@ const (
 	mcpBasePort                          = 8100
 	ZitiSidecarContainerName             = "ziti-sidecar"
 	zitiIdentityVolumeName               = "ziti-identity"
-	zitiIdentityMountPath                = "/var/lib/ziti/identity"
-	ZitiIdentityBasename                 = "/var/lib/ziti/identity/agent"
-	ZitiEnrollmentJWTEnvVar              = "ZITI_ENROLLMENT_JWT"
+	zitiIdentityMountPath                = "/netfoundry"
+	ZitiIdentityBasename                 = "agent"
+	ZitiEnrollmentTokenEnvVar            = "ZITI_ENROLL_TOKEN"
 	ZitiIdentityBasenameEnvVar           = "ZITI_IDENTITY_BASENAME"
 	zitiDNSNameserver                    = "127.0.0.1"
 	zitiSidecarCommand                   = "tproxy"

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -239,17 +239,17 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(request.DnsConfig.Searches, expectedSearches) {
 		t.Fatalf("expected dns searches %+v, got %+v", expectedSearches, request.DnsConfig.Searches)
 	}
-	if len(request.InitContainers) != 2 {
-		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
 		t.Fatal("expected agent-init container")
 	}
-	if len(request.Sidecars) != 0 {
-		t.Fatalf("expected 0 sidecars, got %d", len(request.Sidecars))
+	if len(request.Sidecars) != 1 {
+		t.Fatalf("expected 1 sidecar, got %d", len(request.Sidecars))
 	}
-	zitiSidecar := testutil.FindInitContainer(request.InitContainers, ZitiSidecarContainerName)
+	zitiSidecar := testutil.FindContainer(request.Sidecars, ZitiSidecarContainerName)
 	if zitiSidecar == nil {
 		t.Fatal("expected ziti-sidecar container")
 	}
@@ -262,13 +262,6 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	}
 	if !equalStringSlice(zitiSidecar.RequiredCapabilities, []string{zitiRequiredCapabilityNetAdmin}) {
 		t.Fatalf("expected ziti sidecar capabilities %+v, got %+v", []string{zitiRequiredCapabilityNetAdmin}, zitiSidecar.RequiredCapabilities)
-	}
-	if len(zitiSidecar.Env) != 1 {
-		t.Fatalf("expected 1 ziti sidecar env, got %d", len(zitiSidecar.Env))
-	}
-	zitiEnv := envMap(zitiSidecar.Env)
-	if zitiEnv[ZitiIdentityBasenameEnvVar] != ZitiIdentityBasename {
-		t.Fatalf("expected ziti sidecar basename %q, got %q", ZitiIdentityBasename, zitiEnv[ZitiIdentityBasenameEnvVar])
 	}
 	expectedProperties := map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways}
 	if !equalStringMap(zitiSidecar.AdditionalProperties, expectedProperties) {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -267,8 +267,8 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 		t.Fatalf("expected 1 ziti sidecar env, got %d", len(zitiSidecar.Env))
 	}
 	zitiEnv := envMap(zitiSidecar.Env)
-	if zitiEnv[zitiIdentityBasenameEnvVar] != ZitiIdentityBasename {
-		t.Fatalf("expected ziti sidecar basename %q, got %q", ZitiIdentityBasename, zitiEnv[zitiIdentityBasenameEnvVar])
+	if zitiEnv[ZitiIdentityBasenameEnvVar] != ZitiIdentityBasename {
+		t.Fatalf("expected ziti sidecar basename %q, got %q", ZitiIdentityBasename, zitiEnv[ZitiIdentityBasenameEnvVar])
 	}
 	expectedProperties := map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways}
 	if !equalStringMap(zitiSidecar.AdditionalProperties, expectedProperties) {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -45,6 +45,8 @@ func TestAssemblerMainContainer(t *testing.T) {
 			if req.GetAgentId() == agentID.String() {
 				return &agentsv1.ListEnvsResponse{Envs: []*agentsv1.Env{
 					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "CUSTOM_ENV", Source: &agentsv1.Env_Value{Value: "custom"}},
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "AGENT_NAME", Source: &agentsv1.Env_Value{Value: "override"}},
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "WORKSPACE_DIR", Source: &agentsv1.Env_Value{Value: "/override"}},
 				}}, nil
 			}
 			return &agentsv1.ListEnvsResponse{}, nil
@@ -164,6 +166,12 @@ func TestAssemblerMainContainer(t *testing.T) {
 	assertEnv(t, envs, "WORKSPACE_DIR", agentWorkspaceDir)
 	assertEnv(t, envs, "HOME", agentHomeDir)
 	assertEnv(t, envs, "CUSTOM_ENV", "custom")
+	if _, ok := envs["INIT_SCRIPT"]; ok {
+		t.Fatal("expected INIT_SCRIPT to be absent")
+	}
+	if _, ok := envs["AGENT_SKILLS"]; ok {
+		t.Fatal("expected AGENT_SKILLS to be absent")
+	}
 }
 
 func TestAssemblerAddsZitiSidecar(t *testing.T) {
@@ -551,6 +559,9 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 			if req.GetMcpId() == mcpID.String() {
 				return &agentsv1.ListEnvsResponse{Envs: []*agentsv1.Env{
 					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "MCP_ENV", Source: &agentsv1.Env_Value{Value: "enabled"}},
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "MCP_PORT", Source: &agentsv1.Env_Value{Value: "9090"}},
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "GATEWAY_ADDRESS", Source: &agentsv1.Env_Value{Value: "user-gateway"}},
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "AGYN_GATEWAY_URL", Source: &agentsv1.Env_Value{Value: "http://user-gateway"}},
 				}}, nil
 			}
 			return &agentsv1.ListEnvsResponse{}, nil

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -239,17 +239,17 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(request.DnsConfig.Searches, expectedSearches) {
 		t.Fatalf("expected dns searches %+v, got %+v", expectedSearches, request.DnsConfig.Searches)
 	}
-	if len(request.InitContainers) != 1 {
-		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 2 {
+		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
 		t.Fatal("expected agent-init container")
 	}
-	if len(request.Sidecars) != 1 {
-		t.Fatalf("expected 1 sidecar, got %d", len(request.Sidecars))
+	if len(request.Sidecars) != 0 {
+		t.Fatalf("expected 0 sidecars, got %d", len(request.Sidecars))
 	}
-	zitiSidecar := testutil.FindContainer(request.Sidecars, ZitiSidecarContainerName)
+	zitiSidecar := testutil.FindInitContainer(request.InitContainers, ZitiSidecarContainerName)
 	if zitiSidecar == nil {
 		t.Fatal("expected ziti-sidecar container")
 	}
@@ -262,6 +262,13 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	}
 	if !equalStringSlice(zitiSidecar.RequiredCapabilities, []string{zitiRequiredCapabilityNetAdmin}) {
 		t.Fatalf("expected ziti sidecar capabilities %+v, got %+v", []string{zitiRequiredCapabilityNetAdmin}, zitiSidecar.RequiredCapabilities)
+	}
+	if len(zitiSidecar.Env) != 1 {
+		t.Fatalf("expected 1 ziti sidecar env, got %d", len(zitiSidecar.Env))
+	}
+	zitiEnv := envMap(zitiSidecar.Env)
+	if zitiEnv[zitiIdentityBasenameEnvVar] != ZitiIdentityBasename {
+		t.Fatalf("expected ziti sidecar basename %q, got %q", ZitiIdentityBasename, zitiEnv[zitiIdentityBasenameEnvVar])
 	}
 	expectedProperties := map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways}
 	if !equalStringMap(zitiSidecar.AdditionalProperties, expectedProperties) {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -2,12 +2,10 @@ package assembler
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
@@ -16,7 +14,6 @@ import (
 	"github.com/agynio/agents-orchestrator/internal/testutil"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestAssemblerMainContainer(t *testing.T) {
@@ -37,20 +34,12 @@ func TestAssemblerMainContainer(t *testing.T) {
 		Capabilities:   []string{"privileged", "dind"},
 	}
 
-	skills := []*agentsv1.Skill{{Name: "skill-a", Body: "do-a"}}
-
 	agentsClient := &testutil.FakeAgentsClient{
 		GetAgentFunc: func(_ context.Context, req *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
 			if req.GetId() != agentID.String() {
 				return nil, errors.New("unexpected agent id")
 			}
 			return &agentsv1.GetAgentResponse{Agent: agent}, nil
-		},
-		ListSkillsFunc: func(_ context.Context, req *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
-			if req.GetAgentId() != agentID.String() {
-				return nil, errors.New("unexpected skills agent id")
-			}
-			return &agentsv1.ListSkillsResponse{Skills: skills}, nil
 		},
 		ListEnvsFunc: func(_ context.Context, req *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			if req.GetAgentId() == agentID.String() {
@@ -59,14 +48,6 @@ func TestAssemblerMainContainer(t *testing.T) {
 				}}, nil
 			}
 			return &agentsv1.ListEnvsResponse{}, nil
-		},
-		ListInitScriptsFunc: func(_ context.Context, req *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
-			if req.GetAgentId() != agentID.String() {
-				return &agentsv1.ListInitScriptsResponse{}, nil
-			}
-			return &agentsv1.ListInitScriptsResponse{InitScripts: []*agentsv1.InitScript{
-				{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Script: "echo ready"},
-			}}, nil
 		},
 		ListVolumeAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
 			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
@@ -183,14 +164,6 @@ func TestAssemblerMainContainer(t *testing.T) {
 	assertEnv(t, envs, "WORKSPACE_DIR", agentWorkspaceDir)
 	assertEnv(t, envs, "HOME", agentHomeDir)
 	assertEnv(t, envs, "CUSTOM_ENV", "custom")
-	assertEnv(t, envs, "INIT_SCRIPT", "echo ready")
-	var parsedSkills []skillPayload
-	if err := json.Unmarshal([]byte(envs["AGENT_SKILLS"]), &parsedSkills); err != nil {
-		t.Fatalf("unmarshal skills: %v", err)
-	}
-	if len(parsedSkills) != 1 || parsedSkills[0].Name != "skill-a" || parsedSkills[0].Body != "do-a" {
-		t.Fatalf("unexpected skills payload: %+v", parsedSkills)
-	}
 }
 
 func TestAssemblerAddsZitiSidecar(t *testing.T) {
@@ -266,35 +239,38 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(request.DnsConfig.Searches, expectedSearches) {
 		t.Fatalf("expected dns searches %+v, got %+v", expectedSearches, request.DnsConfig.Searches)
 	}
-	if len(request.InitContainers) != 2 {
-		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
 		t.Fatal("expected agent-init container")
 	}
-	zitiInit := testutil.FindInitContainer(request.InitContainers, ZitiSidecarInitContainerName)
-	if zitiInit == nil {
-		t.Fatal("expected ziti-sidecar init container")
+	if len(request.Sidecars) != 1 {
+		t.Fatalf("expected 1 sidecar, got %d", len(request.Sidecars))
 	}
-	if zitiInit.Image != cfg.ZitiSidecarImage {
-		t.Fatalf("expected ziti sidecar image %q, got %q", cfg.ZitiSidecarImage, zitiInit.Image)
+	zitiSidecar := testutil.FindContainer(request.Sidecars, ZitiSidecarContainerName)
+	if zitiSidecar == nil {
+		t.Fatal("expected ziti-sidecar container")
+	}
+	if zitiSidecar.Image != cfg.ZitiSidecarImage {
+		t.Fatalf("expected ziti sidecar image %q, got %q", cfg.ZitiSidecarImage, zitiSidecar.Image)
 	}
 	expectedCmd := []string{zitiSidecarCommand}
-	if !equalStringSlice(zitiInit.Cmd, expectedCmd) {
-		t.Fatalf("expected ziti sidecar cmd %+v, got %+v", expectedCmd, zitiInit.Cmd)
+	if !equalStringSlice(zitiSidecar.Cmd, expectedCmd) {
+		t.Fatalf("expected ziti sidecar cmd %+v, got %+v", expectedCmd, zitiSidecar.Cmd)
 	}
-	if !equalStringSlice(zitiInit.RequiredCapabilities, []string{zitiRequiredCapabilityNetAdmin}) {
-		t.Fatalf("expected ziti sidecar capabilities %+v, got %+v", []string{zitiRequiredCapabilityNetAdmin}, zitiInit.RequiredCapabilities)
+	if !equalStringSlice(zitiSidecar.RequiredCapabilities, []string{zitiRequiredCapabilityNetAdmin}) {
+		t.Fatalf("expected ziti sidecar capabilities %+v, got %+v", []string{zitiRequiredCapabilityNetAdmin}, zitiSidecar.RequiredCapabilities)
 	}
 	expectedProperties := map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways}
-	if !equalStringMap(zitiInit.AdditionalProperties, expectedProperties) {
-		t.Fatalf("expected ziti sidecar properties %+v, got %+v", expectedProperties, zitiInit.AdditionalProperties)
+	if !equalStringMap(zitiSidecar.AdditionalProperties, expectedProperties) {
+		t.Fatalf("expected ziti sidecar properties %+v, got %+v", expectedProperties, zitiSidecar.AdditionalProperties)
 	}
-	if len(zitiInit.Mounts) != 1 {
-		t.Fatalf("expected 1 ziti sidecar mount, got %d", len(zitiInit.Mounts))
+	if len(zitiSidecar.Mounts) != 1 {
+		t.Fatalf("expected 1 ziti sidecar mount, got %d", len(zitiSidecar.Mounts))
 	}
-	zitiMount := zitiInit.Mounts[0]
+	zitiMount := zitiSidecar.Mounts[0]
 	if zitiMount.Volume != zitiIdentityVolumeName {
 		t.Fatalf("expected ziti mount volume %q, got %q", zitiIdentityVolumeName, zitiMount.Volume)
 	}
@@ -354,9 +330,8 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 		Configuration: "{}",
 	}
 
-	ctx := context.Background()
 	assembler := New(&testutil.FakeAgentsClient{}, &testutil.FakeSecretsClient{}, &cfg)
-	envs := envMap(assembler.baseAgentEnvVars(ctx, agent, agentID, threadID, "[]", ""))
+	envs := envMap(assembler.baseAgentEnvVars(agent, agentID, threadID))
 	assertEnv(t, envs, "GATEWAY_ADDRESS", "gateway.ziti:443")
 	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://gateway.ziti:443")
 	assertEnv(t, envs, "LLM_BASE_URL", "http://llm-proxy.ziti/v1")
@@ -573,14 +548,6 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 			}
 			return &agentsv1.ListEnvsResponse{}, nil
 		},
-		ListInitScriptsFunc: func(_ context.Context, req *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
-			if req.GetMcpId() == mcpID.String() {
-				return &agentsv1.ListInitScriptsResponse{InitScripts: []*agentsv1.InitScript{
-					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString(), CreatedAt: timestamppb.New(time.Unix(5, 0))}, Script: "echo mcp"},
-				}}, nil
-			}
-			return &agentsv1.ListInitScriptsResponse{}, nil
-		},
 		ListVolumeAttachmentsFunc: func(_ context.Context, req *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
 			if req.GetMcpId() == mcpID.String() {
 				return &agentsv1.ListVolumeAttachmentsResponse{VolumeAttachments: []*agentsv1.VolumeAttachment{
@@ -665,7 +632,6 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 	}
 	envs := envMap(sidecar.Env)
 	assertEnv(t, envs, "MCP_ENV", "enabled")
-	assertEnv(t, envs, "INIT_SCRIPT", "echo mcp")
 	assertEnv(t, envs, "GATEWAY_ADDRESS", cfg.AgentGatewayAddress)
 	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://"+cfg.AgentGatewayAddress)
 }

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -263,6 +263,13 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(zitiSidecar.RequiredCapabilities, []string{zitiRequiredCapabilityNetAdmin}) {
 		t.Fatalf("expected ziti sidecar capabilities %+v, got %+v", []string{zitiRequiredCapabilityNetAdmin}, zitiSidecar.RequiredCapabilities)
 	}
+	if len(zitiSidecar.Env) != 1 {
+		t.Fatalf("expected 1 ziti sidecar env, got %d", len(zitiSidecar.Env))
+	}
+	zitiEnv := envMap(zitiSidecar.Env)
+	if zitiEnv[ZitiIdentityBasenameEnvVar] != ZitiIdentityBasename {
+		t.Fatalf("expected ziti sidecar basename %q, got %q", ZitiIdentityBasename, zitiEnv[ZitiIdentityBasenameEnvVar])
+	}
 	expectedProperties := map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways}
 	if !equalStringMap(zitiSidecar.AdditionalProperties, expectedProperties) {
 		t.Fatalf("expected ziti sidecar properties %+v, got %+v", expectedProperties, zitiSidecar.AdditionalProperties)

--- a/internal/reconciler/actual.go
+++ b/internal/reconciler/actual.go
@@ -11,7 +11,11 @@ import (
 const activeWorkloadPageSize int32 = 100
 
 func (r *Reconciler) fetchActual(ctx context.Context) ([]*runnersv1.Workload, error) {
-	tracked, err := r.listActiveWorkloads(ctx)
+	orgIdentities, err := r.agentIdentityByOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tracked, err := r.listActiveWorkloads(ctx, orgIdentities)
 	if err != nil {
 		return nil, err
 	}
@@ -27,38 +31,49 @@ func (r *Reconciler) fetchActual(ctx context.Context) ([]*runnersv1.Workload, er
 	return actual, nil
 }
 
-func (r *Reconciler) listActiveWorkloads(ctx context.Context) ([]*runnersv1.Workload, error) {
+func (r *Reconciler) listActiveWorkloads(ctx context.Context, orgIdentities map[string]string) ([]*runnersv1.Workload, error) {
 	active := []*runnersv1.Workload{}
-	pageToken := ""
-	for {
-		resp, err := r.runners.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{
-			PageSize:  activeWorkloadPageSize,
-			PageToken: pageToken,
-			Statuses: []runnersv1.WorkloadStatus{
-				runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
-				runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
-				runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING,
-			},
-		})
+	if len(orgIdentities) == 0 {
+		return active, nil
+	}
+	for orgID, identityID := range orgIdentities {
+		orgIDCopy := orgID
+		runnerCtx, err := runnerIdentityContext(ctx, identityID)
 		if err != nil {
-			return nil, fmt.Errorf("list workloads: %w", err)
+			return nil, err
 		}
-		for _, workload := range resp.GetWorkloads() {
-			if workload == nil {
-				return nil, fmt.Errorf("workload is nil")
+		pageToken := ""
+		for {
+			resp, err := r.runners.ListWorkloads(runnerCtx, &runnersv1.ListWorkloadsRequest{
+				PageSize:       activeWorkloadPageSize,
+				PageToken:      pageToken,
+				OrganizationId: &orgIDCopy,
+				Statuses: []runnersv1.WorkloadStatus{
+					runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
+					runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+					runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING,
+				},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("list workloads: %w", err)
 			}
-			meta := workload.GetMeta()
-			if meta == nil {
-				return nil, fmt.Errorf("workload meta missing")
+			for _, workload := range resp.GetWorkloads() {
+				if workload == nil {
+					return nil, fmt.Errorf("workload is nil")
+				}
+				meta := workload.GetMeta()
+				if meta == nil {
+					return nil, fmt.Errorf("workload meta missing")
+				}
+				if meta.GetId() == "" {
+					return nil, fmt.Errorf("workload meta id missing")
+				}
+				active = append(active, workload)
 			}
-			if meta.GetId() == "" {
-				return nil, fmt.Errorf("workload meta id missing")
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
 			}
-			active = append(active, workload)
-		}
-		pageToken = resp.GetNextPageToken()
-		if pageToken == "" {
-			break
 		}
 	}
 	return active, nil

--- a/internal/reconciler/desired.go
+++ b/internal/reconciler/desired.go
@@ -103,9 +103,13 @@ func (r *Reconciler) listAgents(ctx context.Context) ([]*agentsv1.Agent, error) 
 
 func (r *Reconciler) listUnackedThreads(ctx context.Context, agentID uuid.UUID) ([]uuid.UUID, error) {
 	threadIDs := make([]uuid.UUID, 0)
+	runnerCtx, err := r.runnerIdentityContextForAgent(ctx, agentID)
+	if err != nil {
+		return nil, err
+	}
 	token := ""
 	for {
-		page, err := r.threads.GetUnackedMessages(ctx, &threadsv1.GetUnackedMessagesRequest{
+		page, err := r.threads.GetUnackedMessages(runnerCtx, &threadsv1.GetUnackedMessagesRequest{
 			ParticipantId: agentID.String(),
 			PageSize:      desiredPageSize,
 			PageToken:     token,
@@ -129,10 +133,14 @@ func (r *Reconciler) listUnackedThreads(ctx context.Context, agentID uuid.UUID) 
 
 func (r *Reconciler) fetchPassiveThreads(ctx context.Context, agentID uuid.UUID) (map[uuid.UUID]struct{}, error) {
 	passiveThreads := make(map[uuid.UUID]struct{})
+	runnerCtx, err := r.runnerIdentityContextForAgent(ctx, agentID)
+	if err != nil {
+		return nil, err
+	}
 	token := ""
 	agentIDString := agentID.String()
 	for {
-		page, err := r.threads.GetThreads(ctx, &threadsv1.GetThreadsRequest{
+		page, err := r.threads.GetThreads(runnerCtx, &threadsv1.GetThreadsRequest{
 			ParticipantId: agentIDString,
 			PageSize:      desiredPageSize,
 			PageToken:     token,

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -63,7 +63,6 @@ func (f *fakeThreadsClient) GetThreads(ctx context.Context, req *threadsv1.GetTh
 func (f *fakeThreadsClient) GetThread(context.Context, *threadsv1.GetThreadRequest, ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }
-
 func (f *fakeThreadsClient) GetOrganizationThreads(context.Context, *threadsv1.GetOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.GetOrganizationThreadsResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -60,15 +60,12 @@ func (f *fakeThreadsClient) GetThreads(ctx context.Context, req *threadsv1.GetTh
 	}
 	return nil, testutil.ErrNotImplemented
 }
-
-func (f *fakeThreadsClient) GetThread(context.Context, *threadsv1.GetThreadRequest, ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
-	return nil, testutil.ErrNotImplemented
-}
-
 func (f *fakeThreadsClient) GetOrganizationThreads(context.Context, *threadsv1.GetOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.GetOrganizationThreadsResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }
-
+func (f *fakeThreadsClient) GetThread(context.Context, *threadsv1.GetThreadRequest, ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
 func (f *fakeThreadsClient) GetMessages(context.Context, *threadsv1.GetMessagesRequest, ...grpc.CallOption) (*threadsv1.GetMessagesResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -60,10 +60,11 @@ func (f *fakeThreadsClient) GetThreads(ctx context.Context, req *threadsv1.GetTh
 	}
 	return nil, testutil.ErrNotImplemented
 }
-func (f *fakeThreadsClient) GetOrganizationThreads(context.Context, *threadsv1.GetOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.GetOrganizationThreadsResponse, error) {
+func (f *fakeThreadsClient) GetThread(context.Context, *threadsv1.GetThreadRequest, ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }
-func (f *fakeThreadsClient) GetThread(context.Context, *threadsv1.GetThreadRequest, ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
+
+func (f *fakeThreadsClient) GetOrganizationThreads(context.Context, *threadsv1.GetOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.GetOrganizationThreadsResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }
 func (f *fakeThreadsClient) GetMessages(context.Context, *threadsv1.GetMessagesRequest, ...grpc.CallOption) (*threadsv1.GetMessagesResponse, error) {

--- a/internal/reconciler/identity_metadata.go
+++ b/internal/reconciler/identity_metadata.go
@@ -1,0 +1,77 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	"github.com/agynio/agents-orchestrator/internal/uuidutil"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/metadata"
+)
+
+const identityMetadataKey = "x-identity-id"
+
+func runnerIdentityContext(ctx context.Context, identityID string) (context.Context, error) {
+	identityID = strings.TrimSpace(identityID)
+	if _, err := uuidutil.ParseUUID(identityID, "identity_id"); err != nil {
+		return nil, err
+	}
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.MD{}
+	}
+	md = md.Copy()
+	md.Set(identityMetadataKey, identityID)
+	return metadata.NewOutgoingContext(ctx, md), nil
+}
+
+func (r *Reconciler) runnerIdentityContextForAgent(ctx context.Context, agentID uuid.UUID) (context.Context, error) {
+	return runnerIdentityContext(ctx, agentID.String())
+}
+
+func (r *Reconciler) agentIdentityByOrg(ctx context.Context) (map[string]string, error) {
+	if r.agents == nil {
+		return nil, fmt.Errorf("agents client is nil")
+	}
+	orgIdentities := map[string]string{}
+	pageToken := ""
+	for {
+		resp, err := r.agents.ListAgents(ctx, &agentsv1.ListAgentsRequest{
+			PageSize:  desiredPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list agents: %w", err)
+		}
+		for _, agent := range resp.GetAgents() {
+			if agent == nil {
+				return nil, fmt.Errorf("agent is nil")
+			}
+			meta := agent.GetMeta()
+			if meta == nil {
+				return nil, fmt.Errorf("agent meta missing")
+			}
+			agentID := strings.TrimSpace(meta.GetId())
+			parsedAgentID, err := uuidutil.ParseUUID(agentID, "agent.meta.id")
+			if err != nil {
+				return nil, err
+			}
+			orgID := strings.TrimSpace(agent.GetOrganizationId())
+			parsedOrgID, err := uuidutil.ParseUUID(orgID, "agent.organization_id")
+			if err != nil {
+				return nil, err
+			}
+			orgIDValue := parsedOrgID.String()
+			if _, ok := orgIdentities[orgIDValue]; ok {
+				continue
+			}
+			orgIdentities[orgIDValue] = parsedAgentID.String()
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return orgIdentities, nil
+		}
+	}
+}

--- a/internal/reconciler/identity_metadata.go
+++ b/internal/reconciler/identity_metadata.go
@@ -18,13 +18,7 @@ func runnerIdentityContext(ctx context.Context, identityID string) (context.Cont
 	if _, err := uuidutil.ParseUUID(identityID, "identity_id"); err != nil {
 		return nil, err
 	}
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		md = metadata.MD{}
-	}
-	md = md.Copy()
-	md.Set(identityMetadataKey, identityID)
-	return metadata.NewOutgoingContext(ctx, md), nil
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs(identityMetadataKey, identityID)), nil
 }
 
 func (r *Reconciler) runnerIdentityContextForAgent(ctx context.Context, agentID uuid.UUID) (context.Context, error) {

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -74,13 +74,19 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if mainEnvs["WORKLOAD_ID"] != workloadID {
 				return nil, errors.New("missing WORKLOAD_ID")
 			}
-			zitiContainer := testutil.FindContainer(req.GetSidecars(), assembler.ZitiSidecarContainerName)
+			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
 			if zitiContainer == nil {
-				return nil, errors.New("missing ziti sidecar container")
+				return nil, errors.New("missing ziti init container")
+			}
+			if len(zitiContainer.GetEnv()) != 2 {
+				return nil, errors.New("unexpected ziti env count")
 			}
 			envs := envMap(zitiContainer.GetEnv())
 			if envs["ZITI_ENROLLMENT_JWT"] != jwt {
 				return nil, errors.New("missing ZITI_ENROLLMENT_JWT")
+			}
+			if envs["ZITI_IDENTITY_BASENAME"] != assembler.ZitiIdentityBasename {
+				return nil, errors.New("missing ZITI_IDENTITY_BASENAME")
 			}
 			return &runnerv1.StartWorkloadResponse{
 				Id:     workloadID,
@@ -211,7 +217,7 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			if mainEnvs["WORKLOAD_ID"] != workloadID {
 				return nil, errors.New("missing WORKLOAD_ID")
 			}
-			zitiContainer := testutil.FindContainer(req.GetSidecars(), assembler.ZitiSidecarContainerName)
+			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
 			if zitiContainer != nil {
 				envs := envMap(zitiContainer.GetEnv())
 				if _, ok := envs["ZITI_ENROLLMENT_JWT"]; ok {

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -70,13 +70,17 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if req.GetAdditionalProperties()[labelKey] != workloadID {
 				return nil, errors.New("unexpected workload key label")
 			}
-			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarInitContainerName)
+			mainEnvs := envMap(req.GetMain().GetEnv())
+			if mainEnvs["WORKLOAD_ID"] != workloadID {
+				return nil, errors.New("missing WORKLOAD_ID")
+			}
+			zitiContainer := testutil.FindContainer(req.GetSidecars(), assembler.ZitiSidecarContainerName)
 			if zitiContainer == nil {
-				return nil, errors.New("missing ziti sidecar init container")
+				return nil, errors.New("missing ziti sidecar container")
 			}
 			envs := envMap(zitiContainer.GetEnv())
-			if envs["ZITI_ENROLL_TOKEN"] != jwt {
-				return nil, errors.New("missing ZITI_ENROLL_TOKEN")
+			if envs["ZITI_ENROLLMENT_JWT"] != jwt {
+				return nil, errors.New("missing ZITI_ENROLLMENT_JWT")
 			}
 			return &runnerv1.StartWorkloadResponse{
 				Id:     workloadID,
@@ -203,11 +207,15 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			if req.GetAdditionalProperties()[labelKey] != workloadID {
 				return nil, errors.New("unexpected workload key label")
 			}
-			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarInitContainerName)
+			mainEnvs := envMap(req.GetMain().GetEnv())
+			if mainEnvs["WORKLOAD_ID"] != workloadID {
+				return nil, errors.New("missing WORKLOAD_ID")
+			}
+			zitiContainer := testutil.FindContainer(req.GetSidecars(), assembler.ZitiSidecarContainerName)
 			if zitiContainer != nil {
 				envs := envMap(zitiContainer.GetEnv())
-				if _, ok := envs["ZITI_ENROLL_TOKEN"]; ok {
-					return nil, errors.New("unexpected ZITI_ENROLL_TOKEN")
+				if _, ok := envs["ZITI_ENROLLMENT_JWT"]; ok {
+					return nil, errors.New("unexpected ZITI_ENROLLMENT_JWT")
 				}
 			}
 			return &runnerv1.StartWorkloadResponse{

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -81,8 +81,8 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 				return nil, errors.New("missing ziti sidecar container")
 			}
 			envs := envMap(zitiContainer.GetEnv())
-			if envs["ZITI_ENROLLMENT_JWT"] != jwt {
-				return nil, errors.New("missing ZITI_ENROLLMENT_JWT")
+			if envs[assembler.ZitiEnrollmentTokenEnvVar] != jwt {
+				return nil, errors.New("missing ZITI_ENROLL_TOKEN")
 			}
 			if envs[assembler.ZitiIdentityBasenameEnvVar] != assembler.ZitiIdentityBasename {
 				return nil, errors.New("missing ZITI_IDENTITY_BASENAME")
@@ -219,8 +219,8 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			zitiContainer := testutil.FindContainer(req.GetSidecars(), assembler.ZitiSidecarContainerName)
 			if zitiContainer != nil {
 				envs := envMap(zitiContainer.GetEnv())
-				if _, ok := envs["ZITI_ENROLLMENT_JWT"]; ok {
-					return nil, errors.New("unexpected ZITI_ENROLLMENT_JWT")
+				if _, ok := envs[assembler.ZitiEnrollmentTokenEnvVar]; ok {
+					return nil, errors.New("unexpected ZITI_ENROLL_TOKEN")
 				}
 			}
 			return &runnerv1.StartWorkloadResponse{

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 const (
-	testOrganizationID         = "org-1"
+	testOrganizationID         = "11111111-1111-1111-1111-111111111111"
+	testAgentID                = "22222222-2222-2222-2222-222222222222"
+	testAgentIDAlt             = "33333333-3333-3333-3333-333333333333"
 	testAllocatedCPUMillicores = int32(500)
 	testAllocatedRAMBytes      = int64(1 << 30)
 )
@@ -771,7 +773,7 @@ func TestStopWorkloadDeletesIdentityAfterStop(t *testing.T) {
 		Runners:      runners,
 		Assembler:    testAssembler,
 	})
-	reconciler.stopWorkload(ctx, &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID, ZitiIdentityId: zitiID, InstanceId: stringPtr(instanceID)})
+	reconciler.stopWorkload(ctx, &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID, AgentId: agentID.String(), ZitiIdentityId: zitiID, InstanceId: stringPtr(instanceID)})
 
 	if !reflect.DeepEqual(calls, []string{"dial", "update-workload", "stop", "update-workload", "delete"}) {
 		t.Fatalf("unexpected call order: %v", calls)
@@ -813,6 +815,7 @@ func TestStopWorkloadMarksMissingRunnerOnNoTerminators(t *testing.T) {
 	reconciler.stopWorkload(ctx, &runnersv1.Workload{
 		Meta:       &runnersv1.EntityMeta{Id: "workload-1"},
 		RunnerId:   runnerID,
+		AgentId:    agentID.String(),
 		InstanceId: stringPtr(instanceID),
 		Status:     runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
 	})
@@ -878,6 +881,7 @@ func TestStopWorkloadMarksMissingRunnerOnNoTerminatorsStopError(t *testing.T) {
 	reconciler.stopWorkload(ctx, &runnersv1.Workload{
 		Meta:       &runnersv1.EntityMeta{Id: "workload-1"},
 		RunnerId:   runnerID,
+		AgentId:    agentID.String(),
 		InstanceId: stringPtr(instanceID),
 		Status:     runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
 	})
@@ -919,7 +923,7 @@ func TestStopWorkloadMarksFailedWhenInstanceMissing(t *testing.T) {
 		Runners:      runners,
 		Assembler:    testAssembler,
 	})
-	reconciler.stopWorkload(ctx, &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID})
+	reconciler.stopWorkload(ctx, &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID, AgentId: agentID.String()})
 
 	if dialCalled {
 		t.Fatal("expected no dial call")
@@ -985,7 +989,7 @@ func TestStopWorkloadSkipsIdentityWhenNil(t *testing.T) {
 		Runners:      runners,
 		Assembler:    testAssembler,
 	})
-	reconciler.stopWorkload(ctx, &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID, InstanceId: stringPtr(instanceID)})
+	reconciler.stopWorkload(ctx, &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID, AgentId: agentID.String(), InstanceId: stringPtr(instanceID)})
 
 	if deleteCalled {
 		t.Fatal("expected no delete identity call")
@@ -1032,7 +1036,7 @@ func TestStopWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 		Runners:      runners,
 		Assembler:    testAssembler,
 	})
-	reconciler.stopWorkload(ctx, &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID, ZitiIdentityId: zitiID, InstanceId: stringPtr(instanceID)})
+	reconciler.stopWorkload(ctx, &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID, AgentId: agentID.String(), ZitiIdentityId: zitiID, InstanceId: stringPtr(instanceID)})
 
 	if !reflect.DeepEqual(calls, []string{"dial", "update-workload", "stop", "update-workload"}) {
 		t.Fatalf("unexpected call order: %v", calls)
@@ -1272,7 +1276,27 @@ func newTestReconciler(cfg Config) *Reconciler {
 	if cfg.Metering == nil {
 		cfg.Metering = &fakeMeteringClient{}
 	}
+	if cfg.Agents == nil {
+		cfg.Agents = defaultAgentsClient()
+	} else if agentsClient, ok := cfg.Agents.(*testutil.FakeAgentsClient); ok && agentsClient.ListAgentsFunc == nil {
+		agentsClient.ListAgentsFunc = defaultListAgentsFunc()
+	}
 	return New(cfg)
+}
+
+func defaultAgentsClient() *testutil.FakeAgentsClient {
+	return &testutil.FakeAgentsClient{ListAgentsFunc: defaultListAgentsFunc()}
+}
+
+func defaultListAgentsFunc() func(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+	return func(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+		return &agentsv1.ListAgentsResponse{Agents: []*agentsv1.Agent{
+			{
+				Meta:           &agentsv1.EntityMeta{Id: testAgentID},
+				OrganizationId: testOrganizationID,
+			},
+		}}, nil
+	}
 }
 
 func newTestAssembler(agentID uuid.UUID, zitiEnabled bool) *assembler.Assembler {

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -82,8 +82,8 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 				return nil, errors.New("unexpected ziti env count")
 			}
 			envs := envMap(zitiContainer.GetEnv())
-			if envs[assembler.ZitiEnrollmentJWTEnvVar] != jwt {
-				return nil, errors.New("missing ZITI_ENROLLMENT_JWT")
+			if envs[assembler.ZitiEnrollmentTokenEnvVar] != jwt {
+				return nil, errors.New("missing ZITI_ENROLL_TOKEN")
 			}
 			if envs[assembler.ZitiIdentityBasenameEnvVar] != assembler.ZitiIdentityBasename {
 				return nil, errors.New("missing ZITI_IDENTITY_BASENAME")
@@ -220,8 +220,8 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
 			if zitiContainer != nil {
 				envs := envMap(zitiContainer.GetEnv())
-				if _, ok := envs[assembler.ZitiEnrollmentJWTEnvVar]; ok {
-					return nil, errors.New("unexpected ZITI_ENROLLMENT_JWT")
+				if _, ok := envs[assembler.ZitiEnrollmentTokenEnvVar]; ok {
+					return nil, errors.New("unexpected ZITI_ENROLL_TOKEN")
 				}
 			}
 			return &runnerv1.StartWorkloadResponse{

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -74,16 +74,13 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if mainEnvs["WORKLOAD_ID"] != workloadID {
 				return nil, errors.New("missing WORKLOAD_ID")
 			}
-			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
+			zitiContainer := testutil.FindContainer(req.GetSidecars(), assembler.ZitiSidecarContainerName)
 			if zitiContainer == nil {
-				return nil, errors.New("missing ziti init container")
-			}
-			if len(zitiContainer.GetEnv()) != 2 {
-				return nil, errors.New("unexpected ziti env count")
+				return nil, errors.New("missing ziti sidecar container")
 			}
 			envs := envMap(zitiContainer.GetEnv())
-			if envs[assembler.ZitiEnrollmentTokenEnvVar] != jwt {
-				return nil, errors.New("missing ZITI_ENROLL_TOKEN")
+			if envs["ZITI_ENROLLMENT_JWT"] != jwt {
+				return nil, errors.New("missing ZITI_ENROLLMENT_JWT")
 			}
 			if envs[assembler.ZitiIdentityBasenameEnvVar] != assembler.ZitiIdentityBasename {
 				return nil, errors.New("missing ZITI_IDENTITY_BASENAME")
@@ -217,11 +214,11 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			if mainEnvs["WORKLOAD_ID"] != workloadID {
 				return nil, errors.New("missing WORKLOAD_ID")
 			}
-			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
+			zitiContainer := testutil.FindContainer(req.GetSidecars(), assembler.ZitiSidecarContainerName)
 			if zitiContainer != nil {
 				envs := envMap(zitiContainer.GetEnv())
-				if _, ok := envs[assembler.ZitiEnrollmentTokenEnvVar]; ok {
-					return nil, errors.New("unexpected ZITI_ENROLL_TOKEN")
+				if _, ok := envs["ZITI_ENROLLMENT_JWT"]; ok {
+					return nil, errors.New("unexpected ZITI_ENROLLMENT_JWT")
 				}
 			}
 			return &runnerv1.StartWorkloadResponse{

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -82,10 +82,10 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 				return nil, errors.New("unexpected ziti env count")
 			}
 			envs := envMap(zitiContainer.GetEnv())
-			if envs["ZITI_ENROLLMENT_JWT"] != jwt {
+			if envs[assembler.ZitiEnrollmentJWTEnvVar] != jwt {
 				return nil, errors.New("missing ZITI_ENROLLMENT_JWT")
 			}
-			if envs["ZITI_IDENTITY_BASENAME"] != assembler.ZitiIdentityBasename {
+			if envs[assembler.ZitiIdentityBasenameEnvVar] != assembler.ZitiIdentityBasename {
 				return nil, errors.New("missing ZITI_IDENTITY_BASENAME")
 			}
 			return &runnerv1.StartWorkloadResponse{
@@ -220,7 +220,7 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
 			if zitiContainer != nil {
 				envs := envMap(zitiContainer.GetEnv())
-				if _, ok := envs["ZITI_ENROLLMENT_JWT"]; ok {
+				if _, ok := envs[assembler.ZitiEnrollmentJWTEnvVar]; ok {
 					return nil, errors.New("unexpected ZITI_ENROLLMENT_JWT")
 				}
 			}

--- a/internal/reconciler/metering_sample.go
+++ b/internal/reconciler/metering_sample.go
@@ -59,11 +59,15 @@ func (r *Reconciler) runMeteringSampleCycle(ctx context.Context) {
 }
 
 func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
-	workloads, err := r.listPendingSampleWorkloads(ctx)
+	orgIdentities, err := r.agentIdentityByOrg(ctx)
 	if err != nil {
 		return err
 	}
-	volumes, err := r.listPendingSampleVolumes(ctx)
+	workloads, err := r.listPendingSampleWorkloads(ctx, orgIdentities)
+	if err != nil {
+		return err
+	}
+	volumes, err := r.listPendingSampleVolumes(ctx, orgIdentities)
 	if err != nil {
 		return err
 	}
@@ -72,8 +76,8 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 	}
 
 	records := make([]*meteringv1.UsageRecord, 0, len(workloads)*2+len(volumes))
-	workloadUpdates := make([]*runnersv1.SampledAtEntry, 0, len(workloads))
-	volumeUpdates := make([]*runnersv1.SampledAtEntry, 0, len(volumes))
+	workloadUpdates := make(map[string][]*runnersv1.SampledAtEntry)
+	volumeUpdates := make(map[string][]*runnersv1.SampledAtEntry)
 
 	for _, workload := range workloads {
 		workloadRecords, update, err := sampleWorkloadMetering(workload, now)
@@ -81,7 +85,19 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 			return err
 		}
 		if update != nil {
-			workloadUpdates = append(workloadUpdates, update)
+			meta := workload.GetMeta()
+			if meta == nil {
+				return fmt.Errorf("workload meta missing")
+			}
+			orgID := strings.TrimSpace(workload.GetOrganizationId())
+			if orgID == "" {
+				return fmt.Errorf("workload %s organization id missing", meta.GetId())
+			}
+			identityID, ok := orgIdentities[orgID]
+			if !ok {
+				return fmt.Errorf("workload %s missing identity for org %s", meta.GetId(), orgID)
+			}
+			workloadUpdates[identityID] = append(workloadUpdates[identityID], update)
 		}
 		records = append(records, workloadRecords...)
 	}
@@ -91,7 +107,19 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 			return err
 		}
 		if update != nil {
-			volumeUpdates = append(volumeUpdates, update)
+			meta := volume.GetMeta()
+			if meta == nil {
+				return fmt.Errorf("volume meta missing")
+			}
+			orgID := strings.TrimSpace(volume.GetOrganizationId())
+			if orgID == "" {
+				return fmt.Errorf("volume %s organization id missing", meta.GetId())
+			}
+			identityID, ok := orgIdentities[orgID]
+			if !ok {
+				return fmt.Errorf("volume %s missing identity for org %s", meta.GetId(), orgID)
+			}
+			volumeUpdates[identityID] = append(volumeUpdates[identityID], update)
 		}
 		if volumeRecord != nil {
 			records = append(records, volumeRecord)
@@ -103,80 +131,116 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 			return fmt.Errorf("record metering: %w", err)
 		}
 	}
-	if len(workloadUpdates) > 0 {
-		if _, err := r.runners.BatchUpdateWorkloadSampledAt(ctx, &runnersv1.BatchUpdateWorkloadSampledAtRequest{Entries: workloadUpdates}); err != nil {
+	for identityID, entries := range workloadUpdates {
+		if len(entries) == 0 {
+			continue
+		}
+		runnerCtx, err := runnerIdentityContext(ctx, identityID)
+		if err != nil {
+			return err
+		}
+		if _, err := r.runners.BatchUpdateWorkloadSampledAt(runnerCtx, &runnersv1.BatchUpdateWorkloadSampledAtRequest{Entries: entries}); err != nil {
 			return fmt.Errorf("update workloads sampled_at: %w", err)
 		}
 	}
-	if len(volumeUpdates) > 0 {
-		if _, err := r.runners.BatchUpdateVolumeSampledAt(ctx, &runnersv1.BatchUpdateVolumeSampledAtRequest{Entries: volumeUpdates}); err != nil {
+	for identityID, entries := range volumeUpdates {
+		if len(entries) == 0 {
+			continue
+		}
+		runnerCtx, err := runnerIdentityContext(ctx, identityID)
+		if err != nil {
+			return err
+		}
+		if _, err := r.runners.BatchUpdateVolumeSampledAt(runnerCtx, &runnersv1.BatchUpdateVolumeSampledAtRequest{Entries: entries}); err != nil {
 			return fmt.Errorf("update volumes sampled_at: %w", err)
 		}
 	}
 	return nil
 }
 
-func (r *Reconciler) listPendingSampleWorkloads(ctx context.Context) ([]*runnersv1.Workload, error) {
+func (r *Reconciler) listPendingSampleWorkloads(ctx context.Context, orgIdentities map[string]string) ([]*runnersv1.Workload, error) {
 	workloads := []*runnersv1.Workload{}
-	pageToken := ""
-	for {
-		resp, err := r.runners.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{
-			PageSize:      meteringSamplePageSize,
-			PageToken:     pageToken,
-			PendingSample: boolPtr(true),
-		})
+	if len(orgIdentities) == 0 {
+		return workloads, nil
+	}
+	for orgID, identityID := range orgIdentities {
+		orgIDCopy := orgID
+		runnerCtx, err := runnerIdentityContext(ctx, identityID)
 		if err != nil {
-			return nil, fmt.Errorf("list workloads for metering: %w", err)
+			return nil, err
 		}
-		for _, workload := range resp.GetWorkloads() {
-			if workload == nil {
-				return nil, fmt.Errorf("workload is nil")
+		pageToken := ""
+		for {
+			resp, err := r.runners.ListWorkloads(runnerCtx, &runnersv1.ListWorkloadsRequest{
+				PageSize:       meteringSamplePageSize,
+				PageToken:      pageToken,
+				OrganizationId: &orgIDCopy,
+				PendingSample:  boolPtr(true),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("list workloads for metering: %w", err)
 			}
-			meta := workload.GetMeta()
-			if meta == nil {
-				return nil, fmt.Errorf("workload meta missing")
+			for _, workload := range resp.GetWorkloads() {
+				if workload == nil {
+					return nil, fmt.Errorf("workload is nil")
+				}
+				meta := workload.GetMeta()
+				if meta == nil {
+					return nil, fmt.Errorf("workload meta missing")
+				}
+				if meta.GetId() == "" {
+					return nil, fmt.Errorf("workload meta id missing")
+				}
+				workloads = append(workloads, workload)
 			}
-			if meta.GetId() == "" {
-				return nil, fmt.Errorf("workload meta id missing")
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
 			}
-			workloads = append(workloads, workload)
-		}
-		pageToken = resp.GetNextPageToken()
-		if pageToken == "" {
-			break
 		}
 	}
 	return workloads, nil
 }
 
-func (r *Reconciler) listPendingSampleVolumes(ctx context.Context) ([]*runnersv1.Volume, error) {
+func (r *Reconciler) listPendingSampleVolumes(ctx context.Context, orgIdentities map[string]string) ([]*runnersv1.Volume, error) {
 	volumes := []*runnersv1.Volume{}
-	pageToken := ""
-	for {
-		resp, err := r.runners.ListVolumes(ctx, &runnersv1.ListVolumesRequest{
-			PageSize:      meteringSamplePageSize,
-			PageToken:     pageToken,
-			PendingSample: boolPtr(true),
-		})
+	if len(orgIdentities) == 0 {
+		return volumes, nil
+	}
+	for orgID, identityID := range orgIdentities {
+		orgIDCopy := orgID
+		runnerCtx, err := runnerIdentityContext(ctx, identityID)
 		if err != nil {
-			return nil, fmt.Errorf("list volumes for metering: %w", err)
+			return nil, err
 		}
-		for _, volume := range resp.GetVolumes() {
-			if volume == nil {
-				return nil, fmt.Errorf("volume is nil")
+		pageToken := ""
+		for {
+			resp, err := r.runners.ListVolumes(runnerCtx, &runnersv1.ListVolumesRequest{
+				PageSize:       meteringSamplePageSize,
+				PageToken:      pageToken,
+				OrganizationId: &orgIDCopy,
+				PendingSample:  boolPtr(true),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("list volumes for metering: %w", err)
 			}
-			meta := volume.GetMeta()
-			if meta == nil {
-				return nil, fmt.Errorf("volume meta missing")
+			for _, volume := range resp.GetVolumes() {
+				if volume == nil {
+					return nil, fmt.Errorf("volume is nil")
+				}
+				meta := volume.GetMeta()
+				if meta == nil {
+					return nil, fmt.Errorf("volume meta missing")
+				}
+				if meta.GetId() == "" {
+					return nil, fmt.Errorf("volume meta id missing")
+				}
+				volumes = append(volumes, volume)
 			}
-			if meta.GetId() == "" {
-				return nil, fmt.Errorf("volume meta id missing")
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
 			}
-			volumes = append(volumes, volume)
-		}
-		pageToken = resp.GetNextPageToken()
-		if pageToken == "" {
-			break
 		}
 	}
 	return volumes, nil

--- a/internal/reconciler/metering_sample.go
+++ b/internal/reconciler/metering_sample.go
@@ -12,6 +12,7 @@ import (
 
 	meteringv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/metering/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -93,7 +94,11 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 			if orgID == "" {
 				return fmt.Errorf("workload %s organization id missing", meta.GetId())
 			}
-			identityID, ok := orgIdentities[orgID]
+			parsedOrgID, err := uuidutil.ParseUUID(orgID, "workload.organization_id")
+			if err != nil {
+				return err
+			}
+			identityID, ok := orgIdentities[parsedOrgID.String()]
 			if !ok {
 				return fmt.Errorf("workload %s missing identity for org %s", meta.GetId(), orgID)
 			}
@@ -115,7 +120,11 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 			if orgID == "" {
 				return fmt.Errorf("volume %s organization id missing", meta.GetId())
 			}
-			identityID, ok := orgIdentities[orgID]
+			parsedOrgID, err := uuidutil.ParseUUID(orgID, "volume.organization_id")
+			if err != nil {
+				return err
+			}
+			identityID, ok := orgIdentities[parsedOrgID.String()]
 			if !ok {
 				return fmt.Errorf("volume %s missing identity for org %s", meta.GetId(), orgID)
 			}

--- a/internal/reconciler/metering_sample_test.go
+++ b/internal/reconciler/metering_sample_test.go
@@ -43,18 +43,18 @@ func TestSampleMeteringEmitsRecordsAndUpdatesSampledAt(t *testing.T) {
 	workload1 := &runnersv1.Workload{
 		Meta:                   &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(workload1Created)},
 		ThreadId:               "thread-1",
-		AgentId:                "agent-1",
+		AgentId:                testAgentID,
 		RunnerId:               "runner-1",
-		OrganizationId:         "org-1",
+		OrganizationId:         testOrganizationID,
 		AllocatedCpuMillicores: 500,
 		AllocatedRamBytes:      2 * (1 << 30),
 	}
 	workload2 := &runnersv1.Workload{
 		Meta:                   &runnersv1.EntityMeta{Id: "workload-2", CreatedAt: timestamppb.New(workload2Created)},
 		ThreadId:               "thread-2",
-		AgentId:                "agent-2",
+		AgentId:                testAgentIDAlt,
 		RunnerId:               "runner-2",
-		OrganizationId:         "org-1",
+		OrganizationId:         testOrganizationID,
 		AllocatedCpuMillicores: 0,
 		AllocatedRamBytes:      0,
 		LastMeteringSampledAt:  timestamppb.New(workload2Sampled),
@@ -62,9 +62,9 @@ func TestSampleMeteringEmitsRecordsAndUpdatesSampledAt(t *testing.T) {
 	volume := &runnersv1.Volume{
 		Meta:           &runnersv1.EntityMeta{Id: "volume-1", CreatedAt: timestamppb.New(volumeCreated)},
 		ThreadId:       "thread-1",
-		AgentId:        "agent-1",
+		AgentId:        testAgentID,
 		RunnerId:       "runner-1",
-		OrganizationId: "org-1",
+		OrganizationId: testOrganizationID,
 		SizeGb:         "10",
 		RemovedAt:      timestamppb.New(volumeRemoved),
 	}
@@ -121,7 +121,7 @@ func TestSampleMeteringEmitsRecordsAndUpdatesSampledAt(t *testing.T) {
 		},
 	}
 
-	reconciler := New(Config{Runners: runners, Metering: metering, MeteringSampleInterval: time.Minute})
+	reconciler := New(Config{Runners: runners, Metering: metering, Agents: defaultAgentsClient(), MeteringSampleInterval: time.Minute})
 	if err := reconciler.sampleMetering(ctx, now); err != nil {
 		t.Fatalf("sample metering: %v", err)
 	}
@@ -184,9 +184,9 @@ func TestSampleMeteringEmitsRecordsAndUpdatesSampledAt(t *testing.T) {
 	assertLabelValue(t, cpuRecord.GetLabels(), labelResource, resourceWorkload)
 	assertLabelValue(t, cpuRecord.GetLabels(), labelResourceID, "workload-1")
 	assertLabelValue(t, cpuRecord.GetLabels(), labelThreadID, "thread-1")
-	assertLabelValue(t, cpuRecord.GetLabels(), labelAgentID, "agent-1")
+	assertLabelValue(t, cpuRecord.GetLabels(), labelAgentID, testAgentID)
 	assertLabelValue(t, cpuRecord.GetLabels(), labelRunnerID, "runner-1")
-	assertLabelValue(t, cpuRecord.GetLabels(), labelIdentityID, "agent-1")
+	assertLabelValue(t, cpuRecord.GetLabels(), labelIdentityID, testAgentID)
 	if _, ok := cpuRecord.GetLabels()[labelKind]; ok {
 		t.Fatalf("unexpected cpu kind label")
 	}

--- a/internal/reconciler/orphan.go
+++ b/internal/reconciler/orphan.go
@@ -13,7 +13,11 @@ import (
 const managedIdentityPageSize int32 = 100
 
 func (r *Reconciler) reconcileOrphanIdentities(ctx context.Context) error {
-	tracked, err := r.listActiveWorkloads(ctx)
+	orgIdentities, err := r.agentIdentityByOrg(ctx)
+	if err != nil {
+		return err
+	}
+	tracked, err := r.listActiveWorkloads(ctx, orgIdentities)
 	if err != nil {
 		return err
 	}

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -27,7 +27,7 @@ func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 	runners := &fakeRunnersClient{
 		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
 			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
-				{Meta: &runnersv1.EntityMeta{Id: workloadKey}, RunnerId: runnerID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING},
+				{Meta: &runnersv1.EntityMeta{Id: workloadKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
@@ -139,7 +139,7 @@ func TestReconcileWorkloadsMarksMissingRunnerOnNoTerminators(t *testing.T) {
 	runners := &fakeRunnersClient{
 		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
 			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
-				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
+				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
@@ -193,7 +193,7 @@ func TestReconcileWorkloadsMarksMissingRunnerOnNoTerminatorsListError(t *testing
 	runners := &fakeRunnersClient{
 		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
 			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
-				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
+				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
@@ -254,13 +254,14 @@ func TestReconcileWorkloadsDegradesUnenrolledRunner(t *testing.T) {
 	runners := &fakeRunnersClient{
 		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
 			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
-				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, ThreadId: threadID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
-				{Meta: &runnersv1.EntityMeta{Id: secondWorkloadID}, RunnerId: runnerID, ThreadId: threadID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
+				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, ThreadId: threadID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
+				{Meta: &runnersv1.EntityMeta{Id: secondWorkloadID}, RunnerId: runnerID, ThreadId: threadID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			orgID := testOrganizationID
 			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{
-				{Meta: &runnersv1.EntityMeta{Id: runnerID}, Status: runnersv1.RunnerStatus_RUNNER_STATUS_OFFLINE},
+				{Meta: &runnersv1.EntityMeta{Id: runnerID}, OrganizationId: &orgID, Status: runnersv1.RunnerStatus_RUNNER_STATUS_OFFLINE},
 			}}, nil
 		},
 		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
@@ -326,7 +327,7 @@ func TestReconcileVolumesActivatesProvisioning(t *testing.T) {
 	runners := &fakeRunnersClient{
 		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
 			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
-				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING, ThreadId: threadID, VolumeId: volumeID},
+				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING, ThreadId: threadID, VolumeId: volumeID},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
@@ -386,7 +387,7 @@ func TestReconcileVolumesMarksMissingRunnerOnNoTerminatorsListError(t *testing.T
 	runners := &fakeRunnersClient{
 		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
 			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
-				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
+				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
@@ -444,7 +445,7 @@ func TestReconcileVolumesDegradesOnMissingPVC(t *testing.T) {
 	runners := &fakeRunnersClient{
 		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
 			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
-				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
+				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
@@ -517,12 +518,13 @@ func TestReconcileVolumesDegradesUnenrolledRunner(t *testing.T) {
 	runners := &fakeRunnersClient{
 		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
 			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
-				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
+				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			orgID := testOrganizationID
 			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{
-				{Meta: &runnersv1.EntityMeta{Id: runnerID}, Status: runnersv1.RunnerStatus_RUNNER_STATUS_OFFLINE},
+				{Meta: &runnersv1.EntityMeta{Id: runnerID}, OrganizationId: &orgID, Status: runnersv1.RunnerStatus_RUNNER_STATUS_OFFLINE},
 			}}, nil
 		},
 		updateVolume: func(_ context.Context, req *runnersv1.UpdateVolumeRequest, _ ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error) {
@@ -585,7 +587,7 @@ func TestReconcileVolumesTTLExpires(t *testing.T) {
 	runners := &fakeRunnersClient{
 		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
 			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
-				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
+				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -254,7 +254,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 	if identity != nil {
 		if err := attachZitiEnrollmentJWT(request, identity.enrollmentJWT); err != nil {
 			log.Printf("reconciler: set ziti enrollment jwt for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
-			r.compensateIdentity(ctx, zitiIdentityID, "missing ziti sidecar")
+			r.compensateIdentity(ctx, zitiIdentityID, "missing ziti init container")
 			return
 		}
 	}
@@ -499,11 +499,11 @@ func failureSummary(failure *runnerv1.WorkloadFailure) string {
 }
 
 func attachZitiEnrollmentJWT(request *runnerv1.StartWorkloadRequest, jwt string) error {
-	for _, container := range request.Sidecars {
+	for _, container := range request.InitContainers {
 		if container.Name == assembler.ZitiSidecarContainerName {
 			container.Env = append(container.Env, &runnerv1.EnvVar{Name: "ZITI_ENROLLMENT_JWT", Value: jwt})
 			return nil
 		}
 	}
-	return fmt.Errorf("missing ziti sidecar container")
+	return fmt.Errorf("missing ziti init container")
 }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -257,7 +257,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 	}
 	zitiIdentityID := identity.idPtr()
 	if identity != nil {
-		if err := attachZitiEnrollmentJWT(request, identity.enrollmentJWT); err != nil {
+		if err := attachZitiEnrollmentToken(request, identity.enrollmentJWT); err != nil {
 			log.Printf("reconciler: set ziti enrollment jwt for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 			r.compensateIdentity(ctx, zitiIdentityID, "missing ziti sidecar container")
 			return
@@ -508,10 +508,10 @@ func failureSummary(failure *runnerv1.WorkloadFailure) string {
 	return failure.GetCode()
 }
 
-func attachZitiEnrollmentJWT(request *runnerv1.StartWorkloadRequest, jwt string) error {
+func attachZitiEnrollmentToken(request *runnerv1.StartWorkloadRequest, jwt string) error {
 	for _, container := range request.Sidecars {
 		if container.Name == assembler.ZitiSidecarContainerName {
-			container.Env = append(container.Env, &runnerv1.EnvVar{Name: "ZITI_ENROLLMENT_JWT", Value: jwt})
+			container.Env = append(container.Env, &runnerv1.EnvVar{Name: assembler.ZitiEnrollmentTokenEnvVar, Value: jwt})
 			return nil
 		}
 	}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -501,7 +501,7 @@ func failureSummary(failure *runnerv1.WorkloadFailure) string {
 func attachZitiEnrollmentJWT(request *runnerv1.StartWorkloadRequest, jwt string) error {
 	for _, container := range request.InitContainers {
 		if container.Name == assembler.ZitiSidecarContainerName {
-			container.Env = append(container.Env, &runnerv1.EnvVar{Name: "ZITI_ENROLLMENT_JWT", Value: jwt})
+			container.Env = append(container.Env, &runnerv1.EnvVar{Name: assembler.ZitiEnrollmentJWTEnvVar, Value: jwt})
 			return nil
 		}
 	}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -197,14 +197,19 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 		log.Printf("reconciler: assemble workload for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 		return
 	}
-	pinnedRunnerID, err := r.pinnedRunnerForThread(ctx, target.ThreadID.String())
+	runnerCtx, err := r.runnerIdentityContextForAgent(ctx, target.AgentID)
+	if err != nil {
+		log.Printf("reconciler: build runner identity for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
+		return
+	}
+	pinnedRunnerID, err := r.pinnedRunnerForThread(runnerCtx, target.ThreadID.String())
 	if err != nil {
 		log.Printf("reconciler: list volumes for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 		return
 	}
 	var selectedRunner *runnersv1.Runner
 	if pinnedRunnerID != "" {
-		runner, enrolled, err := r.getRunnerIfEnrolled(ctx, pinnedRunnerID)
+		runner, enrolled, err := r.getRunnerIfEnrolled(runnerCtx, pinnedRunnerID)
 		if err != nil {
 			log.Printf("reconciler: get runner %s for agent %s thread %s: %v", pinnedRunnerID, target.AgentID.String(), target.ThreadID.String(), err)
 			return
@@ -215,7 +220,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 		}
 		selectedRunner = runner
 	} else {
-		selectedRunner, err = r.selectRunner(ctx, assembled.OrganizationID, assembled.RunnerLabels, assembled.Request.GetCapabilities())
+		selectedRunner, err = r.selectRunner(runnerCtx, target.AgentID.String(), assembled.OrganizationID, assembled.RunnerLabels, assembled.Request.GetCapabilities())
 		if err != nil {
 			log.Printf("reconciler: select runner for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 			return
@@ -252,30 +257,30 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 	}
 	zitiIdentityID := identity.idPtr()
 	if identity != nil {
-		if err := attachZitiEnrollmentToken(request, identity.enrollmentJWT); err != nil {
+		if err := attachZitiEnrollmentJWT(request, identity.enrollmentJWT); err != nil {
 			log.Printf("reconciler: set ziti enrollment jwt for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
-			r.compensateIdentity(ctx, zitiIdentityID, "missing ziti init container")
+			r.compensateIdentity(ctx, zitiIdentityID, "missing ziti sidecar container")
 			return
 		}
 	}
-	createdVolumes, err := r.createVolumeRecords(ctx, volumeRecords, runnerID, target, assembled.OrganizationID)
+	createdVolumes, err := r.createVolumeRecords(runnerCtx, volumeRecords, runnerID, target, assembled.OrganizationID)
 	if err != nil {
 		log.Printf("reconciler: create volume records for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
-		r.markVolumeRecordsFailed(ctx, createdVolumes)
+		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "volume record failure")
 		return
 	}
-	if err := r.createWorkloadRecord(ctx, workloadIDValue, runnerID, target, assembled.OrganizationID, zitiIdentityID, assembled.AllocatedCPUMillicores, assembled.AllocatedRAMBytes); err != nil {
+	if err := r.createWorkloadRecord(runnerCtx, workloadIDValue, runnerID, target, assembled.OrganizationID, zitiIdentityID, assembled.AllocatedCPUMillicores, assembled.AllocatedRAMBytes); err != nil {
 		log.Printf("reconciler: create workload record %s for agent %s thread %s: %v", workloadIDValue, target.AgentID.String(), target.ThreadID.String(), err)
-		r.markVolumeRecordsFailed(ctx, createdVolumes)
+		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload record failure")
 		return
 	}
-	resp, err := runnerClient.StartWorkload(ctx, request)
+	resp, err := runnerClient.StartWorkload(runnerCtx, request)
 	if err != nil {
 		log.Printf("reconciler: start workload for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
-		r.markWorkloadFailed(ctx, workloadIDValue, nil)
-		r.markVolumeRecordsFailed(ctx, createdVolumes)
+		r.markWorkloadFailed(runnerCtx, workloadIDValue, nil)
+		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "start failure")
 		return
 	}
@@ -284,41 +289,41 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 	if resp.GetStatus() == runnerv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
 		log.Printf("reconciler: workload failed for agent %s thread %s: %s", target.AgentID.String(), target.ThreadID.String(), failureSummary(resp.GetFailure()))
 		if instanceID != "" {
-			if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
+			if err := r.stopRunnerWorkload(runnerCtx, runnerClient, instanceID); err != nil {
 				log.Printf("reconciler: stop workload %s after failure: %v", instanceID, err)
 			}
 		}
-		r.markWorkloadFailed(ctx, workloadIDValue, stringPtr(instanceID))
-		r.markVolumeRecordsFailed(ctx, createdVolumes)
+		r.markWorkloadFailed(runnerCtx, workloadIDValue, stringPtr(instanceID))
+		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload failure")
 		return
 	}
 	if rawInstanceID == "" {
 		log.Printf("reconciler: workload started without id for agent %s thread %s", target.AgentID.String(), target.ThreadID.String())
-		r.markWorkloadFailed(ctx, workloadIDValue, nil)
-		r.markVolumeRecordsFailed(ctx, createdVolumes)
+		r.markWorkloadFailed(runnerCtx, workloadIDValue, nil)
+		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "missing workload id")
 		return
 	}
 	if resp.GetId() != workloadIDValue {
 		log.Printf("reconciler: workload id mismatch for agent %s thread %s (expected %s got %s)", target.AgentID.String(), target.ThreadID.String(), workloadIDValue, resp.GetId())
 		instanceID := resp.GetId()
-		if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
+		if err := r.stopRunnerWorkload(runnerCtx, runnerClient, instanceID); err != nil {
 			log.Printf("reconciler: stop workload %s after id mismatch: %v", instanceID, err)
 		}
-		r.markWorkloadFailed(ctx, workloadIDValue, stringPtr(instanceID))
-		r.markVolumeRecordsFailed(ctx, createdVolumes)
+		r.markWorkloadFailed(runnerCtx, workloadIDValue, stringPtr(instanceID))
+		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload id mismatch")
 		return
 	}
 	status, err := runnerStatus(resp.GetStatus())
 	if err != nil {
 		log.Printf("reconciler: map workload status for workload %s: %v", rawInstanceID, err)
-		if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
+		if err := r.stopRunnerWorkload(runnerCtx, runnerClient, instanceID); err != nil {
 			log.Printf("reconciler: stop workload %s after status map failure: %v", instanceID, err)
 		}
-		r.markWorkloadFailed(ctx, workloadIDValue, stringPtr(instanceID))
-		r.markVolumeRecordsFailed(ctx, createdVolumes)
+		r.markWorkloadFailed(runnerCtx, workloadIDValue, stringPtr(instanceID))
+		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "status map failure")
 		return
 	}
@@ -331,7 +336,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 	if containers != nil {
 		updateReq.Containers = containers
 	}
-	if _, err := r.runners.UpdateWorkload(ctx, updateReq); err != nil {
+	if _, err := r.runners.UpdateWorkload(runnerCtx, updateReq); err != nil {
 		log.Printf("reconciler: update workload record %s after start: %v", workloadIDValue, err)
 	}
 }
@@ -342,10 +347,15 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 		log.Printf("reconciler: workload missing id")
 		return
 	}
+	runnerCtx, err := runnerIdentityContext(ctx, workload.GetAgentId())
+	if err != nil {
+		log.Printf("reconciler: build runner identity for workload %s: %v", workloadID, err)
+		return
+	}
 	instanceID := normalizeRunnerWorkloadID(workload.GetInstanceId())
 	if instanceID == "" {
 		log.Printf("reconciler: workload %s missing instance id", workloadID)
-		r.markWorkloadFailed(ctx, workloadID, nil)
+		r.markWorkloadFailed(runnerCtx, workloadID, nil)
 		return
 	}
 	runnerID := workload.GetRunnerId()
@@ -356,7 +366,7 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 	runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
 	if err != nil {
 		if runnerdial.IsNoTerminators(err) {
-			if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+			if err := r.handleMissingRunnerWorkload(runnerCtx, workload); err != nil {
 				log.Printf("reconciler: handle missing workload %s after runner dial failure: %v", workloadID, err)
 			}
 			return
@@ -365,16 +375,16 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 		return
 	}
 	stoppingStatus := runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING
-	if _, err := r.runners.UpdateWorkload(ctx, &runnersv1.UpdateWorkloadRequest{
+	if _, err := r.runners.UpdateWorkload(runnerCtx, &runnersv1.UpdateWorkloadRequest{
 		Id:     workloadID,
 		Status: &stoppingStatus,
 	}); err != nil {
 		log.Printf("reconciler: update workload %s to stopping: %v", workloadID, err)
 	}
 	workload.Status = stoppingStatus
-	if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
+	if err := r.stopRunnerWorkload(runnerCtx, runnerClient, instanceID); err != nil {
 		if runnerdial.IsNoTerminators(err) {
-			if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+			if err := r.handleMissingRunnerWorkload(runnerCtx, workload); err != nil {
 				log.Printf("reconciler: handle missing workload %s after runner stop failure: %v", workloadID, err)
 			}
 			return
@@ -383,7 +393,7 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 		return
 	}
 	stoppedStatus := runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED
-	if _, err := r.runners.UpdateWorkload(ctx, &runnersv1.UpdateWorkloadRequest{
+	if _, err := r.runners.UpdateWorkload(runnerCtx, &runnersv1.UpdateWorkloadRequest{
 		Id:        workloadID,
 		Status:    &stoppedStatus,
 		RemovedAt: timestamppb.New(time.Now().UTC()),

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -498,12 +498,12 @@ func failureSummary(failure *runnerv1.WorkloadFailure) string {
 	return failure.GetCode()
 }
 
-func attachZitiEnrollmentToken(request *runnerv1.StartWorkloadRequest, jwt string) error {
-	for _, container := range request.InitContainers {
+func attachZitiEnrollmentJWT(request *runnerv1.StartWorkloadRequest, jwt string) error {
+	for _, container := range request.Sidecars {
 		if container.Name == assembler.ZitiSidecarContainerName {
-			container.Env = append(container.Env, &runnerv1.EnvVar{Name: assembler.ZitiEnrollmentTokenEnvVar, Value: jwt})
+			container.Env = append(container.Env, &runnerv1.EnvVar{Name: "ZITI_ENROLLMENT_JWT", Value: jwt})
 			return nil
 		}
 	}
-	return fmt.Errorf("missing ziti init container")
+	return fmt.Errorf("missing ziti sidecar container")
 }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -215,7 +215,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 			return
 		}
 		if !enrolled {
-			r.degradeThread(ctx, target.ThreadID.String(), degradeReasonRunnerDeprovisioned, degraded)
+			r.degradeThread(runnerCtx, target.ThreadID.String(), degradeReasonRunnerDeprovisioned, degraded)
 			return
 		}
 		selectedRunner = runner

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -244,6 +244,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 		return
 	}
 	request.WorkloadId = workloadIDValue
+	request.Main.Env = append(request.Main.Env, &runnerv1.EnvVar{Name: "WORKLOAD_ID", Value: workloadIDValue})
 	identity, err := r.createIdentity(ctx, target, workloadID)
 	if err != nil {
 		log.Printf("reconciler: %v", err)
@@ -498,11 +499,11 @@ func failureSummary(failure *runnerv1.WorkloadFailure) string {
 }
 
 func attachZitiEnrollmentJWT(request *runnerv1.StartWorkloadRequest, jwt string) error {
-	for _, container := range request.InitContainers {
-		if container.Name == assembler.ZitiSidecarInitContainerName {
-			container.Env = append(container.Env, &runnerv1.EnvVar{Name: "ZITI_ENROLL_TOKEN", Value: jwt})
+	for _, container := range request.Sidecars {
+		if container.Name == assembler.ZitiSidecarContainerName {
+			container.Env = append(container.Env, &runnerv1.EnvVar{Name: "ZITI_ENROLLMENT_JWT", Value: jwt})
 			return nil
 		}
 	}
-	return fmt.Errorf("missing ziti sidecar init container")
+	return fmt.Errorf("missing ziti sidecar container")
 }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -252,7 +252,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 	}
 	zitiIdentityID := identity.idPtr()
 	if identity != nil {
-		if err := attachZitiEnrollmentJWT(request, identity.enrollmentJWT); err != nil {
+		if err := attachZitiEnrollmentToken(request, identity.enrollmentJWT); err != nil {
 			log.Printf("reconciler: set ziti enrollment jwt for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 			r.compensateIdentity(ctx, zitiIdentityID, "missing ziti init container")
 			return
@@ -498,10 +498,10 @@ func failureSummary(failure *runnerv1.WorkloadFailure) string {
 	return failure.GetCode()
 }
 
-func attachZitiEnrollmentJWT(request *runnerv1.StartWorkloadRequest, jwt string) error {
+func attachZitiEnrollmentToken(request *runnerv1.StartWorkloadRequest, jwt string) error {
 	for _, container := range request.InitContainers {
 		if container.Name == assembler.ZitiSidecarContainerName {
-			container.Env = append(container.Env, &runnerv1.EnvVar{Name: assembler.ZitiEnrollmentJWTEnvVar, Value: jwt})
+			container.Env = append(container.Env, &runnerv1.EnvVar{Name: assembler.ZitiEnrollmentTokenEnvVar, Value: jwt})
 			return nil
 		}
 	}

--- a/internal/reconciler/runners.go
+++ b/internal/reconciler/runners.go
@@ -10,21 +10,30 @@ import (
 
 const runnerPageSize int32 = 100
 
-func (r *Reconciler) selectRunner(ctx context.Context, organizationID string, runnerLabels map[string]string, requiredCapabilities []string) (*runnersv1.Runner, error) {
-	runners, err := r.listRunners(ctx)
+func (r *Reconciler) selectRunner(ctx context.Context, identityID, organizationID string, runnerLabels map[string]string, requiredCapabilities []string) (*runnersv1.Runner, error) {
+	runnerCtx, err := runnerIdentityContext(ctx, identityID)
+	if err != nil {
+		return nil, err
+	}
+	runners, err := r.listRunners(runnerCtx, organizationID)
 	if err != nil {
 		return nil, err
 	}
 	return runnerselect.Select(runners, organizationID, runnerLabels, requiredCapabilities)
 }
 
-func (r *Reconciler) listRunners(ctx context.Context) ([]*runnersv1.Runner, error) {
+func (r *Reconciler) listRunners(ctx context.Context, organizationID string) ([]*runnersv1.Runner, error) {
+	if organizationID == "" {
+		return nil, fmt.Errorf("organization id missing")
+	}
+	orgID := organizationID
 	var runners []*runnersv1.Runner
 	pageToken := ""
 	for {
 		resp, err := r.runners.ListRunners(ctx, &runnersv1.ListRunnersRequest{
-			PageSize:  runnerPageSize,
-			PageToken: pageToken,
+			PageSize:       runnerPageSize,
+			PageToken:      pageToken,
+			OrganizationId: &orgID,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("list runners: %w", err)
@@ -34,6 +43,25 @@ func (r *Reconciler) listRunners(ctx context.Context) ([]*runnersv1.Runner, erro
 		if pageToken == "" {
 			break
 		}
+	}
+	return runners, nil
+}
+
+func (r *Reconciler) listRunnersByOrg(ctx context.Context, orgIdentities map[string]string) ([]*runnersv1.Runner, error) {
+	if len(orgIdentities) == 0 {
+		return nil, nil
+	}
+	var runners []*runnersv1.Runner
+	for orgID, identityID := range orgIdentities {
+		runnerCtx, err := runnerIdentityContext(ctx, identityID)
+		if err != nil {
+			return nil, err
+		}
+		orgRunners, err := r.listRunners(runnerCtx, orgID)
+		if err != nil {
+			return nil, err
+		}
+		runners = append(runners, orgRunners...)
 	}
 	return runners, nil
 }

--- a/internal/reconciler/volume_reconcile.go
+++ b/internal/reconciler/volume_reconcile.go
@@ -117,7 +117,7 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 				if err := r.handleMissingRunnerVolume(volumeCtx, volume); err != nil {
 					log.Printf("reconciler: warn: handle missing volume %s on unenrolled runner: %v", volumeID, err)
 				}
-				r.degradeThread(ctx, volume.GetThreadId(), degradeReasonRunnerDeprovisioned, degraded)
+				r.degradeThread(volumeCtx, volume.GetThreadId(), degradeReasonRunnerDeprovisioned, degraded)
 			}
 			continue
 		}
@@ -187,7 +187,7 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 					log.Printf("reconciler: warn: handle missing volume %s: %v", volumeID, err)
 				}
 				if volume.GetStatus() == runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE {
-					r.degradeThread(ctx, volume.GetThreadId(), degradeReasonVolumeLost, degraded)
+					r.degradeThread(volumeCtx, volume.GetThreadId(), degradeReasonVolumeLost, degraded)
 				}
 				continue
 			}

--- a/internal/reconciler/volume_reconcile.go
+++ b/internal/reconciler/volume_reconcile.go
@@ -32,17 +32,26 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 	if r.agents == nil {
 		return fmt.Errorf("agents client not configured")
 	}
-	tracked, err := r.listActiveVolumes(ctx)
+	orgIdentities, err := r.agentIdentityByOrg(ctx)
+	if err != nil {
+		return err
+	}
+	tracked, err := r.listActiveVolumes(ctx, orgIdentities)
 	if err != nil {
 		return err
 	}
 	runnerIDs := map[string]struct{}{}
 	volumesByRunner := make(map[string]map[string]*runnersv1.Volume)
+	runnerIdentities := map[string]string{}
 	for _, volume := range tracked {
 		runnerID := volume.GetRunnerId()
 		if runnerID == "" {
 			log.Printf("reconciler: warn: volume %s missing runner id", volume.GetMeta().GetId())
 			continue
+		}
+		identityID := strings.TrimSpace(volume.GetAgentId())
+		if identityID == "" {
+			return fmt.Errorf("volume %s missing agent id", volume.GetMeta().GetId())
 		}
 		volumeID := volume.GetMeta().GetId()
 		if volumeID == "" {
@@ -54,8 +63,11 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 			volumesByRunner[runnerID] = map[string]*runnersv1.Volume{}
 		}
 		volumesByRunner[runnerID][volumeID] = volume
+		if _, ok := runnerIdentities[runnerID]; !ok {
+			runnerIdentities[runnerID] = identityID
+		}
 	}
-	runners, err := r.listRunners(ctx)
+	runners, err := r.listRunnersByOrg(ctx, orgIdentities)
 	if err != nil {
 		return err
 	}
@@ -73,6 +85,18 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 		}
 		enrolledRunnerIDs[runnerID] = struct{}{}
 		runnerIDs[runnerID] = struct{}{}
+		if _, ok := runnerIdentities[runnerID]; ok {
+			continue
+		}
+		orgID := strings.TrimSpace(runner.GetOrganizationId())
+		if orgID == "" {
+			return fmt.Errorf("runner %s organization id missing", runnerID)
+		}
+		identityID, ok := orgIdentities[orgID]
+		if !ok {
+			return fmt.Errorf("runner %s missing identity for org %s", runnerID, orgID)
+		}
+		runnerIdentities[runnerID] = identityID
 	}
 
 	degraded := newDegradeTracker()
@@ -80,20 +104,36 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 	threadCache := map[string]threadActivity{}
 	for runnerID := range runnerIDs {
 		trackedVolumes := volumesByRunner[runnerID]
+		identityID, ok := runnerIdentities[runnerID]
+		if !ok {
+			return fmt.Errorf("runner %s missing identity", runnerID)
+		}
 		if _, ok := enrolledRunnerIDs[runnerID]; !ok {
 			for volumeID, volume := range trackedVolumes {
-				if err := r.handleMissingRunnerVolume(ctx, volume); err != nil {
+				volumeCtx, err := runnerIdentityContext(ctx, volume.GetAgentId())
+				if err != nil {
+					return err
+				}
+				if err := r.handleMissingRunnerVolume(volumeCtx, volume); err != nil {
 					log.Printf("reconciler: warn: handle missing volume %s on unenrolled runner: %v", volumeID, err)
 				}
 				r.degradeThread(ctx, volume.GetThreadId(), degradeReasonRunnerDeprovisioned, degraded)
 			}
 			continue
 		}
+		runnerCtx, err := runnerIdentityContext(ctx, identityID)
+		if err != nil {
+			return err
+		}
 		runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
 		if err != nil {
 			if runnerdial.IsNoTerminators(err) {
 				for volumeID, volume := range trackedVolumes {
-					if err := r.handleMissingRunnerVolume(ctx, volume); err != nil {
+					volumeCtx, err := runnerIdentityContext(ctx, volume.GetAgentId())
+					if err != nil {
+						return err
+					}
+					if err := r.handleMissingRunnerVolume(volumeCtx, volume); err != nil {
 						log.Printf("reconciler: warn: handle missing volume %s after runner dial failure: %v", volumeID, err)
 					}
 				}
@@ -102,11 +142,15 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 			log.Printf("reconciler: warn: dial runner %s for volume reconciliation: %v", runnerID, err)
 			continue
 		}
-		resp, err := runnerClient.ListVolumes(ctx, &runnerv1.ListVolumesRequest{})
+		resp, err := runnerClient.ListVolumes(runnerCtx, &runnerv1.ListVolumesRequest{})
 		if err != nil {
 			if runnerdial.IsNoTerminators(err) {
 				for volumeID, volume := range trackedVolumes {
-					if err := r.handleMissingRunnerVolume(ctx, volume); err != nil {
+					volumeCtx, err := runnerIdentityContext(ctx, volume.GetAgentId())
+					if err != nil {
+						return err
+					}
+					if err := r.handleMissingRunnerVolume(volumeCtx, volume); err != nil {
 						log.Printf("reconciler: warn: handle missing volume %s after runner list failure: %v", volumeID, err)
 					}
 				}
@@ -133,9 +177,13 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 		}
 
 		for volumeID, volume := range trackedVolumes {
+			volumeCtx, err := runnerIdentityContext(ctx, volume.GetAgentId())
+			if err != nil {
+				return err
+			}
 			item, ok := runnerVolumes[volumeID]
 			if !ok {
-				if err := r.handleMissingRunnerVolume(ctx, volume); err != nil {
+				if err := r.handleMissingRunnerVolume(volumeCtx, volume); err != nil {
 					log.Printf("reconciler: warn: handle missing volume %s: %v", volumeID, err)
 				}
 				if volume.GetStatus() == runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE {
@@ -144,7 +192,7 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 				continue
 			}
 			delete(runnerVolumes, volumeID)
-			if err := r.handlePresentRunnerVolume(ctx, runnerClient, volume, item, volumeInfoCache, threadCache); err != nil {
+			if err := r.handlePresentRunnerVolume(volumeCtx, runnerClient, volume, item, volumeInfoCache, threadCache); err != nil {
 				log.Printf("reconciler: warn: handle volume %s on runner %s: %v", volumeID, runnerID, err)
 			}
 		}
@@ -155,7 +203,7 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 				log.Printf("reconciler: warn: runner %s orphan volume missing instance id", runnerID)
 				continue
 			}
-			if err := r.removeRunnerVolume(ctx, runnerClient, instanceID); err != nil {
+			if err := r.removeRunnerVolume(runnerCtx, runnerClient, instanceID); err != nil {
 				log.Printf("reconciler: warn: remove orphan volume %s on runner %s: %v", instanceID, runnerID, err)
 			}
 		}
@@ -163,38 +211,49 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 	return nil
 }
 
-func (r *Reconciler) listActiveVolumes(ctx context.Context) ([]*runnersv1.Volume, error) {
+func (r *Reconciler) listActiveVolumes(ctx context.Context, orgIdentities map[string]string) ([]*runnersv1.Volume, error) {
 	active := []*runnersv1.Volume{}
-	pageToken := ""
-	for {
-		resp, err := r.runners.ListVolumes(ctx, &runnersv1.ListVolumesRequest{
-			PageSize:  activeVolumePageSize,
-			PageToken: pageToken,
-			Statuses: []runnersv1.VolumeStatus{
-				runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
-				runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE,
-				runnersv1.VolumeStatus_VOLUME_STATUS_DEPROVISIONING,
-			},
-		})
+	if len(orgIdentities) == 0 {
+		return active, nil
+	}
+	for orgID, identityID := range orgIdentities {
+		orgIDCopy := orgID
+		runnerCtx, err := runnerIdentityContext(ctx, identityID)
 		if err != nil {
-			return nil, fmt.Errorf("list volumes: %w", err)
+			return nil, err
 		}
-		for _, volume := range resp.GetVolumes() {
-			if volume == nil {
-				return nil, fmt.Errorf("volume is nil")
+		pageToken := ""
+		for {
+			resp, err := r.runners.ListVolumes(runnerCtx, &runnersv1.ListVolumesRequest{
+				PageSize:       activeVolumePageSize,
+				PageToken:      pageToken,
+				OrganizationId: &orgIDCopy,
+				Statuses: []runnersv1.VolumeStatus{
+					runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
+					runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE,
+					runnersv1.VolumeStatus_VOLUME_STATUS_DEPROVISIONING,
+				},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("list volumes: %w", err)
 			}
-			meta := volume.GetMeta()
-			if meta == nil {
-				return nil, fmt.Errorf("volume meta missing")
+			for _, volume := range resp.GetVolumes() {
+				if volume == nil {
+					return nil, fmt.Errorf("volume is nil")
+				}
+				meta := volume.GetMeta()
+				if meta == nil {
+					return nil, fmt.Errorf("volume meta missing")
+				}
+				if meta.GetId() == "" {
+					return nil, fmt.Errorf("volume meta id missing")
+				}
+				active = append(active, volume)
 			}
-			if meta.GetId() == "" {
-				return nil, fmt.Errorf("volume meta id missing")
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
 			}
-			active = append(active, volume)
-		}
-		pageToken = resp.GetNextPageToken()
-		if pageToken == "" {
-			break
 		}
 	}
 	return active, nil

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -2,7 +2,9 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
@@ -12,17 +14,26 @@ import (
 )
 
 func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
-	tracked, err := r.listActiveWorkloads(ctx)
+	orgIdentities, err := r.agentIdentityByOrg(ctx)
+	if err != nil {
+		return err
+	}
+	tracked, err := r.listActiveWorkloads(ctx, orgIdentities)
 	if err != nil {
 		return err
 	}
 	runnerIDs := map[string]struct{}{}
 	workloadsByRunner := make(map[string]map[string]*runnersv1.Workload)
+	runnerIdentities := map[string]string{}
 	for _, workload := range tracked {
 		runnerID := workload.GetRunnerId()
 		if runnerID == "" {
 			log.Printf("reconciler: warn: workload %s missing runner id", workload.GetMeta().GetId())
 			continue
+		}
+		identityID := strings.TrimSpace(workload.GetAgentId())
+		if identityID == "" {
+			return fmt.Errorf("workload %s missing agent id", workload.GetMeta().GetId())
 		}
 		workloadID := workload.GetMeta().GetId()
 		if workloadID == "" {
@@ -34,8 +45,11 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 			workloadsByRunner[runnerID] = map[string]*runnersv1.Workload{}
 		}
 		workloadsByRunner[runnerID][workloadID] = workload
+		if _, ok := runnerIdentities[runnerID]; !ok {
+			runnerIdentities[runnerID] = identityID
+		}
 	}
-	runners, err := r.listRunners(ctx)
+	runners, err := r.listRunnersByOrg(ctx, orgIdentities)
 	if err != nil {
 		return err
 	}
@@ -53,26 +67,54 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 		}
 		enrolledRunnerIDs[runnerID] = struct{}{}
 		runnerIDs[runnerID] = struct{}{}
+		if _, ok := runnerIdentities[runnerID]; ok {
+			continue
+		}
+		orgID := strings.TrimSpace(runner.GetOrganizationId())
+		if orgID == "" {
+			return fmt.Errorf("runner %s organization id missing", runnerID)
+		}
+		identityID, ok := orgIdentities[orgID]
+		if !ok {
+			return fmt.Errorf("runner %s missing identity for org %s", runnerID, orgID)
+		}
+		runnerIdentities[runnerID] = identityID
 	}
 
 	degraded := newDegradeTracker()
 
 	for runnerID := range runnerIDs {
 		trackedWorkloads := workloadsByRunner[runnerID]
+		identityID, ok := runnerIdentities[runnerID]
+		if !ok {
+			return fmt.Errorf("runner %s missing identity", runnerID)
+		}
 		if _, ok := enrolledRunnerIDs[runnerID]; !ok {
 			for workloadID, workload := range trackedWorkloads {
-				if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+				workloadCtx, err := runnerIdentityContext(ctx, workload.GetAgentId())
+				if err != nil {
+					return err
+				}
+				if err := r.handleMissingRunnerWorkload(workloadCtx, workload); err != nil {
 					log.Printf("reconciler: warn: handle missing workload %s on unenrolled runner: %v", workloadID, err)
 				}
 				r.degradeThread(ctx, workload.GetThreadId(), degradeReasonRunnerDeprovisioned, degraded)
 			}
 			continue
 		}
+		runnerCtx, err := runnerIdentityContext(ctx, identityID)
+		if err != nil {
+			return err
+		}
 		runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
 		if err != nil {
 			if runnerdial.IsNoTerminators(err) {
 				for workloadID, workload := range trackedWorkloads {
-					if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+					workloadCtx, err := runnerIdentityContext(ctx, workload.GetAgentId())
+					if err != nil {
+						return err
+					}
+					if err := r.handleMissingRunnerWorkload(workloadCtx, workload); err != nil {
 						log.Printf("reconciler: warn: handle missing workload %s after runner dial failure: %v", workloadID, err)
 					}
 				}
@@ -81,11 +123,15 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 			log.Printf("reconciler: warn: dial runner %s for workload reconciliation: %v", runnerID, err)
 			continue
 		}
-		resp, err := runnerClient.ListWorkloads(ctx, &runnerv1.ListWorkloadsRequest{})
+		resp, err := runnerClient.ListWorkloads(runnerCtx, &runnerv1.ListWorkloadsRequest{})
 		if err != nil {
 			if runnerdial.IsNoTerminators(err) {
 				for workloadID, workload := range trackedWorkloads {
-					if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+					workloadCtx, err := runnerIdentityContext(ctx, workload.GetAgentId())
+					if err != nil {
+						return err
+					}
+					if err := r.handleMissingRunnerWorkload(workloadCtx, workload); err != nil {
 						log.Printf("reconciler: warn: handle missing workload %s after runner list failure: %v", workloadID, err)
 					}
 				}
@@ -112,15 +158,19 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 		}
 
 		for workloadID, workload := range trackedWorkloads {
+			workloadCtx, err := runnerIdentityContext(ctx, workload.GetAgentId())
+			if err != nil {
+				return err
+			}
 			item, ok := runnerWorkloads[workloadID]
 			if !ok {
-				if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+				if err := r.handleMissingRunnerWorkload(workloadCtx, workload); err != nil {
 					log.Printf("reconciler: warn: handle missing workload %s: %v", workloadID, err)
 				}
 				continue
 			}
 			delete(runnerWorkloads, workloadID)
-			if err := r.handlePresentRunnerWorkload(ctx, runnerClient, workload, item); err != nil {
+			if err := r.handlePresentRunnerWorkload(workloadCtx, runnerClient, workload, item); err != nil {
 				log.Printf("reconciler: warn: handle workload %s on runner %s: %v", workloadID, runnerID, err)
 			}
 		}
@@ -131,7 +181,7 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 				log.Printf("reconciler: warn: runner %s orphan workload missing instance id", runnerID)
 				continue
 			}
-			if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
+			if err := r.stopRunnerWorkload(runnerCtx, runnerClient, instanceID); err != nil {
 				log.Printf("reconciler: warn: stop orphan workload %s on runner %s: %v", instanceID, runnerID, err)
 			}
 		}

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -98,7 +98,7 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 				if err := r.handleMissingRunnerWorkload(workloadCtx, workload); err != nil {
 					log.Printf("reconciler: warn: handle missing workload %s on unenrolled runner: %v", workloadID, err)
 				}
-				r.degradeThread(ctx, workload.GetThreadId(), degradeReasonRunnerDeprovisioned, degraded)
+				r.degradeThread(workloadCtx, workload.GetThreadId(), degradeReasonRunnerDeprovisioned, degraded)
 			}
 			continue
 		}

--- a/internal/testutil/container.go
+++ b/internal/testutil/container.go
@@ -2,11 +2,15 @@ package testutil
 
 import runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 
-func FindInitContainer(containers []*runnerv1.ContainerSpec, name string) *runnerv1.ContainerSpec {
+func FindContainer(containers []*runnerv1.ContainerSpec, name string) *runnerv1.ContainerSpec {
 	for _, container := range containers {
 		if container.GetName() == name {
 			return container
 		}
 	}
 	return nil
+}
+
+func FindInitContainer(containers []*runnerv1.ContainerSpec, name string) *runnerv1.ContainerSpec {
+	return FindContainer(containers, name)
 }

--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -14,6 +14,7 @@ var ErrNotImplemented = errors.New("not implemented")
 type FakeAgentsClient struct {
 	GetAgentFunc                       func(context.Context, *agentsv1.GetAgentRequest, ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
 	ResolveAgentIdentityFunc           func(context.Context, *agentsv1.ResolveAgentIdentityRequest, ...grpc.CallOption) (*agentsv1.ResolveAgentIdentityResponse, error)
+	ListAgentsFunc                     func(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error)
 	ListSkillsFunc                     func(context.Context, *agentsv1.ListSkillsRequest, ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error)
 	ListEnvsFunc                       func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error)
 	ListInitScriptsFunc                func(context.Context, *agentsv1.ListInitScriptsRequest, ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error)
@@ -69,7 +70,10 @@ func (f *FakeAgentsClient) DeleteAgent(context.Context, *agentsv1.DeleteAgentReq
 	return nil, ErrNotImplemented
 }
 
-func (f *FakeAgentsClient) ListAgents(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+func (f *FakeAgentsClient) ListAgents(ctx context.Context, req *agentsv1.ListAgentsRequest, opts ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+	if f.ListAgentsFunc != nil {
+		return f.ListAgentsFunc(ctx, req, opts...)
+	}
 	return nil, ErrNotImplemented
 }
 

--- a/test/e2e/dedup_test.go
+++ b/test/e2e/dedup_test.go
@@ -36,6 +36,7 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	threadsCtx := withIdentity(ctx, identityID)
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
@@ -58,15 +59,15 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
+	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
 	for i := 1; i <= 3; i++ {
-		sendMessage(t, ctx, threadsClient, threadID, identityID, fmt.Sprintf("msg %d", i))
+		sendMessage(t, threadsCtx, threadsClient, threadID, identityID, fmt.Sprintf("msg %d", i))
 	}
 
 	labels := map[string]string{
@@ -78,7 +79,8 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		ackAllUnackedMessagesBestEffort(t, cleanupCtx, threadsClient, agentID)
+		agentCleanupCtx := withIdentity(cleanupCtx, agentID)
+		ackAllUnackedMessagesBestEffort(t, agentCleanupCtx, threadsClient, agentID)
 		ids, err := findWorkloadsByLabels(cleanupCtx, runnerClient, labels)
 		if err != nil {
 			t.Logf("cleanup: find workloads: %v", err)

--- a/test/e2e/diagnostics_helpers_test.go
+++ b/test/e2e/diagnostics_helpers_test.go
@@ -37,18 +37,29 @@ func logTracingDiagnostics(t *testing.T, threadID string) {
 	}
 }
 
+type logReadOptions struct {
+	TailLines int64
+	MaxLines  int
+	Previous  bool
+}
+
 func readWorkloadLogs(t *testing.T, ctx context.Context, namespace, podName, containerName string) {
 	t.Helper()
-	tail := int64(50)
-	maxLines := 5
+	options := logReadOptions{TailLines: 50, MaxLines: 5}
 	if strings.HasPrefix(containerName, "mcp-") {
-		tail = 200
-		maxLines = 20
+		options.TailLines = 200
+		options.MaxLines = 20
 	}
+	readWorkloadLogsWithOptions(t, ctx, namespace, podName, containerName, options)
+}
+
+func readWorkloadLogsWithOptions(t *testing.T, ctx context.Context, namespace, podName, containerName string, options logReadOptions) {
+	t.Helper()
 	request := kubeClientset(t).CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
 		Container:  containerName,
-		TailLines:  &tail,
+		TailLines:  &options.TailLines,
 		Timestamps: true,
+		Previous:   options.Previous,
 	})
 	stream, err := request.Stream(ctx)
 	if err != nil {
@@ -67,7 +78,7 @@ func readWorkloadLogs(t *testing.T, ctx context.Context, namespace, podName, con
 		}
 		t.Logf("diagnostics: pod=%s container=%s log=%s", podName, containerName, truncateLogLine(line))
 		lines++
-		if lines >= maxLines {
+		if lines >= options.MaxLines {
 			break
 		}
 	}
@@ -164,6 +175,7 @@ func logWorkloadPodDiagnosticsFromPod(t *testing.T, ctx context.Context, pod cor
 		namespace = workloadNamespace(t)
 	}
 	logWorkloadPodEvents(t, ctx, namespace, pod.Name)
+	logWorkloadInitContainerLogs(t, ctx, namespace, pod)
 	logWorkloadContainerLogs(t, ctx, namespace, pod)
 }
 
@@ -310,6 +322,21 @@ func logWorkloadContainerLogs(t *testing.T, ctx context.Context, namespace strin
 	for _, container := range containers {
 		t.Logf("diagnostics: workload pod=%s container=%s", pod.Name, container)
 		readWorkloadLogs(t, ctx, namespace, pod.Name, container)
+	}
+}
+
+func logWorkloadInitContainerLogs(t *testing.T, ctx context.Context, namespace string, pod corev1.Pod) {
+	t.Helper()
+	for _, container := range pod.Spec.InitContainers {
+		if container.Name != "ziti-sidecar" {
+			continue
+		}
+		t.Logf("diagnostics: workload pod=%s init-container=%s (previous)", pod.Name, container.Name)
+		readWorkloadLogsWithOptions(t, ctx, namespace, pod.Name, container.Name, logReadOptions{
+			TailLines: 200,
+			MaxLines:  20,
+			Previous:  true,
+		})
 	}
 }
 

--- a/test/e2e/expose_test.go
+++ b/test/e2e/expose_test.go
@@ -39,6 +39,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	exposeInitImage := envOrDefault("AGN_EXPOSE_INIT_IMAGE", "ghcr.io/agynio/agent-init-agn:0.4.4")
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	threadsCtx := withIdentity(ctx, identityID)
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
@@ -61,12 +62,12 @@ func TestAgentExposeListExec(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
+	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
 	labels := map[string]string{
 		labelManagedBy: managedByValue,
@@ -85,10 +86,10 @@ func TestAgentExposeListExec(t *testing.T) {
 	})
 
 	expectedResponse := "Hi! How are you?"
-	sentMessage := sendMessage(t, ctx, threadsClient, threadID, identityID, "hi")
+	sentMessage := sendMessage(t, threadsCtx, threadsClient, threadID, identityID, "hi")
 	sentMessageTime := messageCreatedAt(t, sentMessage)
 
-	pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Minute)
+	pollCtx, pollCancel := context.WithTimeout(threadsCtx, 5*time.Minute)
 	defer pollCancel()
 	agentBody, err := pollForAgentResponse(t, pollCtx, threadsClient, runnerClient, threadID, agentID, labels, sentMessageTime, expectedResponse)
 	if err != nil {

--- a/test/e2e/idle_test.go
+++ b/test/e2e/idle_test.go
@@ -45,6 +45,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	runnersClient := runnersv1.NewRunnersServiceClient(runnersConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	threadsCtx := withIdentity(ctx, identityID)
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
@@ -65,6 +66,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	if agentID == "" {
 		t.Fatal("create agent: missing id")
 	}
+	agentThreadsCtx := withIdentity(ctx, agentID)
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	agentInfoResp, err := agentsClient.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID})
 	if err != nil {
@@ -81,14 +83,14 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	}
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
+	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
-	message := sendMessage(t, ctx, threadsClient, threadID, identityID, "hello")
+	message := sendMessage(t, threadsCtx, threadsClient, threadID, identityID, "hello")
 	messageID := message.GetId()
 	if messageID == "" {
 		t.Fatal("send message: missing id")
@@ -125,14 +127,14 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 		t.Fatalf("wait for workload: %v", err)
 	}
 
-	responseCtx, responseCancel := context.WithTimeout(ctx, agentResponseTimeout)
+	responseCtx, responseCancel := context.WithTimeout(threadsCtx, agentResponseTimeout)
 	defer responseCancel()
 	if _, err := pollForAgentResponse(t, responseCtx, threadsClient, runnerClient, threadID, agentID, labels, sentMessageTime, ""); err != nil {
 		t.Fatalf("wait for agent response: %v", err)
 	}
 
-	ackAllUnackedMessages(t, ctx, threadsClient, agentID)
-	unackedCtx, unackedCancel := context.WithTimeout(ctx, unackedDrainTimeout)
+	ackAllUnackedMessages(t, agentThreadsCtx, threadsClient, agentID)
+	unackedCtx, unackedCancel := context.WithTimeout(agentThreadsCtx, unackedDrainTimeout)
 	defer unackedCancel()
 	if err := pollUntil(unackedCtx, pollInterval, func(ctx context.Context) error {
 		messageIDs, err := listUnackedMessageIDs(ctx, threadsClient, agentID)

--- a/test/e2e/imagepull_test.go
+++ b/test/e2e/imagepull_test.go
@@ -49,6 +49,7 @@ func TestImagePullSecretAttachedToPod(t *testing.T) {
 	secretsClient := secretsv1.NewSecretsServiceClient(secretsConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	threadsCtx := withIdentity(ctx, identityID)
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
@@ -94,14 +95,14 @@ func TestImagePullSecretAttachedToPod(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteImagePullSecretAttachment(t, ctx, agentsClient, attachmentID) })
 
-	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
+	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
-	sendMessage(t, ctx, threadsClient, threadID, identityID, "e2e image pull secret")
+	sendMessage(t, threadsCtx, threadsClient, threadID, identityID, "e2e image pull secret")
 
 	labelsMap := map[string]string{
 		labelManagedBy: managedByValue,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -372,7 +372,8 @@ func messageStartTimeMinNs(t *testing.T, msg *threadsv1.Message) uint64 {
 
 func ackMessages(t *testing.T, ctx context.Context, client threadsv1.ThreadsServiceClient, participantID string, messageIDs []string) {
 	t.Helper()
-	_, err := client.AckMessages(ctx, &threadsv1.AckMessagesRequest{
+	callCtx := withIdentity(ctx, participantID)
+	_, err := client.AckMessages(callCtx, &threadsv1.AckMessagesRequest{
 		ParticipantId: participantID,
 		MessageIds:    messageIDs,
 	})
@@ -399,12 +400,13 @@ func ackAllUnackedMessagesBestEffort(t *testing.T, ctx context.Context, client t
 	t.Helper()
 	drainCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
+	callCtx := withIdentity(drainCtx, participantID)
 
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
 	for {
-		messageIDs, err := listUnackedMessageIDs(drainCtx, client, participantID)
+		messageIDs, err := listUnackedMessageIDs(callCtx, client, participantID)
 		if err != nil {
 			t.Logf("cleanup: list unacked messages for %s: %v", participantID, err)
 			return
@@ -412,7 +414,7 @@ func ackAllUnackedMessagesBestEffort(t *testing.T, ctx context.Context, client t
 		if len(messageIDs) == 0 {
 			return
 		}
-		_, err = client.AckMessages(drainCtx, &threadsv1.AckMessagesRequest{
+		_, err = client.AckMessages(callCtx, &threadsv1.AckMessagesRequest{
 			ParticipantId: participantID,
 			MessageIds:    messageIDs,
 		})
@@ -432,8 +434,9 @@ func ackAllUnackedMessagesBestEffort(t *testing.T, ctx context.Context, client t
 func listUnackedMessageIDs(ctx context.Context, client threadsv1.ThreadsServiceClient, participantID string) ([]string, error) {
 	messageIDs := make([]string, 0, unackedPageSize)
 	token := ""
+	callCtx := withIdentity(ctx, participantID)
 	for {
-		page, err := client.GetUnackedMessages(ctx, &threadsv1.GetUnackedMessagesRequest{
+		page, err := client.GetUnackedMessages(callCtx, &threadsv1.GetUnackedMessagesRequest{
 			ParticipantId: participantID,
 			PageSize:      unackedPageSize,
 			PageToken:     token,

--- a/test/e2e/mcp_test.go
+++ b/test/e2e/mcp_test.go
@@ -45,6 +45,7 @@ func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	threadsCtx := withIdentity(ctx, identityID)
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
@@ -97,12 +98,12 @@ func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
 	}
 	t.Cleanup(func() { deleteMCP(t, ctx, agentsClient, filesystemMcpID) })
 
-	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
+	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
 	labels := map[string]string{
 		labelManagedBy: managedByValue,
@@ -121,7 +122,7 @@ func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
 	})
 
 	message := "Create an entity called test_project of type project with observation 'A test project', then list files in /test-data"
-	sentMessage := sendMessage(t, ctx, threadsClient, threadID, identityID, message)
+	sentMessage := sendMessage(t, threadsCtx, threadsClient, threadID, identityID, message)
 	sentMessageTime := messageCreatedAt(t, sentMessage)
 	startTimeMinNs := messageStartTimeMinNs(t, sentMessage)
 	t.Logf("test setup complete: agentID=%s threadID=%s memoryMcpID=%s filesystemMcpID=%s", agentID, threadID, memoryMcpID, filesystemMcpID)
@@ -134,7 +135,7 @@ func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
 		t.Fatalf("wait for mcp sidecars: %v", err)
 	}
 
-	pollCtx, pollCancel := context.WithTimeout(ctx, 6*time.Minute)
+	pollCtx, pollCancel := context.WithTimeout(threadsCtx, 6*time.Minute)
 	defer pollCancel()
 	agentBody, err := pollForAgentResponse(t, pollCtx, threadsClient, runnerClient, threadID, agentID, labels, sentMessageTime, expected)
 	if err != nil {

--- a/test/e2e/multi_test.go
+++ b/test/e2e/multi_test.go
@@ -36,6 +36,7 @@ func TestMultipleAgentsSeparateThreads(t *testing.T) {
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	threadsCtx := withIdentity(ctx, identityID)
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
@@ -62,18 +63,18 @@ func TestMultipleAgentsSeparateThreads(t *testing.T) {
 	createAgentEnv(t, ctx, agentsClient, agentAID, "LLM_API_TOKEN", token)
 	createAgentEnv(t, ctx, agentsClient, agentBID, "LLM_API_TOKEN", token)
 
-	threadA := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentAID})
-	threadB := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentBID})
+	threadA := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentAID})
+	threadB := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentBID})
 	threadAID := threadA.GetId()
 	threadBID := threadB.GetId()
 	if threadAID == "" || threadBID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadAID) })
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadBID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadAID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadBID) })
 
-	sendMessage(t, ctx, threadsClient, threadAID, identityID, "multi agent message a")
-	sendMessage(t, ctx, threadsClient, threadBID, identityID, "multi agent message b")
+	sendMessage(t, threadsCtx, threadsClient, threadAID, identityID, "multi agent message a")
+	sendMessage(t, threadsCtx, threadsClient, threadBID, identityID, "multi agent message b")
 
 	labelsA := map[string]string{
 		labelManagedBy: managedByValue,
@@ -170,6 +171,7 @@ func TestSameAgentMultipleThreads(t *testing.T) {
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	threadsCtx := withIdentity(ctx, identityID)
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
@@ -192,18 +194,18 @@ func TestSameAgentMultipleThreads(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	threadA := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
-	threadB := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
+	threadA := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
+	threadB := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadAID := threadA.GetId()
 	threadBID := threadB.GetId()
 	if threadAID == "" || threadBID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadAID) })
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadBID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadAID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadBID) })
 
-	sendMessage(t, ctx, threadsClient, threadAID, identityID, "multi thread message a")
-	sendMessage(t, ctx, threadsClient, threadBID, identityID, "multi thread message b")
+	sendMessage(t, threadsCtx, threadsClient, threadAID, identityID, "multi thread message a")
+	sendMessage(t, threadsCtx, threadsClient, threadBID, identityID, "multi thread message b")
 
 	labels := map[string]string{
 		labelManagedBy: managedByValue,

--- a/test/e2e/pipeline_test.go
+++ b/test/e2e/pipeline_test.go
@@ -46,6 +46,7 @@ func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, messag
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	threadsCtx := withIdentity(ctx, identityID)
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
@@ -68,14 +69,14 @@ func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, messag
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
+	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
-	sentMessage := sendMessage(t, ctx, threadsClient, threadID, identityID, message)
+	sentMessage := sendMessage(t, threadsCtx, threadsClient, threadID, identityID, message)
 	sentMessageTime := messageCreatedAt(t, sentMessage)
 	startTimeMinNs := messageStartTimeMinNs(t, sentMessage)
 
@@ -95,7 +96,7 @@ func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, messag
 		}
 	})
 
-	pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Minute)
+	pollCtx, pollCancel := context.WithTimeout(threadsCtx, 5*time.Minute)
 	defer pollCancel()
 	agentBody, err := pollForAgentResponse(t, pollCtx, threadsClient, runnerClient, threadID, agentID, labels, sentMessageTime, expectedResponse)
 	if err != nil {

--- a/test/e2e/rbac/workloads-role.yaml
+++ b/test/e2e/rbac/workloads-role.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: e2e-runner
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "secrets"]
+    resources: ["pods", "pods/log", "secrets", "events"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["pods/exec"]

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -36,6 +36,7 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	threadsCtx := withIdentity(ctx, identityID)
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
@@ -58,14 +59,14 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
+	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
-	_ = sendMessage(t, ctx, threadsClient, threadID, identityID, "e2e test message")
+	_ = sendMessage(t, threadsCtx, threadsClient, threadID, identityID, "e2e test message")
 
 	labels := map[string]string{
 		labelManagedBy: managedByValue,

--- a/test/e2e/threads_send_test.go
+++ b/test/e2e/threads_send_test.go
@@ -37,6 +37,7 @@ func TestThreadsSendShell(t *testing.T) {
 	runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 
 	identityID := resolveOrCreateUser(t, ctx, usersClient)
+	threadsCtx := withIdentity(ctx, identityID)
 	token := createAPIToken(t, ctx, usersClient, identityID)
 	orgID := createTestOrganization(t, ctx, orgsClient, identityID)
 
@@ -59,14 +60,14 @@ func TestThreadsSendShell(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
+	thread := createThread(t, threadsCtx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")
 	}
-	t.Cleanup(func() { archiveThread(t, ctx, threadsClient, threadID) })
+	t.Cleanup(func() { archiveThread(t, threadsCtx, threadsClient, threadID) })
 
-	sentMessage := sendMessage(t, ctx, threadsClient, threadID, identityID, "Send me an intermediate update then reply")
+	sentMessage := sendMessage(t, threadsCtx, threadsClient, threadID, identityID, "Send me an intermediate update then reply")
 	sentMessageTime := messageCreatedAt(t, sentMessage)
 	startTimeMinNs := messageStartTimeMinNs(t, sentMessage)
 
@@ -86,7 +87,7 @@ func TestThreadsSendShell(t *testing.T) {
 		}
 	})
 
-	pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Minute)
+	pollCtx, pollCancel := context.WithTimeout(threadsCtx, 5*time.Minute)
 	defer pollCancel()
 	expectedBodies := []string{"Thinking", "Done thinking. Here is my reply."}
 	agentMessages, err := pollForAgentMessages(t, pollCtx, threadsClient, runnerClient, threadID, agentID, labels, sentMessageTime, expectedBodies)

--- a/test/e2e/tracing_availability_test.go
+++ b/test/e2e/tracing_availability_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -75,8 +76,15 @@ func checkTracingAvailability() tracingAvailability {
 	traceID, err := runTraceCanary(ctx, addr)
 	if err != nil {
 		if isCanaryAuthFailure(err) {
+			availability := checkTracingQueryAvailability(ctx, addr)
+			if availability.available {
+				return availability
+			}
 			reason := canaryAuthFailureReason(err)
-			return tracingAvailability{available: false, unavailableReason: reason, skipReason: reason}
+			if availability.unavailableReason != "" {
+				reason = fmt.Sprintf("%s; %s", reason, availability.unavailableReason)
+			}
+			return tracingAvailability{available: false, unavailableReason: reason}
 		}
 		reason := canaryFailureReason(err)
 		if reason == "" {
@@ -113,6 +121,37 @@ func checkTracingAvailability() tracingAvailability {
 	}
 
 	return tracingAvailability{available: true}
+}
+
+func checkTracingQueryAvailability(ctx context.Context, addr string) tracingAvailability {
+	conn, err := dialGRPCForCheck(ctx, addr)
+	if err != nil {
+		return tracingAvailability{available: false, unavailableReason: fmt.Sprintf("dial tracing %s: %v", addr, err)}
+	}
+	defer conn.Close()
+
+	queryClient := tracingv1.NewTracingServiceClient(conn)
+	traceID, err := randomTraceID()
+	if err != nil {
+		return tracingAvailability{available: false, unavailableReason: fmt.Sprintf("generate trace id: %v", err)}
+	}
+
+	_, err = queryClient.GetTrace(ctx, &tracingv1.GetTraceRequest{TraceId: traceID})
+	if err == nil {
+		return tracingAvailability{available: false, unavailableReason: "tracing query check returned unexpected trace"}
+	}
+	if status.Code(err) == codes.NotFound {
+		return tracingAvailability{available: true}
+	}
+	return tracingAvailability{available: false, unavailableReason: fmt.Sprintf("tracing query check failed: %v", err)}
+}
+
+func randomTraceID() ([]byte, error) {
+	traceID := make([]byte, 16)
+	if _, err := rand.Read(traceID); err != nil {
+		return nil, err
+	}
+	return traceID, nil
 }
 
 func dialGRPCForCheck(ctx context.Context, addr string) (*grpc.ClientConn, error) {


### PR DESCRIPTION
## Summary
- drop env-based skills/init script injection from workload assembly
- move Ziti sidecar into the sidecar list and target ZITI_ENROLLMENT_JWT there
- inject WORKLOAD_ID into agent containers and refresh related tests

## Testing
- go vet -p 1 ./...
- go test ./...

Refs agynio/architecture#136