### PR TITLE
fix: handle stale runner dial errors

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -143,7 +143,7 @@ deployments:
               - name: USERS_ADDRESS
                 value: "users:50051"
               - name: ORGANIZATIONS_ADDRESS
-                value: "tenants:50051"
+                value: "organizations:50051"
               - name: RUNNER_ADDRESS
                 value: "k8s-runner:50051"
               - name: RUNNERS_ADDRESS

--- a/internal/reconciler/degrade.go
+++ b/internal/reconciler/degrade.go
@@ -1,0 +1,52 @@
+package reconciler
+
+import (
+	"context"
+	"log"
+
+	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
+)
+
+const (
+	degradeReasonRunnerDeprovisioned = "runner_deprovisioned"
+	degradeReasonVolumeLost          = "volume_lost"
+)
+
+type degradeTracker struct {
+	seen map[string]struct{}
+}
+
+func newDegradeTracker() *degradeTracker {
+	return &degradeTracker{seen: make(map[string]struct{})}
+}
+
+func (d *degradeTracker) shouldDegrade(threadID string) bool {
+	if d == nil {
+		return true
+	}
+	if _, ok := d.seen[threadID]; ok {
+		return false
+	}
+	d.seen[threadID] = struct{}{}
+	return true
+}
+
+func (r *Reconciler) degradeThread(ctx context.Context, threadID, reason string, tracker *degradeTracker) {
+	if threadID == "" {
+		log.Printf("reconciler: warn: degrade thread missing id for reason %s", reason)
+		return
+	}
+	if tracker != nil && !tracker.shouldDegrade(threadID) {
+		return
+	}
+	if r.threads == nil {
+		log.Printf("reconciler: warn: threads client not configured for degrade thread %s", threadID)
+		return
+	}
+	if _, err := r.threads.DegradeThread(ctx, &threadsv1.DegradeThreadRequest{
+		ThreadId: threadID,
+		Reason:   reason,
+	}); err != nil {
+		log.Printf("reconciler: degrade thread %s (%s): %v", threadID, reason, err)
+	}
+}

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -53,6 +53,14 @@ func (f *fakeThreadsClient) GetThreads(ctx context.Context, req *threadsv1.GetTh
 	return nil, testutil.ErrNotImplemented
 }
 
+func (f *fakeThreadsClient) GetThread(context.Context, *threadsv1.GetThreadRequest, ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
+
+func (f *fakeThreadsClient) GetOrganizationThreads(context.Context, *threadsv1.GetOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.GetOrganizationThreadsResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
+
 func (f *fakeThreadsClient) GetMessages(context.Context, *threadsv1.GetMessagesRequest, ...grpc.CallOption) (*threadsv1.GetMessagesResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -28,6 +28,7 @@ func (f *fakeAgentsClient) ListAgents(ctx context.Context, req *agentsv1.ListAge
 type fakeThreadsClient struct {
 	getThreads         func(context.Context, *threadsv1.GetThreadsRequest, ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error)
 	getUnackedMessages func(context.Context, *threadsv1.GetUnackedMessagesRequest, ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error)
+	degradeThread      func(context.Context, *threadsv1.DegradeThreadRequest, ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error)
 }
 
 func (f *fakeThreadsClient) CreateThread(context.Context, *threadsv1.CreateThreadRequest, ...grpc.CallOption) (*threadsv1.CreateThreadResponse, error) {
@@ -35,6 +36,13 @@ func (f *fakeThreadsClient) CreateThread(context.Context, *threadsv1.CreateThrea
 }
 
 func (f *fakeThreadsClient) ArchiveThread(context.Context, *threadsv1.ArchiveThreadRequest, ...grpc.CallOption) (*threadsv1.ArchiveThreadResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
+
+func (f *fakeThreadsClient) DegradeThread(ctx context.Context, req *threadsv1.DegradeThreadRequest, opts ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error) {
+	if f.degradeThread != nil {
+		return f.degradeThread(ctx, req, opts...)
+	}
 	return nil, testutil.ErrNotImplemented
 }
 

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -659,6 +659,65 @@ func TestStopWorkloadMarksMissingRunnerOnNoTerminators(t *testing.T) {
 	}
 }
 
+func TestStopWorkloadMarksMissingRunnerOnNoTerminatorsStopError(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	testAssembler := newTestAssembler(agentID, true)
+	runnerID := "runner-1"
+	rawInstanceID := uuid.New().String()
+	instanceID := "workload-" + rawInstanceID
+
+	var updateStatuses []runnersv1.WorkloadStatus
+	runners := &fakeRunnersClient{
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateStatuses = append(updateStatuses, req.GetStatus())
+			if req.GetStatus() == runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED && req.GetRemovedAt() == nil {
+				return nil, errors.New("missing removed_at")
+			}
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	stopCalled := false
+	runner := &fakeRunnerClient{
+		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+			if req.GetWorkloadId() != rawInstanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			stopCalled = true
+			return nil, errors.New("service runner-1 has no terminators")
+		},
+	}
+
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Assembler:    testAssembler,
+	})
+	reconciler.stopWorkload(ctx, &runnersv1.Workload{
+		Meta:       &runnersv1.EntityMeta{Id: "workload-1"},
+		RunnerId:   runnerID,
+		InstanceId: stringPtr(instanceID),
+		Status:     runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+	})
+
+	if !stopCalled {
+		t.Fatal("expected stop workload")
+	}
+	if !reflect.DeepEqual(updateStatuses, []runnersv1.WorkloadStatus{runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING, runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED}) {
+		t.Fatalf("unexpected update statuses: %v", updateStatuses)
+	}
+}
+
 func TestStopWorkloadMarksFailedWhenInstanceMissing(t *testing.T) {
 	ctx := context.Background()
 	agentID := uuid.New()

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	zitimgmtv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/agents-orchestrator/internal/assembler"
 	"github.com/agynio/agents-orchestrator/internal/config"
@@ -169,7 +170,7 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 		ZitiMgmt:     zitiMgmt,
 		Assembler:    testAssembler,
 	})
-	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID})
+	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
 
 	if !reflect.DeepEqual(calls, []string{"dial", "create", "create-workload", "start", "update-workload"}) {
 		t.Fatalf("unexpected call order: %v", calls)
@@ -275,9 +276,169 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 		Runners:      runners,
 		Assembler:    testAssembler,
 	})
-	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID})
+	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
 
 	if !reflect.DeepEqual(calls, []string{"dial", "create-workload", "start", "update-workload"}) {
+		t.Fatalf("unexpected call order: %v", calls)
+	}
+}
+
+func TestStartWorkloadPinsRunnerFromVolumes(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	threadID := uuid.New()
+	runnerID := "runner-1"
+	volumeKey := "volume-1"
+	mainContainerID := "container-main"
+	testAssembler := newTestAssembler(agentID, false)
+
+	var calls []string
+	var workloadID string
+	runner := &fakeRunnerClient{
+		startWorkload: func(_ context.Context, req *runnerv1.StartWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StartWorkloadResponse, error) {
+			calls = append(calls, "start")
+			workloadID = req.GetWorkloadId()
+			return &runnerv1.StartWorkloadResponse{
+				Id:     workloadID,
+				Status: runnerv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+				Containers: &runnerv1.WorkloadContainers{
+					Main: mainContainerID,
+				},
+			}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			calls = append(calls, "dial")
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+
+	runners := &fakeRunnersClient{
+		listVolumesByThread: func(_ context.Context, req *runnersv1.ListVolumesByThreadRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error) {
+			calls = append(calls, "list-volumes")
+			if req.GetThreadId() != threadID.String() {
+				return nil, errors.New("unexpected thread id")
+			}
+			return &runnersv1.ListVolumesByThreadResponse{Volumes: []*runnersv1.Volume{
+				{
+					Meta:     &runnersv1.EntityMeta{Id: volumeKey},
+					RunnerId: runnerID,
+					Status:   runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE,
+					ThreadId: threadID.String(),
+					VolumeId: "volume-id",
+				},
+			}}, nil
+		},
+		getRunner: func(_ context.Context, req *runnersv1.GetRunnerRequest, _ ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
+			calls = append(calls, "get-runner")
+			if req.GetId() != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return &runnersv1.GetRunnerResponse{Runner: buildRunner(runnerID)}, nil
+		},
+		createWorkload: func(_ context.Context, req *runnersv1.CreateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error) {
+			calls = append(calls, "create-workload")
+			if req.GetRunnerId() != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return &runnersv1.CreateWorkloadResponse{}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			calls = append(calls, "update-workload")
+			if req.GetInstanceId() == "" {
+				return nil, errors.New("missing instance id")
+			}
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+		listRunners: func(context.Context, *runnersv1.ListRunnersRequest, ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return nil, errors.New("unexpected list runners")
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Assembler:    testAssembler,
+	})
+	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
+
+	if !reflect.DeepEqual(calls, []string{"list-volumes", "get-runner", "dial", "create-workload", "start", "update-workload"}) {
+		t.Fatalf("unexpected call order: %v", calls)
+	}
+}
+
+func TestStartWorkloadDegradesWhenPinnedRunnerNotEnrolled(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	threadID := uuid.New()
+	runnerID := "runner-1"
+	volumeKey := "volume-1"
+	testAssembler := newTestAssembler(agentID, false)
+
+	var calls []string
+	threads := &fakeThreadsClient{
+		degradeThread: func(_ context.Context, req *threadsv1.DegradeThreadRequest, _ ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error) {
+			calls = append(calls, "degrade")
+			if req.GetThreadId() != threadID.String() {
+				return nil, errors.New("unexpected thread id")
+			}
+			if req.GetReason() != degradeReasonRunnerDeprovisioned {
+				return nil, errors.New("unexpected degrade reason")
+			}
+			return &threadsv1.DegradeThreadResponse{}, nil
+		},
+	}
+
+	runners := &fakeRunnersClient{
+		listVolumesByThread: func(_ context.Context, req *runnersv1.ListVolumesByThreadRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error) {
+			calls = append(calls, "list-volumes")
+			if req.GetThreadId() != threadID.String() {
+				return nil, errors.New("unexpected thread id")
+			}
+			return &runnersv1.ListVolumesByThreadResponse{Volumes: []*runnersv1.Volume{
+				{
+					Meta:     &runnersv1.EntityMeta{Id: volumeKey},
+					RunnerId: runnerID,
+					Status:   runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE,
+					ThreadId: threadID.String(),
+					VolumeId: "volume-id",
+				},
+			}}, nil
+		},
+		getRunner: func(_ context.Context, req *runnersv1.GetRunnerRequest, _ ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
+			calls = append(calls, "get-runner")
+			if req.GetId() != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return &runnersv1.GetRunnerResponse{Runner: &runnersv1.Runner{
+				Meta:   &runnersv1.EntityMeta{Id: runnerID},
+				Status: runnersv1.RunnerStatus_RUNNER_STATUS_OFFLINE,
+			}}, nil
+		},
+		createWorkload: func(context.Context, *runnersv1.CreateWorkloadRequest, ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error) {
+			return nil, errors.New("unexpected create workload")
+		},
+	}
+
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(context.Context, string) (runnerv1.RunnerServiceClient, error) {
+			return nil, errors.New("unexpected dial")
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Threads:      threads,
+		Assembler:    testAssembler,
+	})
+	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
+
+	if !reflect.DeepEqual(calls, []string{"list-volumes", "get-runner", "degrade"}) {
 		t.Fatalf("unexpected call order: %v", calls)
 	}
 }
@@ -353,7 +514,7 @@ func TestStartWorkloadDeletesIdentityOnRunnerError(t *testing.T) {
 		Runners:      runners,
 		Assembler:    testAssembler,
 	})
-	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID})
+	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
 
 	if !reflect.DeepEqual(calls, []string{"dial", "create", "create-workload", "start", "update-workload", "delete"}) {
 		t.Fatalf("unexpected call order: %v", calls)
@@ -466,7 +627,7 @@ func TestStartWorkloadRollsBackOnWorkloadIDMismatch(t *testing.T) {
 		Runners:      runners,
 		Assembler:    testAssembler,
 	})
-	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID})
+	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
 
 	if !reflect.DeepEqual(calls, []string{"dial", "create", "create-workload", "start", "stop", "update-workload", "delete"}) {
 		t.Fatalf("unexpected call order: %v", calls)
@@ -538,7 +699,7 @@ func TestStartWorkloadStopsAndDeletesIdentityOnStoreFailure(t *testing.T) {
 		Runners:      runners,
 		Assembler:    testAssembler,
 	})
-	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID})
+	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
 
 	if !reflect.DeepEqual(calls, []string{"dial", "create", "create-workload", "delete"}) {
 		t.Fatalf("unexpected call order: %v", calls)
@@ -1187,10 +1348,12 @@ type fakeRunnersClient struct {
 	createWorkload        func(context.Context, *runnersv1.CreateWorkloadRequest, ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error)
 	createVolume          func(context.Context, *runnersv1.CreateVolumeRequest, ...grpc.CallOption) (*runnersv1.CreateVolumeResponse, error)
 	deleteWorkload        func(context.Context, *runnersv1.DeleteWorkloadRequest, ...grpc.CallOption) (*runnersv1.DeleteWorkloadResponse, error)
+	getRunner             func(context.Context, *runnersv1.GetRunnerRequest, ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error)
 	listWorkloads         func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error)
 	listWorkloadsByThread func(context.Context, *runnersv1.ListWorkloadsByThreadRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsByThreadResponse, error)
 	batchUpdateWorkload   func(context.Context, *runnersv1.BatchUpdateWorkloadSampledAtRequest, ...grpc.CallOption) (*runnersv1.BatchUpdateWorkloadSampledAtResponse, error)
 	listVolumes           func(context.Context, *runnersv1.ListVolumesRequest, ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error)
+	listVolumesByThread   func(context.Context, *runnersv1.ListVolumesByThreadRequest, ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error)
 	listRunners           func(context.Context, *runnersv1.ListRunnersRequest, ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error)
 	updateWorkload        func(context.Context, *runnersv1.UpdateWorkloadRequest, ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error)
 	updateWorkloadStatus  func(context.Context, *runnersv1.UpdateWorkloadStatusRequest, ...grpc.CallOption) (*runnersv1.UpdateWorkloadStatusResponse, error)
@@ -1202,7 +1365,10 @@ func (f *fakeRunnersClient) RegisterRunner(context.Context, *runnersv1.RegisterR
 	return nil, errNotImplemented
 }
 
-func (f *fakeRunnersClient) GetRunner(context.Context, *runnersv1.GetRunnerRequest, ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
+func (f *fakeRunnersClient) GetRunner(ctx context.Context, req *runnersv1.GetRunnerRequest, opts ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
+	if f.getRunner != nil {
+		return f.getRunner(ctx, req, opts...)
+	}
 	return nil, errNotImplemented
 }
 
@@ -1300,8 +1466,11 @@ func (f *fakeRunnersClient) ListVolumes(ctx context.Context, req *runnersv1.List
 	return nil, errNotImplemented
 }
 
-func (f *fakeRunnersClient) ListVolumesByThread(context.Context, *runnersv1.ListVolumesByThreadRequest, ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error) {
-	return nil, errNotImplemented
+func (f *fakeRunnersClient) ListVolumesByThread(ctx context.Context, req *runnersv1.ListVolumesByThreadRequest, opts ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error) {
+	if f.listVolumesByThread != nil {
+		return f.listVolumesByThread(ctx, req, opts...)
+	}
+	return &runnersv1.ListVolumesByThreadResponse{}, nil
 }
 
 func (f *fakeRunnersClient) BatchUpdateVolumeSampledAt(ctx context.Context, req *runnersv1.BatchUpdateVolumeSampledAtRequest, opts ...grpc.CallOption) (*runnersv1.BatchUpdateVolumeSampledAtResponse, error) {

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -609,6 +609,56 @@ func TestStopWorkloadDeletesIdentityAfterStop(t *testing.T) {
 	}
 }
 
+func TestStopWorkloadMarksMissingRunnerOnNoTerminators(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	testAssembler := newTestAssembler(agentID, true)
+	runnerID := "runner-1"
+	instanceID := "workload-" + uuid.New().String()
+
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return nil, errors.New("service runner-1 has no terminators")
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Assembler:    testAssembler,
+	})
+	reconciler.stopWorkload(ctx, &runnersv1.Workload{
+		Meta:       &runnersv1.EntityMeta{Id: "workload-1"},
+		RunnerId:   runnerID,
+		InstanceId: stringPtr(instanceID),
+		Status:     runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+	})
+
+	if updateReq == nil {
+		t.Fatal("expected update workload")
+	}
+	if updateReq.GetId() != "workload-1" {
+		t.Fatalf("unexpected workload id: %s", updateReq.GetId())
+	}
+	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
+		t.Fatalf("unexpected workload status: %v", updateReq.GetStatus())
+	}
+	if updateReq.GetRemovedAt() == nil {
+		t.Fatal("expected removed_at")
+	}
+}
+
 func TestStopWorkloadMarksFailedWhenInstanceMissing(t *testing.T) {
 	ctx := context.Background()
 	agentID := uuid.New()

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -9,6 +9,7 @@ import (
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/agynio/agents-orchestrator/internal/testutil"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
@@ -142,7 +143,7 @@ func TestReconcileWorkloadsMarksMissingRunnerOnNoTerminators(t *testing.T) {
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
-			return &runnersv1.ListRunnersResponse{}, nil
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
 		},
 		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
 			updateReq = req
@@ -196,7 +197,7 @@ func TestReconcileWorkloadsMarksMissingRunnerOnNoTerminatorsListError(t *testing
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
-			return &runnersv1.ListRunnersResponse{}, nil
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
 		},
 		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
 			updateReq = req
@@ -239,6 +240,77 @@ func TestReconcileWorkloadsMarksMissingRunnerOnNoTerminatorsListError(t *testing
 	}
 	if updateReq.GetRemovedAt() == nil {
 		t.Fatal("expected removed_at")
+	}
+}
+
+func TestReconcileWorkloadsDegradesUnenrolledRunner(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	threadID := uuid.New().String()
+	workloadID := "workload-1"
+	secondWorkloadID := "workload-2"
+
+	updateCount := 0
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, ThreadId: threadID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
+				{Meta: &runnersv1.EntityMeta{Id: secondWorkloadID}, RunnerId: runnerID, ThreadId: threadID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{
+				{Meta: &runnersv1.EntityMeta{Id: runnerID}, Status: runnersv1.RunnerStatus_RUNNER_STATUS_OFFLINE},
+			}}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateCount++
+			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
+				return nil, errors.New("unexpected workload status")
+			}
+			if req.GetRemovedAt() == nil {
+				return nil, errors.New("missing removed_at")
+			}
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	degradeCalls := 0
+	threads := &fakeThreadsClient{
+		degradeThread: func(_ context.Context, req *threadsv1.DegradeThreadRequest, _ ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error) {
+			degradeCalls++
+			if req.GetThreadId() != threadID {
+				return nil, errors.New("unexpected thread id")
+			}
+			if req.GetReason() != degradeReasonRunnerDeprovisioned {
+				return nil, errors.New("unexpected degrade reason")
+			}
+			return &threadsv1.DegradeThreadResponse{}, nil
+		},
+	}
+
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(context.Context, string) (runnerv1.RunnerServiceClient, error) {
+			return nil, errors.New("unexpected dial")
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Threads:      threads,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateCount != 2 {
+		t.Fatalf("expected 2 workload updates, got %d", updateCount)
+	}
+	if degradeCalls != 1 {
+		t.Fatalf("expected 1 degrade call, got %d", degradeCalls)
 	}
 }
 
@@ -318,7 +390,7 @@ func TestReconcileVolumesMarksMissingRunnerOnNoTerminatorsListError(t *testing.T
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
-			return &runnersv1.ListRunnersResponse{}, nil
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
 		},
 		updateVolume: func(_ context.Context, req *runnersv1.UpdateVolumeRequest, _ ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error) {
 			updateReq = req
@@ -358,6 +430,146 @@ func TestReconcileVolumesMarksMissingRunnerOnNoTerminatorsListError(t *testing.T
 	}
 	if updateReq.GetStatus() != runnersv1.VolumeStatus_VOLUME_STATUS_FAILED {
 		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
+	}
+}
+
+func TestReconcileVolumesDegradesOnMissingPVC(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	volumeKey := "volume-1"
+	threadID := uuid.New().String()
+	volumeID := uuid.New().String()
+
+	var updateReq *runnersv1.UpdateVolumeRequest
+	runners := &fakeRunnersClient{
+		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
+				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateVolume: func(_ context.Context, req *runnersv1.UpdateVolumeRequest, _ ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateVolumeResponse{}, nil
+		},
+	}
+
+	degradeCalls := 0
+	threads := &fakeThreadsClient{
+		degradeThread: func(_ context.Context, req *threadsv1.DegradeThreadRequest, _ ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error) {
+			degradeCalls++
+			if req.GetThreadId() != threadID {
+				return nil, errors.New("unexpected thread id")
+			}
+			if req.GetReason() != degradeReasonVolumeLost {
+				return nil, errors.New("unexpected degrade reason")
+			}
+			return &threadsv1.DegradeThreadResponse{}, nil
+		},
+	}
+
+	runner := &fakeRunnerClient{
+		listVolumes: func(_ context.Context, _ *runnerv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnerv1.ListVolumesResponse, error) {
+			return &runnerv1.ListVolumesResponse{}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Threads:      threads,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileVolumes(ctx); err != nil {
+		t.Fatalf("reconcile volumes: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected update volume")
+	}
+	if updateReq.GetStatus() != runnersv1.VolumeStatus_VOLUME_STATUS_FAILED {
+		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
+	}
+	if degradeCalls != 1 {
+		t.Fatalf("expected 1 degrade call, got %d", degradeCalls)
+	}
+}
+
+func TestReconcileVolumesDegradesUnenrolledRunner(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	volumeKey := "volume-1"
+	threadID := uuid.New().String()
+	volumeID := uuid.New().String()
+
+	updateCount := 0
+	runners := &fakeRunnersClient{
+		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
+				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{
+				{Meta: &runnersv1.EntityMeta{Id: runnerID}, Status: runnersv1.RunnerStatus_RUNNER_STATUS_OFFLINE},
+			}}, nil
+		},
+		updateVolume: func(_ context.Context, req *runnersv1.UpdateVolumeRequest, _ ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error) {
+			updateCount++
+			if req.GetStatus() != runnersv1.VolumeStatus_VOLUME_STATUS_FAILED {
+				return nil, errors.New("unexpected volume status")
+			}
+			return &runnersv1.UpdateVolumeResponse{}, nil
+		},
+	}
+
+	degradeCalls := 0
+	threads := &fakeThreadsClient{
+		degradeThread: func(_ context.Context, req *threadsv1.DegradeThreadRequest, _ ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error) {
+			degradeCalls++
+			if req.GetThreadId() != threadID {
+				return nil, errors.New("unexpected thread id")
+			}
+			if req.GetReason() != degradeReasonRunnerDeprovisioned {
+				return nil, errors.New("unexpected degrade reason")
+			}
+			return &threadsv1.DegradeThreadResponse{}, nil
+		},
+	}
+
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(context.Context, string) (runnerv1.RunnerServiceClient, error) {
+			return nil, errors.New("unexpected dial")
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Threads:      threads,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileVolumes(ctx); err != nil {
+		t.Fatalf("reconcile volumes: %v", err)
+	}
+	if updateCount != 1 {
+		t.Fatalf("expected 1 volume update, got %d", updateCount)
+	}
+	if degradeCalls != 1 {
+		t.Fatalf("expected 1 degrade call, got %d", degradeCalls)
 	}
 }
 

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -129,6 +129,60 @@ func TestReconcileWorkloadsStopsOrphan(t *testing.T) {
 	}
 }
 
+func TestReconcileWorkloadsMarksMissingRunnerOnNoTerminators(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadID := "workload-1"
+
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return nil, errors.New("service runner-1 has no terminators")
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected update workload")
+	}
+	if updateReq.GetId() != workloadID {
+		t.Fatalf("unexpected workload id: %v", updateReq.GetId())
+	}
+	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
+		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
+	}
+	if updateReq.GetRemovedAt() == nil {
+		t.Fatal("expected removed_at")
+	}
+}
+
 func TestReconcileVolumesActivatesProvisioning(t *testing.T) {
 	ctx := context.Background()
 	runnerID := "runner-1"

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -183,6 +183,65 @@ func TestReconcileWorkloadsMarksMissingRunnerOnNoTerminators(t *testing.T) {
 	}
 }
 
+func TestReconcileWorkloadsMarksMissingRunnerOnNoTerminatorsListError(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadID := "workload-1"
+
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	runner := &fakeRunnerClient{
+		listWorkloads: func(_ context.Context, _ *runnerv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnerv1.ListWorkloadsResponse, error) {
+			return nil, errors.New("service runner-1 has no terminators")
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected update workload")
+	}
+	if updateReq.GetId() != workloadID {
+		t.Fatalf("unexpected workload id: %v", updateReq.GetId())
+	}
+	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
+		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
+	}
+	if updateReq.GetRemovedAt() == nil {
+		t.Fatal("expected removed_at")
+	}
+}
+
 func TestReconcileVolumesActivatesProvisioning(t *testing.T) {
 	ctx := context.Background()
 	runnerID := "runner-1"
@@ -241,6 +300,64 @@ func TestReconcileVolumesActivatesProvisioning(t *testing.T) {
 	}
 	if updateReq.GetInstanceId() != instanceID {
 		t.Fatalf("unexpected instance id: %v", updateReq.GetInstanceId())
+	}
+}
+
+func TestReconcileVolumesMarksMissingRunnerOnNoTerminatorsListError(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	volumeKey := "volume-1"
+	threadID := uuid.New().String()
+	volumeID := uuid.New().String()
+
+	var updateReq *runnersv1.UpdateVolumeRequest
+	runners := &fakeRunnersClient{
+		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
+				{Meta: &runnersv1.EntityMeta{Id: volumeKey}, RunnerId: runnerID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, ThreadId: threadID, VolumeId: volumeID},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{}, nil
+		},
+		updateVolume: func(_ context.Context, req *runnersv1.UpdateVolumeRequest, _ ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateVolumeResponse{}, nil
+		},
+	}
+
+	runner := &fakeRunnerClient{
+		listVolumes: func(_ context.Context, _ *runnerv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnerv1.ListVolumesResponse, error) {
+			return nil, errors.New("service runner-1 has no terminators")
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileVolumes(ctx); err != nil {
+		t.Fatalf("reconcile volumes: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected update volume")
+	}
+	if updateReq.GetId() != volumeKey {
+		t.Fatalf("unexpected volume id: %v", updateReq.GetId())
+	}
+	if updateReq.GetStatus() != runnersv1.VolumeStatus_VOLUME_STATUS_FAILED {
+		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
 	}
 }
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -334,6 +334,12 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 	}
 	runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
 	if err != nil {
+		if runnerdial.IsNoTerminators(err) {
+			if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+				log.Printf("reconciler: handle missing workload %s after runner dial failure: %v", workloadID, err)
+			}
+			return
+		}
 		log.Printf("reconciler: dial runner %s for workload %s: %v", runnerID, workloadID, err)
 		return
 	}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -124,8 +124,9 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	degraded := newDegradeTracker()
 	for _, candidate := range actions.ToStart {
-		r.startWorkload(ctx, candidate)
+		r.startWorkload(ctx, candidate, degraded)
 	}
 	for _, workload := range actions.ToStop {
 		r.stopWorkload(ctx, workload)
@@ -190,16 +191,35 @@ func (r *Reconciler) compensateIdentity(ctx context.Context, zitiIdentityID *str
 	}
 }
 
-func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread) {
+func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degraded *degradeTracker) {
 	assembled, err := r.assembler.Assemble(ctx, target.AgentID, target.ThreadID)
 	if err != nil {
 		log.Printf("reconciler: assemble workload for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 		return
 	}
-	selectedRunner, err := r.selectRunner(ctx, assembled.OrganizationID, assembled.RunnerLabels, assembled.Request.GetCapabilities())
+	pinnedRunnerID, err := r.pinnedRunnerForThread(ctx, target.ThreadID.String())
 	if err != nil {
-		log.Printf("reconciler: select runner for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
+		log.Printf("reconciler: list volumes for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 		return
+	}
+	var selectedRunner *runnersv1.Runner
+	if pinnedRunnerID != "" {
+		runner, enrolled, err := r.getRunnerIfEnrolled(ctx, pinnedRunnerID)
+		if err != nil {
+			log.Printf("reconciler: get runner %s for agent %s thread %s: %v", pinnedRunnerID, target.AgentID.String(), target.ThreadID.String(), err)
+			return
+		}
+		if !enrolled {
+			r.degradeThread(ctx, target.ThreadID.String(), degradeReasonRunnerDeprovisioned, degraded)
+			return
+		}
+		selectedRunner = runner
+	} else {
+		selectedRunner, err = r.selectRunner(ctx, assembled.OrganizationID, assembled.RunnerLabels, assembled.Request.GetCapabilities())
+		if err != nil {
+			log.Printf("reconciler: select runner for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
+			return
+		}
 	}
 	runnerID := selectedRunner.GetMeta().GetId()
 	if runnerID == "" {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -350,7 +350,14 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 	}); err != nil {
 		log.Printf("reconciler: update workload %s to stopping: %v", workloadID, err)
 	}
+	workload.Status = stoppingStatus
 	if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
+		if runnerdial.IsNoTerminators(err) {
+			if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+				log.Printf("reconciler: handle missing workload %s after runner stop failure: %v", workloadID, err)
+			}
+			return
+		}
 		log.Printf("reconciler: stop workload %s: %v", workloadID, err)
 		return
 	}

--- a/internal/reconciler/runner_pinning.go
+++ b/internal/reconciler/runner_pinning.go
@@ -1,0 +1,94 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const volumesByThreadPageSize int32 = 100
+
+func (r *Reconciler) pinnedRunnerForThread(ctx context.Context, threadID string) (string, error) {
+	if threadID == "" {
+		return "", fmt.Errorf("thread id missing")
+	}
+	pageToken := ""
+	runnerID := ""
+	for {
+		resp, err := r.runners.ListVolumesByThread(ctx, &runnersv1.ListVolumesByThreadRequest{
+			ThreadId:  threadID,
+			PageSize:  volumesByThreadPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return "", fmt.Errorf("list volumes for thread %s: %w", threadID, err)
+		}
+		for _, volume := range resp.GetVolumes() {
+			if volume == nil {
+				return "", fmt.Errorf("volume is nil")
+			}
+			meta := volume.GetMeta()
+			if meta == nil || meta.GetId() == "" {
+				return "", fmt.Errorf("volume meta missing")
+			}
+			if !isPinnedVolumeStatus(volume.GetStatus()) {
+				continue
+			}
+			volumeRunnerID := volume.GetRunnerId()
+			if volumeRunnerID == "" {
+				return "", fmt.Errorf("volume %s missing runner id", meta.GetId())
+			}
+			if runnerID == "" {
+				runnerID = volumeRunnerID
+				continue
+			}
+			if runnerID != volumeRunnerID {
+				return "", fmt.Errorf("thread %s volumes span runners %s and %s", threadID, runnerID, volumeRunnerID)
+			}
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	return runnerID, nil
+}
+
+func isPinnedVolumeStatus(status runnersv1.VolumeStatus) bool {
+	switch status {
+	case runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
+		runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE,
+		runnersv1.VolumeStatus_VOLUME_STATUS_DEPROVISIONING:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *Reconciler) getRunnerIfEnrolled(ctx context.Context, runnerID string) (*runnersv1.Runner, bool, error) {
+	if runnerID == "" {
+		return nil, false, fmt.Errorf("runner id missing")
+	}
+	resp, err := r.runners.GetRunner(ctx, &runnersv1.GetRunnerRequest{Id: runnerID})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("get runner %s: %w", runnerID, err)
+	}
+	runner := resp.GetRunner()
+	if runner == nil {
+		return nil, false, fmt.Errorf("runner %s missing", runnerID)
+	}
+	meta := runner.GetMeta()
+	if meta == nil || meta.GetId() == "" {
+		return nil, false, fmt.Errorf("runner %s missing meta", runnerID)
+	}
+	if runner.GetStatus() != runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED {
+		return runner, false, nil
+	}
+	return runner, true, nil
+}

--- a/internal/reconciler/volume_reconcile.go
+++ b/internal/reconciler/volume_reconcile.go
@@ -55,25 +55,40 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 		}
 		volumesByRunner[runnerID][volumeID] = volume
 	}
-	if runners, err := r.listRunners(ctx); err != nil {
-		log.Printf("reconciler: warn: list runners for volume reconciliation: %v", err)
-	} else {
-		for _, runner := range runners {
-			if runner == nil {
-				continue
-			}
-			runnerID := runner.GetMeta().GetId()
-			if runnerID == "" {
-				continue
-			}
-			runnerIDs[runnerID] = struct{}{}
+	runners, err := r.listRunners(ctx)
+	if err != nil {
+		return err
+	}
+	enrolledRunnerIDs := map[string]struct{}{}
+	for _, runner := range runners {
+		if runner == nil {
+			continue
 		}
+		runnerID := runner.GetMeta().GetId()
+		if runnerID == "" {
+			continue
+		}
+		if runner.GetStatus() != runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED {
+			continue
+		}
+		enrolledRunnerIDs[runnerID] = struct{}{}
+		runnerIDs[runnerID] = struct{}{}
 	}
 
+	degraded := newDegradeTracker()
 	volumeInfoCache := map[string]volumeTTLInfo{}
 	threadCache := map[string]threadActivity{}
 	for runnerID := range runnerIDs {
 		trackedVolumes := volumesByRunner[runnerID]
+		if _, ok := enrolledRunnerIDs[runnerID]; !ok {
+			for volumeID, volume := range trackedVolumes {
+				if err := r.handleMissingRunnerVolume(ctx, volume); err != nil {
+					log.Printf("reconciler: warn: handle missing volume %s on unenrolled runner: %v", volumeID, err)
+				}
+				r.degradeThread(ctx, volume.GetThreadId(), degradeReasonRunnerDeprovisioned, degraded)
+			}
+			continue
+		}
 		runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
 		if err != nil {
 			if runnerdial.IsNoTerminators(err) {
@@ -122,6 +137,9 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 			if !ok {
 				if err := r.handleMissingRunnerVolume(ctx, volume); err != nil {
 					log.Printf("reconciler: warn: handle missing volume %s: %v", volumeID, err)
+				}
+				if volume.GetStatus() == runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE {
+					r.degradeThread(ctx, volume.GetThreadId(), degradeReasonVolumeLost, degraded)
 				}
 				continue
 			}

--- a/internal/reconciler/volume_reconcile.go
+++ b/internal/reconciler/volume_reconcile.go
@@ -73,10 +73,10 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 	volumeInfoCache := map[string]volumeTTLInfo{}
 	threadCache := map[string]threadActivity{}
 	for runnerID := range runnerIDs {
+		trackedVolumes := volumesByRunner[runnerID]
 		runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
 		if err != nil {
 			if runnerdial.IsNoTerminators(err) {
-				trackedVolumes := volumesByRunner[runnerID]
 				for volumeID, volume := range trackedVolumes {
 					if err := r.handleMissingRunnerVolume(ctx, volume); err != nil {
 						log.Printf("reconciler: warn: handle missing volume %s after runner dial failure: %v", volumeID, err)
@@ -89,6 +89,14 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 		}
 		resp, err := runnerClient.ListVolumes(ctx, &runnerv1.ListVolumesRequest{})
 		if err != nil {
+			if runnerdial.IsNoTerminators(err) {
+				for volumeID, volume := range trackedVolumes {
+					if err := r.handleMissingRunnerVolume(ctx, volume); err != nil {
+						log.Printf("reconciler: warn: handle missing volume %s after runner list failure: %v", volumeID, err)
+					}
+				}
+				continue
+			}
 			log.Printf("reconciler: warn: list volumes for runner %s: %v", runnerID, err)
 			continue
 		}
@@ -109,7 +117,6 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 			runnerVolumes[volumeKey] = item
 		}
 
-		trackedVolumes := volumesByRunner[runnerID]
 		for volumeID, volume := range trackedVolumes {
 			item, ok := runnerVolumes[volumeID]
 			if !ok {

--- a/internal/reconciler/volume_reconcile.go
+++ b/internal/reconciler/volume_reconcile.go
@@ -11,6 +11,7 @@ import (
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agents-orchestrator/internal/runnerdial"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -74,6 +75,15 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 	for runnerID := range runnerIDs {
 		runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
 		if err != nil {
+			if runnerdial.IsNoTerminators(err) {
+				trackedVolumes := volumesByRunner[runnerID]
+				for volumeID, volume := range trackedVolumes {
+					if err := r.handleMissingRunnerVolume(ctx, volume); err != nil {
+						log.Printf("reconciler: warn: handle missing volume %s after runner dial failure: %v", volumeID, err)
+					}
+				}
+				continue
+			}
 			log.Printf("reconciler: warn: dial runner %s for volume reconciliation: %v", runnerID, err)
 			continue
 		}

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -35,23 +35,39 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 		}
 		workloadsByRunner[runnerID][workloadID] = workload
 	}
-	if runners, err := r.listRunners(ctx); err != nil {
-		log.Printf("reconciler: warn: list runners for workload reconciliation: %v", err)
-	} else {
-		for _, runner := range runners {
-			if runner == nil {
-				continue
-			}
-			runnerID := runner.GetMeta().GetId()
-			if runnerID == "" {
-				continue
-			}
-			runnerIDs[runnerID] = struct{}{}
-		}
+	runners, err := r.listRunners(ctx)
+	if err != nil {
+		return err
 	}
+	enrolledRunnerIDs := map[string]struct{}{}
+	for _, runner := range runners {
+		if runner == nil {
+			continue
+		}
+		runnerID := runner.GetMeta().GetId()
+		if runnerID == "" {
+			continue
+		}
+		if runner.GetStatus() != runnersv1.RunnerStatus_RUNNER_STATUS_ENROLLED {
+			continue
+		}
+		enrolledRunnerIDs[runnerID] = struct{}{}
+		runnerIDs[runnerID] = struct{}{}
+	}
+
+	degraded := newDegradeTracker()
 
 	for runnerID := range runnerIDs {
 		trackedWorkloads := workloadsByRunner[runnerID]
+		if _, ok := enrolledRunnerIDs[runnerID]; !ok {
+			for workloadID, workload := range trackedWorkloads {
+				if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+					log.Printf("reconciler: warn: handle missing workload %s on unenrolled runner: %v", workloadID, err)
+				}
+				r.degradeThread(ctx, workload.GetThreadId(), degradeReasonRunnerDeprovisioned, degraded)
+			}
+			continue
+		}
 		runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
 		if err != nil {
 			if runnerdial.IsNoTerminators(err) {

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -51,10 +51,10 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 	}
 
 	for runnerID := range runnerIDs {
+		trackedWorkloads := workloadsByRunner[runnerID]
 		runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
 		if err != nil {
 			if runnerdial.IsNoTerminators(err) {
-				trackedWorkloads := workloadsByRunner[runnerID]
 				for workloadID, workload := range trackedWorkloads {
 					if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
 						log.Printf("reconciler: warn: handle missing workload %s after runner dial failure: %v", workloadID, err)
@@ -67,6 +67,14 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 		}
 		resp, err := runnerClient.ListWorkloads(ctx, &runnerv1.ListWorkloadsRequest{})
 		if err != nil {
+			if runnerdial.IsNoTerminators(err) {
+				for workloadID, workload := range trackedWorkloads {
+					if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+						log.Printf("reconciler: warn: handle missing workload %s after runner list failure: %v", workloadID, err)
+					}
+				}
+				continue
+			}
 			log.Printf("reconciler: warn: list workloads for runner %s: %v", runnerID, err)
 			continue
 		}
@@ -87,7 +95,6 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 			runnerWorkloads[workloadKey] = item
 		}
 
-		trackedWorkloads := workloadsByRunner[runnerID]
 		for workloadID, workload := range trackedWorkloads {
 			item, ok := runnerWorkloads[workloadID]
 			if !ok {

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -7,6 +7,7 @@ import (
 
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agents-orchestrator/internal/runnerdial"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -52,6 +53,15 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 	for runnerID := range runnerIDs {
 		runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
 		if err != nil {
+			if runnerdial.IsNoTerminators(err) {
+				trackedWorkloads := workloadsByRunner[runnerID]
+				for workloadID, workload := range trackedWorkloads {
+					if err := r.handleMissingRunnerWorkload(ctx, workload); err != nil {
+						log.Printf("reconciler: warn: handle missing workload %s after runner dial failure: %v", workloadID, err)
+					}
+				}
+				continue
+			}
 			log.Printf("reconciler: warn: dial runner %s for workload reconciliation: %v", runnerID, err)
 			continue
 		}

--- a/internal/runnerdial/dialer_test.go
+++ b/internal/runnerdial/dialer_test.go
@@ -142,6 +142,41 @@ func TestDialerErrorsOnMissingRunnerID(t *testing.T) {
 	}
 }
 
+func TestIsNoTerminators(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "has no terminators",
+			err:      errors.New("service runner-a has no terminators"),
+			expected: true,
+		},
+		{
+			name:     "no terminators",
+			err:      errors.New("no terminators available"),
+			expected: true,
+		},
+		{
+			name:     "other",
+			err:      errors.New("other"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		if got := IsNoTerminators(tt.err); got != tt.expected {
+			t.Fatalf("%s: expected %v, got %v", tt.name, tt.expected, got)
+		}
+	}
+}
+
 func TestIsAuthFailure(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -222,6 +257,21 @@ func TestDialZitiWithRetryAuthFailureWaits(t *testing.T) {
 	}
 }
 
+func TestDialZitiWithRetryStopsOnNoTerminators(t *testing.T) {
+	dialer := &noTerminatorsDialer{dialError: errors.New("service runner-a has no terminators")}
+
+	_, err := dialZitiWithRetry(context.Background(), dialer, "service-a")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if dialer.dialCalls.Load() != 1 {
+		t.Fatalf("expected 1 dial attempt, got %d", dialer.dialCalls.Load())
+	}
+	if dialer.notifyCalls.Load() != 0 {
+		t.Fatalf("expected 0 notify calls, got %d", dialer.notifyCalls.Load())
+	}
+}
+
 type authFailureDialer struct {
 	dialErrors    []error
 	dialCalls     atomic.Int32
@@ -250,4 +300,19 @@ func (a *authFailureDialer) NotifyAuthFailure(ctx context.Context) {
 		return
 	case <-a.notifyRelease:
 	}
+}
+
+type noTerminatorsDialer struct {
+	dialCalls   atomic.Int32
+	notifyCalls atomic.Int32
+	dialError   error
+}
+
+func (n *noTerminatorsDialer) DialContext(context.Context, string) (edge.Conn, error) {
+	n.dialCalls.Add(1)
+	return nil, n.dialError
+}
+
+func (n *noTerminatorsDialer) NotifyAuthFailure(context.Context) {
+	n.notifyCalls.Add(1)
 }

--- a/internal/runnerdial/runnerdial.go
+++ b/internal/runnerdial/runnerdial.go
@@ -165,6 +165,9 @@ func dialZitiWithRetry(ctx context.Context, zitiCtx ZitiDialer, service string) 
 		if err == nil {
 			return conn, nil
 		}
+		if IsNoTerminators(err) {
+			return nil, fmt.Errorf("dial ziti service %s: %w", service, err)
+		}
 		log.Printf("dial ziti service %s: attempt %d/%d failed: %v", service, attempt, retryMaxAttempts, err)
 		lastErr = err
 		if isAuthFailure(err) {
@@ -190,6 +193,14 @@ func dialZitiWithRetry(ctx context.Context, zitiCtx ZitiDialer, service string) 
 		}
 	}
 	return nil, fmt.Errorf("dial ziti service %s: %w", service, lastErr)
+}
+
+func IsNoTerminators(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no terminators")
 }
 
 func isAuthFailure(err error) bool {

--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -13,6 +13,7 @@ var ErrNotImplemented = errors.New("not implemented")
 
 type FakeAgentsClient struct {
 	GetAgentFunc                       func(context.Context, *agentsv1.GetAgentRequest, ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+	ResolveAgentIdentityFunc           func(context.Context, *agentsv1.ResolveAgentIdentityRequest, ...grpc.CallOption) (*agentsv1.ResolveAgentIdentityResponse, error)
 	ListSkillsFunc                     func(context.Context, *agentsv1.ListSkillsRequest, ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error)
 	ListEnvsFunc                       func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error)
 	ListInitScriptsFunc                func(context.Context, *agentsv1.ListInitScriptsRequest, ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error)
@@ -49,6 +50,13 @@ func (f *FakeAgentsClient) ListImagePullSecretAttachments(ctx context.Context, r
 func (f *FakeAgentsClient) GetAgent(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
 	if f.GetAgentFunc != nil {
 		return f.GetAgentFunc(ctx, req, opts...)
+	}
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeAgentsClient) ResolveAgentIdentity(ctx context.Context, req *agentsv1.ResolveAgentIdentityRequest, opts ...grpc.CallOption) (*agentsv1.ResolveAgentIdentityResponse, error) {
+	if f.ResolveAgentIdentityFunc != nil {
+		return f.ResolveAgentIdentityFunc(ctx, req, opts...)
 	}
 	return nil, ErrNotImplemented
 }

--- a/test/e2e/dedup_test.go
+++ b/test/e2e/dedup_test.go
@@ -58,7 +58,7 @@ func TestNoDuplicateWorkloads(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")

--- a/test/e2e/expose_test.go
+++ b/test/e2e/expose_test.go
@@ -61,7 +61,7 @@ func TestAgentExposeListExec(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")

--- a/test/e2e/idle_test.go
+++ b/test/e2e/idle_test.go
@@ -81,7 +81,7 @@ func TestWorkloadStopsAfterIdleTimeout(t *testing.T) {
 	}
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")

--- a/test/e2e/imagepull_test.go
+++ b/test/e2e/imagepull_test.go
@@ -94,7 +94,7 @@ func TestImagePullSecretAttachedToPod(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteImagePullSecretAttachment(t, ctx, agentsClient, attachmentID) })
 
-	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -307,10 +307,14 @@ func createMCPEnv(t *testing.T, ctx context.Context, client agentsv1.AgentsServi
 	return env
 }
 
-func createThread(t *testing.T, ctx context.Context, client threadsv1.ThreadsServiceClient, participantIDs []string) *threadsv1.Thread {
+func createThread(t *testing.T, ctx context.Context, client threadsv1.ThreadsServiceClient, organizationID string, participantIDs []string) *threadsv1.Thread {
 	t.Helper()
+	if organizationID == "" {
+		t.Fatal("create thread: missing organization id")
+	}
 	resp, err := client.CreateThread(ctx, &threadsv1.CreateThreadRequest{
 		ParticipantIds: participantIDs,
+		OrganizationId: &organizationID,
 	})
 	if err != nil {
 		t.Fatalf("create thread: %v", err)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -62,6 +62,7 @@ var (
 
 type pipelineRun struct {
 	threadID       string
+	organizationID string
 	startTimeMinNs uint64
 	agentResponse  string
 	messageText    string

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -51,7 +51,7 @@ var (
 	threadsAddr    = envOrDefault("THREADS_ADDRESS", "threads:50051")
 	llmAddr        = envOrDefault("LLM_ADDRESS", "llm:50051")
 	usersAddr      = envOrDefault("USERS_ADDRESS", "users:50051")
-	orgsAddr       = envOrDefault("ORGANIZATIONS_ADDRESS", "tenants:50051")
+	orgsAddr       = envOrDefault("ORGANIZATIONS_ADDRESS", "organizations:50051")
 	runnerAddr     = envOrDefault("RUNNER_ADDRESS", "k8s-runner:50051")
 	runnersAddr    = envOrDefault("RUNNERS_ADDRESS", "runners:50051")
 	secretsAddr    = envOrDefault("SECRETS_ADDRESS", "secrets:50051")

--- a/test/e2e/mcp_test.go
+++ b/test/e2e/mcp_test.go
@@ -146,6 +146,7 @@ func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
 
 	return pipelineRun{
 		threadID:       threadID,
+		organizationID: orgID,
 		startTimeMinNs: startTimeMinNs,
 		agentResponse:  agentBody,
 		messageText:    message,

--- a/test/e2e/mcp_test.go
+++ b/test/e2e/mcp_test.go
@@ -97,7 +97,7 @@ func runMCPToolsE2E(t *testing.T, llmEndpoint, initImage string) pipelineRun {
 	}
 	t.Cleanup(func() { deleteMCP(t, ctx, agentsClient, filesystemMcpID) })
 
-	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")

--- a/test/e2e/multi_test.go
+++ b/test/e2e/multi_test.go
@@ -62,8 +62,8 @@ func TestMultipleAgentsSeparateThreads(t *testing.T) {
 	createAgentEnv(t, ctx, agentsClient, agentAID, "LLM_API_TOKEN", token)
 	createAgentEnv(t, ctx, agentsClient, agentBID, "LLM_API_TOKEN", token)
 
-	threadA := createThread(t, ctx, threadsClient, []string{identityID, agentAID})
-	threadB := createThread(t, ctx, threadsClient, []string{identityID, agentBID})
+	threadA := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentAID})
+	threadB := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentBID})
 	threadAID := threadA.GetId()
 	threadBID := threadB.GetId()
 	if threadAID == "" || threadBID == "" {
@@ -192,8 +192,8 @@ func TestSameAgentMultipleThreads(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	threadA := createThread(t, ctx, threadsClient, []string{identityID, agentID})
-	threadB := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	threadA := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
+	threadB := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
 	threadAID := threadA.GetId()
 	threadBID := threadB.GetId()
 	if threadAID == "" || threadBID == "" {

--- a/test/e2e/pipeline_test.go
+++ b/test/e2e/pipeline_test.go
@@ -68,7 +68,7 @@ func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, messag
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")

--- a/test/e2e/pipeline_test.go
+++ b/test/e2e/pipeline_test.go
@@ -107,6 +107,7 @@ func runFullPipelineMessageResponse(t *testing.T, llmEndpoint, initImage, messag
 
 	return pipelineRun{
 		threadID:       threadID,
+		organizationID: orgID,
 		startTimeMinNs: startTimeMinNs,
 		agentResponse:  agentBody,
 		messageText:    message,

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -58,7 +58,7 @@ func TestWorkloadStartsOnUnackedMessage(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")

--- a/test/e2e/threads_send_test.go
+++ b/test/e2e/threads_send_test.go
@@ -91,7 +91,7 @@ func TestThreadsSendShell(t *testing.T) {
 	expectedBodies := []string{"Thinking", "Done thinking. Here is my reply."}
 	agentMessages, err := pollForAgentMessages(t, pollCtx, threadsClient, runnerClient, threadID, agentID, labels, sentMessageTime, expectedBodies)
 	if err != nil {
-		logShellToolExecutionDiagnostics(t, startTimeMinNs, threadID)
+		logShellToolExecutionDiagnostics(t, startTimeMinNs, orgID, threadID)
 		t.Fatalf("wait for agent messages: %v", err)
 	}
 	if len(agentMessages) != len(expectedBodies) {

--- a/test/e2e/threads_send_test.go
+++ b/test/e2e/threads_send_test.go
@@ -59,7 +59,7 @@ func TestThreadsSendShell(t *testing.T) {
 	t.Cleanup(func() { deleteAgent(t, ctx, agentsClient, agentID) })
 	createAgentEnv(t, ctx, agentsClient, agentID, "LLM_API_TOKEN", token)
 
-	thread := createThread(t, ctx, threadsClient, []string{identityID, agentID})
+	thread := createThread(t, ctx, threadsClient, orgID, []string{identityID, agentID})
 	threadID := thread.GetId()
 	if threadID == "" {
 		t.Fatal("create thread: missing id")

--- a/test/e2e/tracing_availability_test.go
+++ b/test/e2e/tracing_availability_test.go
@@ -5,7 +5,6 @@ package e2e
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -30,6 +29,12 @@ var (
 	tracingSkipReason        string
 )
 
+type tracingAvailability struct {
+	available         bool
+	unavailableReason string
+	skipReason        string
+}
+
 func TestMain(m *testing.M) {
 	e2eSkipReason = skipE2EReason()
 	if e2eSkipReason != "" {
@@ -43,8 +48,13 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
-	tracingAvailable, tracingUnavailableReason = checkTracingAvailability()
-	if !tracingAvailable {
+	availability := checkTracingAvailability()
+	tracingAvailable = availability.available
+	tracingUnavailableReason = availability.unavailableReason
+	if availability.skipReason != "" {
+		tracingSkipReason = availability.skipReason
+		log.Printf("tracing e2e skipped: %s", tracingSkipReason)
+	} else if !tracingAvailable {
 		reason := strings.TrimSpace(tracingUnavailableReason)
 		if reason == "" {
 			reason = "unknown reason"
@@ -54,10 +64,10 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func checkTracingAvailability() (bool, string) {
+func checkTracingAvailability() tracingAvailability {
 	addr := strings.TrimSpace(tracingAddr)
 	if addr == "" {
-		return false, "TRACING_ADDRESS is empty"
+		return tracingAvailability{available: false, unavailableReason: "TRACING_ADDRESS is empty"}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -65,15 +75,19 @@ func checkTracingAvailability() (bool, string) {
 	traceID, err := runTraceCanary(ctx, addr)
 	if err != nil {
 		if isCanaryAuthFailure(err) {
-			ok, reason := checkTracingQueryConnectivity(ctx, addr)
-			return ok, reason
+			reason := canaryAuthFailureReason(err)
+			return tracingAvailability{available: false, unavailableReason: reason, skipReason: reason}
 		}
-		return false, fmt.Sprintf("export canary span: %v", err)
+		reason := canaryFailureReason(err)
+		if reason == "" {
+			reason = err.Error()
+		}
+		return tracingAvailability{available: false, unavailableReason: fmt.Sprintf("trace canary failed: %s", reason)}
 	}
 
 	conn, err := dialGRPCForCheck(ctx, addr)
 	if err != nil {
-		return false, fmt.Sprintf("dial tracing %s: %v", addr, err)
+		return tracingAvailability{available: false, unavailableReason: fmt.Sprintf("dial tracing %s: %v", addr, err)}
 	}
 	defer conn.Close()
 
@@ -95,36 +109,10 @@ func checkTracingAvailability() (bool, string) {
 		return nil
 	})
 	if err != nil {
-		return false, fmt.Sprintf("tracing ingest check failed: %v", err)
+		return tracingAvailability{available: false, unavailableReason: fmt.Sprintf("tracing ingest check failed: %v", err)}
 	}
 
-	return true, ""
-}
-
-func checkTracingQueryConnectivity(ctx context.Context, addr string) (bool, string) {
-	conn, err := dialGRPCForCheck(ctx, addr)
-	if err != nil {
-		return false, fmt.Sprintf("dial tracing %s: %v", addr, err)
-	}
-	defer conn.Close()
-
-	traceID, err := randomTraceID()
-	if err != nil {
-		return false, err.Error()
-	}
-	queryClient := tracingv1.NewTracingServiceClient(conn)
-	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	_, err = queryClient.GetTrace(queryCtx, &tracingv1.GetTraceRequest{TraceId: traceID})
-	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return true, ""
-		}
-		return false, fmt.Sprintf("get trace: %v", err)
-	}
-
-	return true, ""
+	return tracingAvailability{available: true}
 }
 
 func dialGRPCForCheck(ctx context.Context, addr string) (*grpc.ClientConn, error) {
@@ -163,12 +151,23 @@ func isCanaryAuthFailure(err error) bool {
 	return strings.Contains(message, "source identity missing") || strings.Contains(message, "unauthenticated")
 }
 
-func randomTraceID() ([]byte, error) {
-	traceID := make([]byte, 16)
-	if _, err := rand.Read(traceID); err != nil {
-		return nil, fmt.Errorf("generate trace id: %w", err)
+func canaryFailureReason(err error) string {
+	if err == nil {
+		return ""
 	}
-	return traceID, nil
+	message := strings.TrimSpace(err.Error())
+	if message == "" {
+		return ""
+	}
+	return strings.TrimPrefix(message, "trace canary failed: ")
+}
+
+func canaryAuthFailureReason(err error) string {
+	reason := strings.TrimSpace(canaryFailureReason(err))
+	if reason == "" {
+		reason = "source identity missing"
+	}
+	return fmt.Sprintf("trace canary unauthenticated: %s", reason)
 }
 
 func skipTracingReason() string {

--- a/test/e2e/tracing_availability_test.go
+++ b/test/e2e/tracing_availability_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -63,6 +64,10 @@ func checkTracingAvailability() (bool, string) {
 
 	traceID, err := runTraceCanary(ctx, addr)
 	if err != nil {
+		if isCanaryAuthFailure(err) {
+			ok, reason := checkTracingQueryConnectivity(ctx, addr)
+			return ok, reason
+		}
 		return false, fmt.Sprintf("export canary span: %v", err)
 	}
 
@@ -96,6 +101,32 @@ func checkTracingAvailability() (bool, string) {
 	return true, ""
 }
 
+func checkTracingQueryConnectivity(ctx context.Context, addr string) (bool, string) {
+	conn, err := dialGRPCForCheck(ctx, addr)
+	if err != nil {
+		return false, fmt.Sprintf("dial tracing %s: %v", addr, err)
+	}
+	defer conn.Close()
+
+	traceID, err := randomTraceID()
+	if err != nil {
+		return false, err.Error()
+	}
+	queryClient := tracingv1.NewTracingServiceClient(conn)
+	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	_, err = queryClient.GetTrace(queryCtx, &tracingv1.GetTraceRequest{TraceId: traceID})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return true, ""
+		}
+		return false, fmt.Sprintf("get trace: %v", err)
+	}
+
+	return true, ""
+}
+
 func dialGRPCForCheck(ctx context.Context, addr string) (*grpc.ClientConn, error) {
 	return grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 }
@@ -120,6 +151,22 @@ func runTraceCanary(ctx context.Context, addr string) ([]byte, error) {
 	traceID, err := hex.DecodeString(traceHex)
 	if err != nil {
 		return nil, fmt.Errorf("decode trace id %q: %w", traceHex, err)
+	}
+	return traceID, nil
+}
+
+func isCanaryAuthFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "source identity missing") || strings.Contains(message, "unauthenticated")
+}
+
+func randomTraceID() ([]byte, error) {
+	traceID := make([]byte, 16)
+	if _, err := rand.Read(traceID); err != nil {
+		return nil, fmt.Errorf("generate trace id: %w", err)
 	}
 	return traceID, nil
 }

--- a/test/e2e/tracing_helpers_test.go
+++ b/test/e2e/tracing_helpers_test.go
@@ -47,11 +47,15 @@ func discoverTraceID(
 	t *testing.T,
 	ctx context.Context,
 	client tracingv1.TracingServiceClient,
+	organizationID string,
 	threadID string,
 	startTimeMinNs uint64,
 	messageText string,
 ) []byte {
 	t.Helper()
+	if strings.TrimSpace(organizationID) == "" {
+		t.Fatal("discover trace id: missing organization id")
+	}
 	searchStartTimeMinNs := startTimeMinNs
 	if tracingStartTimeBuffer > 0 {
 		bufferNs := uint64(tracingStartTimeBuffer.Nanoseconds())
@@ -69,7 +73,7 @@ func discoverTraceID(
 	var traceID []byte
 	err := pollUntil(pollCtx, pollInterval, func(ctx context.Context) error {
 		var err error
-		traceID, err = findTraceID(ctx, client, threadID, messageText, searchStartTimeMinNs)
+		traceID, err = findTraceID(ctx, client, organizationID, threadID, messageText, searchStartTimeMinNs)
 		if err != nil {
 			return err
 		}
@@ -79,7 +83,7 @@ func discoverTraceID(
 		return fmt.Errorf("trace id not found")
 	})
 	if err != nil {
-		logTraceSearchDiagnostics(t, client, searchStartTimeMinNs, messageText)
+		logTraceSearchDiagnostics(t, client, organizationID, searchStartTimeMinNs, messageText)
 		logTracingDiagnostics(t, threadID)
 		t.Fatalf("discover trace id: %v", err)
 	}
@@ -89,12 +93,13 @@ func discoverTraceID(
 func findTraceID(
 	ctx context.Context,
 	client tracingv1.TracingServiceClient,
+	organizationID string,
 	threadID string,
 	messageText string,
 	startTimeMinNs uint64,
 ) ([]byte, error) {
 	for _, spanName := range traceSearchSpanNames {
-		traceID, err := listTraceIDForSpanName(ctx, client, threadID, messageText, startTimeMinNs, spanName)
+		traceID, err := listTraceIDForSpanName(ctx, client, organizationID, threadID, messageText, startTimeMinNs, spanName)
 		if err != nil {
 			return nil, err
 		}
@@ -108,6 +113,7 @@ func findTraceID(
 func listTraceIDForSpanName(
 	ctx context.Context,
 	client tracingv1.TracingServiceClient,
+	organizationID string,
 	threadID string,
 	messageText string,
 	startTimeMinNs uint64,
@@ -120,9 +126,10 @@ func listTraceIDForSpanName(
 				StartTimeMin: startTimeMinNs,
 				Names:        []string{spanName},
 			},
-			PageSize:  100,
-			PageToken: pageToken,
-			OrderBy:   tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_DESC,
+			PageSize:       100,
+			PageToken:      pageToken,
+			OrderBy:        tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_DESC,
+			OrganizationId: organizationID,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("list spans %s: %w", spanName, err)
@@ -148,6 +155,7 @@ type traceIDSet map[string]struct{}
 func traceIDsForSpanName(
 	ctx context.Context,
 	client tracingv1.TracingServiceClient,
+	organizationID string,
 	threadID string,
 	messageText string,
 	startTimeMinNs uint64,
@@ -161,9 +169,10 @@ func traceIDsForSpanName(
 				StartTimeMin: startTimeMinNs,
 				Names:        []string{spanName},
 			},
-			PageSize:  200,
-			PageToken: pageToken,
-			OrderBy:   tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_DESC,
+			PageSize:       200,
+			PageToken:      pageToken,
+			OrderBy:        tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_DESC,
+			OrganizationId: organizationID,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("list spans %s: %w", spanName, err)
@@ -198,6 +207,7 @@ func traceIDsForSpanName(
 func countSpansForThread(
 	ctx context.Context,
 	client tracingv1.TracingServiceClient,
+	organizationID string,
 	threadID string,
 	messageText string,
 	startTimeMinNs uint64,
@@ -211,9 +221,10 @@ func countSpansForThread(
 				StartTimeMin: startTimeMinNs,
 				Names:        []string{spanName},
 			},
-			PageSize:  200,
-			PageToken: pageToken,
-			OrderBy:   tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_DESC,
+			PageSize:       200,
+			PageToken:      pageToken,
+			OrderBy:        tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_DESC,
+			OrganizationId: organizationID,
 		})
 		if err != nil {
 			return 0, fmt.Errorf("list spans %s: %w", spanName, err)
@@ -520,6 +531,7 @@ func attributeStringValue(value *commonv1.AnyValue) (string, bool) {
 func logTraceSearchDiagnostics(
 	t *testing.T,
 	client tracingv1.TracingServiceClient,
+	organizationID string,
 	startTimeMinNs uint64,
 	messageText string,
 ) {
@@ -530,10 +542,10 @@ func logTraceSearchDiagnostics(
 	if strings.TrimSpace(messageText) != "" {
 		t.Logf("diagnostics: trace search message=%s", truncateLogLine(messageText))
 	}
-	logSpanSamples(t, ctx, client, startTimeMinNs, []string{"invocation.message"}, "invocation.message")
-	logSpanSamples(t, ctx, client, startTimeMinNs, []string{"tool.execution"}, "tool.execution")
-	logSpanSamples(t, ctx, client, startTimeMinNs, []string{"llm.call"}, "llm.call")
-	logSpanSamples(t, ctx, client, startTimeMinNs, nil, "all-spans")
+	logSpanSamples(t, ctx, client, organizationID, startTimeMinNs, []string{"invocation.message"}, "invocation.message")
+	logSpanSamples(t, ctx, client, organizationID, startTimeMinNs, []string{"tool.execution"}, "tool.execution")
+	logSpanSamples(t, ctx, client, organizationID, startTimeMinNs, []string{"llm.call"}, "llm.call")
+	logSpanSamples(t, ctx, client, organizationID, startTimeMinNs, nil, "all-spans")
 	logTracingStackDiagnostics(t)
 }
 
@@ -541,6 +553,7 @@ func logSpanSamples(
 	t *testing.T,
 	ctx context.Context,
 	client tracingv1.TracingServiceClient,
+	organizationID string,
 	startTimeMinNs uint64,
 	spanNames []string,
 	label string,
@@ -551,9 +564,10 @@ func logSpanSamples(
 		filter.Names = spanNames
 	}
 	resp, err := client.ListSpans(ctx, &tracingv1.ListSpansRequest{
-		Filter:   filter,
-		PageSize: 10,
-		OrderBy:  tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_DESC,
+		Filter:         filter,
+		PageSize:       10,
+		OrderBy:        tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_DESC,
+		OrganizationId: organizationID,
 	})
 	if err != nil {
 		t.Logf("diagnostics: list spans %s error: %v", label, err)
@@ -591,7 +605,7 @@ func logSpanSamples(
 	}
 }
 
-func logShellToolExecutionDiagnostics(t *testing.T, startTimeMinNs uint64, threadID string) {
+func logShellToolExecutionDiagnostics(t *testing.T, startTimeMinNs uint64, organizationID string, threadID string) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
@@ -612,9 +626,10 @@ func logShellToolExecutionDiagnostics(t *testing.T, startTimeMinNs uint64, threa
 				StartTimeMin: startTimeMinNs,
 				Names:        []string{"tool.execution"},
 			},
-			PageSize:  200,
-			PageToken: pageToken,
-			OrderBy:   tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_DESC,
+			PageSize:       200,
+			PageToken:      pageToken,
+			OrderBy:        tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_DESC,
+			OrganizationId: organizationID,
 		})
 		if err != nil {
 			t.Logf("diagnostics: list tool.execution spans: %v", err)

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -15,7 +15,7 @@ func TestAgentSimpleHelloProducesTrace(t *testing.T) {
 
 	ctx := context.Background()
 	tracingClient := newTracingClient(t)
-	traceID := discoverTraceID(t, ctx, tracingClient, result.threadID, result.startTimeMinNs, result.messageText)
+	traceID := discoverTraceID(t, ctx, tracingClient, result.organizationID, result.threadID, result.startTimeMinNs, result.messageText)
 	assertTraceSummary(t, ctx, tracingClient, traceID, map[string]int64{
 		"invocation.message": 1,
 		"llm.call":           1,
@@ -42,7 +42,7 @@ func TestAgentMCPToolsProducesTrace(t *testing.T) {
 
 	ctx := context.Background()
 	tracingClient := newTracingClient(t)
-	traceID := discoverTraceID(t, ctx, tracingClient, result.threadID, result.startTimeMinNs, result.messageText)
+	traceID := discoverTraceID(t, ctx, tracingClient, result.organizationID, result.threadID, result.startTimeMinNs, result.messageText)
 	expectedCounts := map[string]int64{
 		"invocation.message": 1,
 		"llm.call":           2,


### PR DESCRIPTION
## Summary
- add no-terminators classification to runner dialer and stop retry spam
- mark workloads/volumes terminal when runner dial reports no terminators
- update tests and fakes for new behavior

## Testing
- go test ./...
- go vet -p 1 ./...

## Issue
- #148