### PR TITLE
Refresh workload container state

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: f3017f9d17f34204bb16b2d4965e8e58
-    digest: shake256:d7a844b0d81eb46525351d250d8b7df473f5dd907aa1b1e26273cf27fab84f0edde9844c07924e86f1f7583ed5204371aa1647f7d09165563973b0228206c086
+    commit: 0c3439c9954c41edbb633c6a0df915ca
+    digest: shake256:9413c5ef59e316eb902acad778a2c55043fe0d31d593d2f533425aa263ee6f4686a095fe5affc9370ec461e5540d89abdb3fd8707c86cc04591751af89d0f4a4
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -253,6 +253,162 @@ func TestReconcileWorkloadsRefreshesContainersOnRunning(t *testing.T) {
 	}
 }
 
+func TestReconcileWorkloadsTransitionsStartingToRunningOnInspectError(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadKey := "workload-1"
+	rawInstanceID := uuid.New().String()
+	instanceID := "workload-" + rawInstanceID
+
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	inspectCalled := false
+	runner := &fakeRunnerClient{
+		listWorkloads: func(_ context.Context, _ *runnerv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnerv1.ListWorkloadsResponse, error) {
+			return &runnerv1.ListWorkloadsResponse{Workloads: []*runnerv1.WorkloadListItem{
+				{WorkloadKey: workloadKey, InstanceId: instanceID},
+			}}, nil
+		},
+		inspectWorkload: func(_ context.Context, req *runnerv1.InspectWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+			inspectCalled = true
+			if req.GetWorkloadId() != rawInstanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return nil, errors.New("inspect failed")
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected update workload")
+	}
+	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
+	}
+	if updateReq.GetInstanceId() != rawInstanceID {
+		t.Fatalf("unexpected instance id: %v", updateReq.GetInstanceId())
+	}
+	if len(updateReq.GetContainers()) != 0 {
+		t.Fatalf("expected no containers, got %d", len(updateReq.GetContainers()))
+	}
+	if !inspectCalled {
+		t.Fatal("expected inspect workload")
+	}
+}
+
+func TestReconcileWorkloadsStopsStoppingOnInspectError(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadKey := "workload-1"
+	rawInstanceID := uuid.New().String()
+	instanceID := "workload-" + rawInstanceID
+
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	inspectCalled := false
+	stopCalled := false
+	runner := &fakeRunnerClient{
+		listWorkloads: func(_ context.Context, _ *runnerv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnerv1.ListWorkloadsResponse, error) {
+			return &runnerv1.ListWorkloadsResponse{Workloads: []*runnerv1.WorkloadListItem{
+				{WorkloadKey: workloadKey, InstanceId: instanceID},
+			}}, nil
+		},
+		inspectWorkload: func(_ context.Context, req *runnerv1.InspectWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+			inspectCalled = true
+			if req.GetWorkloadId() != rawInstanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return nil, errors.New("inspect failed")
+		},
+		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+			if req.GetWorkloadId() != rawInstanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			stopCalled = true
+			return &runnerv1.StopWorkloadResponse{}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected update workload")
+	}
+	if updateReq.GetInstanceId() != rawInstanceID {
+		t.Fatalf("unexpected instance id: %v", updateReq.GetInstanceId())
+	}
+	if updateReq.Status != nil {
+		t.Fatalf("unexpected status update: %v", updateReq.GetStatus())
+	}
+	if !inspectCalled {
+		t.Fatal("expected inspect workload")
+	}
+	if !stopCalled {
+		t.Fatal("expected stop workload")
+	}
+}
+
 func TestReconcileWorkloadsStopsOrphan(t *testing.T) {
 	ctx := context.Background()
 	runnerID := "runner-1"

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -22,6 +22,11 @@ func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 	workloadKey := "workload-1"
 	rawInstanceID := uuid.New().String()
 	instanceID := "workload-" + rawInstanceID
+	startTime := timestamppb.New(time.Date(2024, time.January, 1, 2, 3, 4, 0, time.UTC))
+	finishTime := timestamppb.New(time.Date(2024, time.January, 1, 3, 4, 5, 0, time.UTC))
+	reason := "Completed"
+	message := "done"
+	exitCode := int32(0)
 
 	var updateReq *runnersv1.UpdateWorkloadRequest
 	runners := &fakeRunnersClient{
@@ -39,10 +44,48 @@ func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 		},
 	}
 
+	inspectCalled := false
 	runner := &fakeRunnerClient{
 		listWorkloads: func(_ context.Context, _ *runnerv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnerv1.ListWorkloadsResponse, error) {
 			return &runnerv1.ListWorkloadsResponse{Workloads: []*runnerv1.WorkloadListItem{
 				{WorkloadKey: workloadKey, InstanceId: instanceID},
+			}}, nil
+		},
+		inspectWorkload: func(_ context.Context, req *runnerv1.InspectWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+			inspectCalled = true
+			if req.GetWorkloadId() != rawInstanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return &runnerv1.InspectWorkloadResponse{Containers: []*runnerv1.WorkloadContainer{
+				{
+					ContainerId:  "init-id",
+					Name:         "init",
+					Role:         runnerv1.ContainerRole_CONTAINER_ROLE_INIT,
+					Image:        "init-image",
+					Status:       runnerv1.ContainerStatus_CONTAINER_STATUS_TERMINATED,
+					Reason:       &reason,
+					Message:      &message,
+					ExitCode:     &exitCode,
+					RestartCount: 2,
+					StartedAt:    startTime,
+					FinishedAt:   finishTime,
+				},
+				{
+					ContainerId:  "main-id",
+					Name:         "main",
+					Role:         runnerv1.ContainerRole_CONTAINER_ROLE_MAIN,
+					Image:        "main-image",
+					Status:       runnerv1.ContainerStatus_CONTAINER_STATUS_RUNNING,
+					RestartCount: 1,
+					StartedAt:    startTime,
+				},
+				{
+					ContainerId: "sidecar-id",
+					Name:        "sidecar",
+					Role:        runnerv1.ContainerRole_CONTAINER_ROLE_SIDECAR,
+					Image:       "sidecar-image",
+					Status:      runnerv1.ContainerStatus_CONTAINER_STATUS_WAITING,
+				},
 			}}, nil
 		},
 	}
@@ -73,6 +116,140 @@ func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 	}
 	if updateReq.GetInstanceId() != rawInstanceID {
 		t.Fatalf("unexpected instance id: %v", updateReq.GetInstanceId())
+	}
+	if !inspectCalled {
+		t.Fatal("expected inspect workload")
+	}
+	if len(updateReq.GetContainers()) != 3 {
+		t.Fatalf("expected 3 containers, got %d", len(updateReq.GetContainers()))
+	}
+	initContainer := updateReq.GetContainers()[0]
+	if initContainer.GetRole() != runnersv1.ContainerRole_CONTAINER_ROLE_INIT {
+		t.Fatalf("unexpected init role: %v", initContainer.GetRole())
+	}
+	if initContainer.GetStatus() != runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED {
+		t.Fatalf("unexpected init status: %v", initContainer.GetStatus())
+	}
+	if initContainer.GetReason() != reason || initContainer.Reason == nil {
+		t.Fatalf("unexpected init reason: %v", initContainer.GetReason())
+	}
+	if initContainer.GetMessage() != message || initContainer.Message == nil {
+		t.Fatalf("unexpected init message: %v", initContainer.GetMessage())
+	}
+	if initContainer.GetExitCode() != exitCode || initContainer.ExitCode == nil {
+		t.Fatalf("unexpected init exit code: %v", initContainer.GetExitCode())
+	}
+	if initContainer.GetStartedAt().AsTime() != startTime.AsTime() {
+		t.Fatalf("unexpected init started_at")
+	}
+	if initContainer.GetFinishedAt().AsTime() != finishTime.AsTime() {
+		t.Fatalf("unexpected init finished_at")
+	}
+	mainContainer := updateReq.GetContainers()[1]
+	if mainContainer.GetRole() != runnersv1.ContainerRole_CONTAINER_ROLE_MAIN {
+		t.Fatalf("unexpected main role: %v", mainContainer.GetRole())
+	}
+	if mainContainer.GetStatus() != runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING {
+		t.Fatalf("unexpected main status: %v", mainContainer.GetStatus())
+	}
+	sidecarContainer := updateReq.GetContainers()[2]
+	if sidecarContainer.GetRole() != runnersv1.ContainerRole_CONTAINER_ROLE_SIDECAR {
+		t.Fatalf("unexpected sidecar role: %v", sidecarContainer.GetRole())
+	}
+}
+
+func TestReconcileWorkloadsRefreshesContainersOnRunning(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadKey := "workload-1"
+	rawInstanceID := uuid.New().String()
+	instanceID := "workload-" + rawInstanceID
+	startTime := timestamppb.New(time.Date(2024, time.February, 1, 2, 3, 4, 0, time.UTC))
+
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING, InstanceId: stringPtr(rawInstanceID)},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	inspectCalled := false
+	runner := &fakeRunnerClient{
+		listWorkloads: func(_ context.Context, _ *runnerv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnerv1.ListWorkloadsResponse, error) {
+			return &runnerv1.ListWorkloadsResponse{Workloads: []*runnerv1.WorkloadListItem{
+				{WorkloadKey: workloadKey, InstanceId: instanceID},
+			}}, nil
+		},
+		inspectWorkload: func(_ context.Context, req *runnerv1.InspectWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+			inspectCalled = true
+			if req.GetWorkloadId() != rawInstanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return &runnerv1.InspectWorkloadResponse{Containers: []*runnerv1.WorkloadContainer{
+				{
+					ContainerId:  "main-id",
+					Name:         "main",
+					Role:         runnerv1.ContainerRole_CONTAINER_ROLE_MAIN,
+					Image:        "main-image",
+					Status:       runnerv1.ContainerStatus_CONTAINER_STATUS_RUNNING,
+					RestartCount: 3,
+					StartedAt:    startTime,
+				},
+			}}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected update workload")
+	}
+	if updateReq.InstanceId != nil {
+		t.Fatalf("unexpected instance id update: %v", updateReq.GetInstanceId())
+	}
+	if updateReq.Status != nil {
+		t.Fatalf("unexpected status update: %v", updateReq.GetStatus())
+	}
+	if !inspectCalled {
+		t.Fatal("expected inspect workload")
+	}
+	if len(updateReq.GetContainers()) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(updateReq.GetContainers()))
+	}
+	mainContainer := updateReq.GetContainers()[0]
+	if mainContainer.GetContainerId() != "main-id" {
+		t.Fatalf("unexpected main container id: %s", mainContainer.GetContainerId())
+	}
+	if mainContainer.GetRestartCount() != 3 {
+		t.Fatalf("unexpected main restart count: %v", mainContainer.GetRestartCount())
+	}
+	if mainContainer.GetStartedAt().AsTime() != startTime.AsTime() {
+		t.Fatalf("unexpected main started_at")
 	}
 }
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -436,6 +436,36 @@ func (r *Reconciler) stopRunnerWorkloadWithPrefix(ctx context.Context, runnerCli
 	return nil
 }
 
+func (r *Reconciler) inspectRunnerWorkload(ctx context.Context, runnerClient runnerv1.RunnerServiceClient, instanceID string) (*runnerv1.InspectWorkloadResponse, error) {
+	resp, err := r.inspectRunnerWorkloadID(ctx, runnerClient, instanceID)
+	if err == nil {
+		return resp, nil
+	}
+	if status.Code(err) != codes.NotFound {
+		return nil, err
+	}
+	if _, parseErr := uuid.Parse(instanceID); parseErr != nil {
+		return nil, err
+	}
+	return r.inspectRunnerWorkloadWithPrefix(ctx, runnerClient, instanceID)
+}
+
+func (r *Reconciler) inspectRunnerWorkloadID(ctx context.Context, runnerClient runnerv1.RunnerServiceClient, workloadID string) (*runnerv1.InspectWorkloadResponse, error) {
+	return runnerClient.InspectWorkload(ctx, &runnerv1.InspectWorkloadRequest{WorkloadId: workloadID})
+}
+
+func (r *Reconciler) inspectRunnerWorkloadWithPrefix(ctx context.Context, runnerClient runnerv1.RunnerServiceClient, instanceID string) (*runnerv1.InspectWorkloadResponse, error) {
+	prefixedID := runnerWorkloadPrefix + instanceID
+	resp, err := r.inspectRunnerWorkloadID(ctx, runnerClient, prefixedID)
+	if err == nil {
+		return resp, nil
+	}
+	if status.Code(err) != codes.NotFound {
+		return nil, err
+	}
+	return nil, err
+}
+
 func (r *Reconciler) deleteIdentity(ctx context.Context, identityID string) error {
 	_, err := r.zitiMgmt.DeleteIdentity(ctx, &zitimgmtv1.DeleteIdentityRequest{ZitiIdentityId: identityID})
 	return err
@@ -456,6 +486,70 @@ func runnerStatus(status runnerv1.WorkloadStatus) (runnersv1.WorkloadStatus, err
 	default:
 		return runnersv1.WorkloadStatus_WORKLOAD_STATUS_UNSPECIFIED, fmt.Errorf("unknown runner workload status: %v", status)
 	}
+}
+
+func runnerContainerRole(role runnerv1.ContainerRole) (runnersv1.ContainerRole, error) {
+	switch role {
+	case runnerv1.ContainerRole_CONTAINER_ROLE_UNSPECIFIED:
+		return runnersv1.ContainerRole_CONTAINER_ROLE_UNSPECIFIED, fmt.Errorf("runner returned unspecified container role")
+	case runnerv1.ContainerRole_CONTAINER_ROLE_MAIN:
+		return runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, nil
+	case runnerv1.ContainerRole_CONTAINER_ROLE_SIDECAR:
+		return runnersv1.ContainerRole_CONTAINER_ROLE_SIDECAR, nil
+	case runnerv1.ContainerRole_CONTAINER_ROLE_INIT:
+		return runnersv1.ContainerRole_CONTAINER_ROLE_INIT, nil
+	default:
+		return runnersv1.ContainerRole_CONTAINER_ROLE_UNSPECIFIED, fmt.Errorf("unknown runner container role: %v", role)
+	}
+}
+
+func runnerContainerStatus(status runnerv1.ContainerStatus) (runnersv1.ContainerStatus, error) {
+	switch status {
+	case runnerv1.ContainerStatus_CONTAINER_STATUS_UNSPECIFIED:
+		return runnersv1.ContainerStatus_CONTAINER_STATUS_UNSPECIFIED, fmt.Errorf("runner returned unspecified container status")
+	case runnerv1.ContainerStatus_CONTAINER_STATUS_RUNNING:
+		return runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING, nil
+	case runnerv1.ContainerStatus_CONTAINER_STATUS_TERMINATED:
+		return runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED, nil
+	case runnerv1.ContainerStatus_CONTAINER_STATUS_WAITING:
+		return runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING, nil
+	default:
+		return runnersv1.ContainerStatus_CONTAINER_STATUS_UNSPECIFIED, fmt.Errorf("unknown runner container status: %v", status)
+	}
+}
+
+func mapRunnerContainers(containers []*runnerv1.WorkloadContainer) ([]*runnersv1.Container, error) {
+	if len(containers) == 0 {
+		return nil, nil
+	}
+	result := make([]*runnersv1.Container, 0, len(containers))
+	for _, container := range containers {
+		if container == nil {
+			return nil, fmt.Errorf("runner returned nil workload container")
+		}
+		role, err := runnerContainerRole(container.GetRole())
+		if err != nil {
+			return nil, err
+		}
+		status, err := runnerContainerStatus(container.GetStatus())
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, &runnersv1.Container{
+			ContainerId:  container.GetContainerId(),
+			Name:         container.GetName(),
+			Role:         role,
+			Image:        container.GetImage(),
+			Status:       status,
+			Reason:       container.Reason,
+			Message:      container.Message,
+			ExitCode:     container.ExitCode,
+			RestartCount: container.GetRestartCount(),
+			StartedAt:    container.StartedAt,
+			FinishedAt:   container.FinishedAt,
+		})
+	}
+	return result, nil
 }
 
 func buildContainers(request *runnerv1.StartWorkloadRequest, resp *runnerv1.StartWorkloadResponse) []*runnersv1.Container {

--- a/internal/reconciler/reconciler_unit_test.go
+++ b/internal/reconciler/reconciler_unit_test.go
@@ -2,9 +2,11 @@ package reconciler
 
 import (
 	"testing"
+	"time"
 
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestRunnerStatus(t *testing.T) {
@@ -156,4 +158,101 @@ func TestBuildContainers(t *testing.T) {
 			t.Fatalf("unexpected sidecar-b container status: %v", sidecarB.GetStatus())
 		}
 	})
+}
+
+func TestMapRunnerContainers(t *testing.T) {
+	start := timestamppb.New(time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC))
+	finish := timestamppb.New(time.Date(2024, time.January, 2, 4, 5, 6, 0, time.UTC))
+	reason := "Completed"
+	message := "done"
+	exitCode := int32(0)
+
+	containers, err := mapRunnerContainers([]*runnerv1.WorkloadContainer{
+		{
+			ContainerId:  "init-id",
+			Name:         "init",
+			Role:         runnerv1.ContainerRole_CONTAINER_ROLE_INIT,
+			Image:        "init-image",
+			Status:       runnerv1.ContainerStatus_CONTAINER_STATUS_TERMINATED,
+			Reason:       &reason,
+			Message:      &message,
+			ExitCode:     &exitCode,
+			RestartCount: 2,
+			StartedAt:    start,
+			FinishedAt:   finish,
+		},
+		{
+			ContainerId:  "main-id",
+			Name:         "main",
+			Role:         runnerv1.ContainerRole_CONTAINER_ROLE_MAIN,
+			Image:        "main-image",
+			Status:       runnerv1.ContainerStatus_CONTAINER_STATUS_RUNNING,
+			RestartCount: 1,
+			StartedAt:    start,
+		},
+		{
+			ContainerId: "sidecar-id",
+			Name:        "sidecar",
+			Role:        runnerv1.ContainerRole_CONTAINER_ROLE_SIDECAR,
+			Image:       "sidecar-image",
+			Status:      runnerv1.ContainerStatus_CONTAINER_STATUS_WAITING,
+		},
+	})
+	if err != nil {
+		t.Fatalf("map containers: %v", err)
+	}
+	if len(containers) != 3 {
+		t.Fatalf("expected 3 containers, got %d", len(containers))
+	}
+
+	initContainer := containers[0]
+	if initContainer.GetContainerId() != "init-id" {
+		t.Fatalf("unexpected init container id: %s", initContainer.GetContainerId())
+	}
+	if initContainer.GetRole() != runnersv1.ContainerRole_CONTAINER_ROLE_INIT {
+		t.Fatalf("unexpected init container role: %v", initContainer.GetRole())
+	}
+	if initContainer.GetStatus() != runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED {
+		t.Fatalf("unexpected init container status: %v", initContainer.GetStatus())
+	}
+	if initContainer.GetReason() != reason || initContainer.Reason == nil {
+		t.Fatalf("unexpected init container reason: %v", initContainer.GetReason())
+	}
+	if initContainer.GetMessage() != message || initContainer.Message == nil {
+		t.Fatalf("unexpected init container message: %v", initContainer.GetMessage())
+	}
+	if initContainer.GetExitCode() != exitCode || initContainer.ExitCode == nil {
+		t.Fatalf("unexpected init container exit code: %v", initContainer.GetExitCode())
+	}
+	if initContainer.GetRestartCount() != 2 {
+		t.Fatalf("unexpected init restart count: %v", initContainer.GetRestartCount())
+	}
+	if initContainer.GetStartedAt().AsTime() != start.AsTime() {
+		t.Fatalf("unexpected init started_at")
+	}
+	if initContainer.GetFinishedAt().AsTime() != finish.AsTime() {
+		t.Fatalf("unexpected init finished_at")
+	}
+
+	mainContainer := containers[1]
+	if mainContainer.GetName() != "main" {
+		t.Fatalf("unexpected main container name: %s", mainContainer.GetName())
+	}
+	if mainContainer.GetRole() != runnersv1.ContainerRole_CONTAINER_ROLE_MAIN {
+		t.Fatalf("unexpected main container role: %v", mainContainer.GetRole())
+	}
+	if mainContainer.GetStatus() != runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING {
+		t.Fatalf("unexpected main container status: %v", mainContainer.GetStatus())
+	}
+	if mainContainer.GetRestartCount() != 1 {
+		t.Fatalf("unexpected main restart count: %v", mainContainer.GetRestartCount())
+	}
+
+	sidecarContainer := containers[2]
+	if sidecarContainer.GetRole() != runnersv1.ContainerRole_CONTAINER_ROLE_SIDECAR {
+		t.Fatalf("unexpected sidecar container role: %v", sidecarContainer.GetRole())
+	}
+	if sidecarContainer.GetStatus() != runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING {
+		t.Fatalf("unexpected sidecar container status: %v", sidecarContainer.GetStatus())
+	}
 }

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -227,34 +227,41 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 	if instanceID == "" {
 		return nil
 	}
-	inspectResp, err := r.inspectRunnerWorkload(ctx, runnerClient, instanceID)
-	if err != nil {
-		return err
-	}
-	containers, err := mapRunnerContainers(inspectResp.GetContainers())
-	if err != nil {
-		return err
-	}
-	updateReq := &runnersv1.UpdateWorkloadRequest{
-		Id:         workloadID,
-		Containers: containers,
-	}
+	updateReq := &runnersv1.UpdateWorkloadRequest{Id: workloadID}
+	shouldUpdate := false
 	switch workload.GetStatus() {
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING:
 		status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING
 		updateReq.Status = &status
 		updateReq.InstanceId = stringPtr(instanceID)
+		shouldUpdate = true
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING:
 		if workload.GetInstanceId() != instanceID {
 			updateReq.InstanceId = stringPtr(instanceID)
+			shouldUpdate = true
 		}
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING:
 		if workload.GetInstanceId() != instanceID {
 			updateReq.InstanceId = stringPtr(instanceID)
+			shouldUpdate = true
 		}
 	}
-	if _, err := r.runners.UpdateWorkload(ctx, updateReq); err != nil {
-		return err
+	inspectResp, err := r.inspectRunnerWorkload(ctx, runnerClient, instanceID)
+	if err != nil {
+		log.Printf("reconciler: warn: inspect workload %s: %v", workloadID, err)
+	} else {
+		containers, err := mapRunnerContainers(inspectResp.GetContainers())
+		if err != nil {
+			log.Printf("reconciler: warn: map workload %s containers: %v", workloadID, err)
+		} else {
+			updateReq.Containers = containers
+			shouldUpdate = true
+		}
+	}
+	if shouldUpdate {
+		if _, err := r.runners.UpdateWorkload(ctx, updateReq); err != nil {
+			return err
+		}
 	}
 	if workload.GetStatus() == runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING {
 		return r.stopRunnerWorkload(ctx, runnerClient, instanceID)

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -227,27 +227,37 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 	if instanceID == "" {
 		return nil
 	}
+	inspectResp, err := r.inspectRunnerWorkload(ctx, runnerClient, instanceID)
+	if err != nil {
+		return err
+	}
+	containers, err := mapRunnerContainers(inspectResp.GetContainers())
+	if err != nil {
+		return err
+	}
+	updateReq := &runnersv1.UpdateWorkloadRequest{
+		Id:         workloadID,
+		Containers: containers,
+	}
 	switch workload.GetStatus() {
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING:
 		status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING
-		_, err := r.runners.UpdateWorkload(ctx, &runnersv1.UpdateWorkloadRequest{
-			Id:         workloadID,
-			Status:     &status,
-			InstanceId: stringPtr(instanceID),
-		})
-		return err
+		updateReq.Status = &status
+		updateReq.InstanceId = stringPtr(instanceID)
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING:
-		if workload.GetInstanceId() == instanceID {
-			return nil
+		if workload.GetInstanceId() != instanceID {
+			updateReq.InstanceId = stringPtr(instanceID)
 		}
-		_, err := r.runners.UpdateWorkload(ctx, &runnersv1.UpdateWorkloadRequest{
-			Id:         workloadID,
-			InstanceId: stringPtr(instanceID),
-		})
-		return err
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING:
-		return r.stopRunnerWorkload(ctx, runnerClient, instanceID)
-	default:
-		return nil
+		if workload.GetInstanceId() != instanceID {
+			updateReq.InstanceId = stringPtr(instanceID)
+		}
 	}
+	if _, err := r.runners.UpdateWorkload(ctx, updateReq); err != nil {
+		return err
+	}
+	if workload.GetStatus() == runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING {
+		return r.stopRunnerWorkload(ctx, runnerClient, instanceID)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- update buf.lock to latest agynio/api
- inspect workloads during reconciliation and persist container runtime state
- add tests for container mapping and refresh behavior

## Testing
- buf generate
- go test ./...
- go vet -p 1 ./...

Refs #33