### PR TITLE
fix(assembler): remove workspace/home injection

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
+        env:
+          AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.14
+          AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.14
         with:
           service: agents_orchestrator
 

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -18,31 +18,25 @@ import (
 )
 
 const (
-	listPageSize                      int32 = 100
-	rpcTimeout                              = 10 * time.Second
-	agynBinVolumeName                       = "agyn-bin"
-	agynBinMountPath                        = "/agyn-bin"
-	agynBinBinaryPath                       = "/agyn-bin/agynd"
-	agentWorkspaceDir                       = "/workspace"
-	agentHomeDir                            = "/agyn"
-	agentWorkspaceVolumeName                = "agyn-workspace"
-	agentHomeVolumeName                     = "agyn-home"
-	agentPermissionsInitContainerName       = "agent-permissions"
-	agentPermissionsInitImage               = "busybox:1.37.0"
-	mcpBasePort                             = 8100
-	ZitiSidecarContainerName                = "ziti-sidecar"
-	zitiIdentityVolumeName                  = "ziti-identity"
-	zitiIdentityMountPath                   = "/netfoundry"
-	ZitiIdentityBasename                    = "agent"
-	ZitiEnrollmentTokenEnvVar               = "ZITI_ENROLL_TOKEN"
-	ZitiIdentityBasenameEnvVar              = "ZITI_IDENTITY_BASENAME"
-	zitiDNSNameserver                       = "127.0.0.1"
-	zitiSidecarCommand                      = "tproxy"
-	zitiRequiredCapabilityNetAdmin          = "NET_ADMIN"
-	zitiRestartPolicyKey                    = "restart_policy"
-	zitiRestartPolicyAlways                 = "Always"
-	zitiDNSSearchService                    = "svc.cluster.local"
-	zitiDNSSearchCluster                    = "cluster.local"
+	listPageSize                   int32 = 100
+	rpcTimeout                           = 10 * time.Second
+	agynBinVolumeName                    = "agyn-bin"
+	agynBinMountPath                     = "/agyn-bin"
+	agynBinBinaryPath                    = "/agyn-bin/agynd"
+	mcpBasePort                          = 8100
+	ZitiSidecarContainerName             = "ziti-sidecar"
+	zitiIdentityVolumeName               = "ziti-identity"
+	zitiIdentityMountPath                = "/netfoundry"
+	ZitiIdentityBasename                 = "agent"
+	ZitiEnrollmentTokenEnvVar            = "ZITI_ENROLL_TOKEN"
+	ZitiIdentityBasenameEnvVar           = "ZITI_IDENTITY_BASENAME"
+	zitiDNSNameserver                    = "127.0.0.1"
+	zitiSidecarCommand                   = "tproxy"
+	zitiRequiredCapabilityNetAdmin       = "NET_ADMIN"
+	zitiRestartPolicyKey                 = "restart_policy"
+	zitiRestartPolicyAlways              = "Always"
+	zitiDNSSearchService                 = "svc.cluster.local"
+	zitiDNSSearchCluster                 = "cluster.local"
 )
 
 var reservedEnvNames = map[string]struct{}{
@@ -57,8 +51,6 @@ var reservedEnvNames = map[string]struct{}{
 	"AGYN_GATEWAY_URL":         {},
 	"LLM_BASE_URL":             {},
 	"TRACING_ADDRESS":          {},
-	"WORKSPACE_DIR":            {},
-	"HOME":                     {},
 	"AGENT_MCP_SERVERS":        {},
 	"MCP_PORT":                 {},
 	ZitiEnrollmentTokenEnvVar:  {},
@@ -118,7 +110,6 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	if err != nil {
 		return nil, fmt.Errorf("resolve agent mounts: %w", err)
 	}
-	agentMounts, workspaceMount, homeMount, platformVolumes := ensureAgentDirMounts(agentMounts)
 	agentImagePullAttachments, err := a.listImagePullSecretAttachments(ctx, &agentsv1.ListImagePullSecretAttachmentsRequest{AgentId: agentID.String()})
 	if err != nil {
 		return nil, fmt.Errorf("list agent image pull secret attachments: %w", err)
@@ -143,8 +134,6 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		Env:    mainEnv,
 		Mounts: mainMounts,
 	}
-
-	permissionsInitContainer := buildAgentPermissionsInitContainer(workspaceMount, homeMount)
 	initContainer := &runnerv1.ContainerSpec{
 		Image: initImage,
 		Name:  "agent-init",
@@ -152,7 +141,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			{Volume: agynBinVolumeName, MountPath: agynBinMountPath},
 		},
 	}
-	initContainers := []*runnerv1.ContainerSpec{permissionsInitContainer, initContainer}
+	initContainers := []*runnerv1.ContainerSpec{initContainer}
 
 	mcps, err := a.listMcps(ctx, agentID)
 	if err != nil {
@@ -239,7 +228,6 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		Kind: runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL,
 	}
 	volumes := append(volumeResolver.Specs(), agynBinVolume)
-	volumes = append(volumes, platformVolumes...)
 	if a.cfg.ZitiEnabled {
 		volumes = append(volumes, &runnerv1.VolumeSpec{
 			Name: zitiIdentityVolumeName,
@@ -598,51 +586,6 @@ func appendPlatformEnvVar(envs []*runnerv1.EnvVar, env *runnerv1.EnvVar) []*runn
 	return result
 }
 
-func ensureAgentDirMounts(mounts []*runnerv1.VolumeMount) ([]*runnerv1.VolumeMount, *runnerv1.VolumeMount, *runnerv1.VolumeMount, []*runnerv1.VolumeSpec) {
-	workspaceMount := findMountByPath(mounts, agentWorkspaceDir)
-	homeMount := findMountByPath(mounts, agentHomeDir)
-	platformVolumes := []*runnerv1.VolumeSpec{}
-	if workspaceMount == nil {
-		workspaceMount = &runnerv1.VolumeMount{Volume: agentWorkspaceVolumeName, MountPath: agentWorkspaceDir}
-		mounts = append(mounts, workspaceMount)
-		platformVolumes = append(platformVolumes, &runnerv1.VolumeSpec{Name: agentWorkspaceVolumeName, Kind: runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL})
-	}
-	if homeMount == nil {
-		homeMount = &runnerv1.VolumeMount{Volume: agentHomeVolumeName, MountPath: agentHomeDir}
-		mounts = append(mounts, homeMount)
-		platformVolumes = append(platformVolumes, &runnerv1.VolumeSpec{Name: agentHomeVolumeName, Kind: runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL})
-	}
-	return mounts, workspaceMount, homeMount, platformVolumes
-}
-
-func findMountByPath(mounts []*runnerv1.VolumeMount, path string) *runnerv1.VolumeMount {
-	for _, mount := range mounts {
-		if mount == nil {
-			panic("assembler: nil volume mount")
-		}
-		if mount.MountPath == path {
-			return mount
-		}
-	}
-	return nil
-}
-
-func buildAgentPermissionsInitContainer(workspaceMount, homeMount *runnerv1.VolumeMount) *runnerv1.ContainerSpec {
-	return &runnerv1.ContainerSpec{
-		Image: agentPermissionsInitImage,
-		Name:  agentPermissionsInitContainerName,
-		Cmd:   []string{"/bin/sh", "-c", agentPermissionsInitCommand()},
-		Mounts: []*runnerv1.VolumeMount{
-			{Volume: workspaceMount.Volume, MountPath: workspaceMount.MountPath},
-			{Volume: homeMount.Volume, MountPath: homeMount.MountPath},
-		},
-	}
-}
-
-func agentPermissionsInitCommand() string {
-	return fmt.Sprintf("mkdir -p %s %s && chmod 1777 %s && chmod 0777 %s", agentWorkspaceDir, agentHomeDir, agentWorkspaceDir, agentHomeDir)
-}
-
 func (a *Assembler) baseAgentEnvVars(agent *agentsv1.Agent, agentID, threadID uuid.UUID) []*runnerv1.EnvVar {
 	gatewayURL := buildGatewayURL(a.cfg.AgentGatewayAddress)
 	vars := []*runnerv1.EnvVar{
@@ -655,8 +598,6 @@ func (a *Assembler) baseAgentEnvVars(agent *agentsv1.Agent, agentID, threadID uu
 		{Name: "GATEWAY_ADDRESS", Value: a.cfg.AgentGatewayAddress},
 		{Name: "AGYN_GATEWAY_URL", Value: gatewayURL},
 		{Name: "LLM_BASE_URL", Value: a.cfg.AgentLLMBaseURL},
-		{Name: "WORKSPACE_DIR", Value: agentWorkspaceDir},
-		{Name: "HOME", Value: agentHomeDir},
 	}
 	if a.cfg.AgentTracingAddress != "" {
 		vars = append(vars, &runnerv1.EnvVar{Name: "TRACING_ADDRESS", Value: a.cfg.AgentTracingAddress})

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -45,10 +45,6 @@ const (
 	platformNamespaceFallback            = "platform"
 	serviceAccountNamespacePath          = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 	agnTokenCountingEnvVar               = "AGN_TOKEN_COUNTING_ADDRESS"
-	agnWrapperContainerName              = "agn-wrapper"
-	agnWrapperImage                      = "busybox:1.37.0"
-	agnBinaryPath                        = "/agyn-bin/agn"
-	agnRealBinaryPath                    = "/agyn-bin/agn.real"
 )
 
 var reservedEnvNames = map[string]struct{}{
@@ -154,15 +150,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			{Volume: agynBinVolumeName, MountPath: agynBinMountPath},
 		},
 	}
-	agentWrapper := &runnerv1.ContainerSpec{
-		Image: agnWrapperImage,
-		Name:  agnWrapperContainerName,
-		Cmd:   buildAgnWrapperCommand(),
-		Mounts: []*runnerv1.VolumeMount{
-			{Volume: agynBinVolumeName, MountPath: agynBinMountPath},
-		},
-	}
-	initContainers := []*runnerv1.ContainerSpec{initContainer, agentWrapper}
+	initContainers := []*runnerv1.ContainerSpec{initContainer}
 	if a.cfg.ZitiEnabled {
 		gatewayHostname, err := gatewayHost(a.cfg.AgentGatewayAddress)
 		if err != nil {
@@ -182,7 +170,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			Name:  zitiGatewayWaitContainerName,
 			Cmd:   buildZitiGatewayWaitCommand(gatewayHostname),
 		}
-		initContainers = []*runnerv1.ContainerSpec{zitiSidecar, zitiGatewayWait, initContainer, agentWrapper}
+		initContainers = []*runnerv1.ContainerSpec{zitiSidecar, zitiGatewayWait, initContainer}
 	}
 
 	mcps, err := a.listMcps(ctx, agentID)
@@ -613,36 +601,6 @@ func buildZitiGatewayWaitCommand(host string) []string {
 		zitiDNSNameserver,
 		host,
 	)
-	return []string{"/bin/sh", "-c", script}
-}
-
-func buildAgnWrapperCommand() []string {
-	script := fmt.Sprintf(`set -e
-if [ ! -x %s ]; then
-  exit 0
-fi
-if [ ! -f %s ]; then
-  mv %s %s
-fi
-cat > %s <<'EOF'
-#!/bin/sh
-set -e
-config_path="${AGN_CONFIG_PATH:-}"
-if [ -n "$config_path" ] && [ -f "$config_path" ]; then
-  if grep -Eq '^[[:space:]]*system_prompt:[[:space:]]*assistant[[:space:]]*$' "$config_path"; then
-    tmp="${config_path}.agn.tmp"
-    awk '
-      /^[[:space:]]*system_prompt:[[:space:]]*assistant[[:space:]]*$/ {
-        sub(/assistant[[:space:]]*$/, "\"\"")
-      }
-      { print }
-    ' "$config_path" > "$tmp" && mv "$tmp" "$config_path"
-  fi
-fi
-exec %s "$@"
-EOF
-chmod +x %s
-`, agnBinaryPath, agnRealBinaryPath, agnBinaryPath, agnRealBinaryPath, agnBinaryPath, agnRealBinaryPath, agnBinaryPath)
 	return []string{"/bin/sh", "-c", script}
 }
 

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,6 +38,9 @@ const (
 	zitiRestartPolicyAlways              = "Always"
 	zitiDNSSearchService                 = "svc.cluster.local"
 	zitiDNSSearchCluster                 = "cluster.local"
+	zitiGatewayWaitContainerName         = "ziti-gateway-wait"
+	zitiGatewayWaitImage                 = "busybox:1.37.0"
+	zitiGatewayWaitTimeoutSeconds        = 60
 )
 
 var reservedEnvNames = map[string]struct{}{
@@ -143,6 +147,10 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}
 	initContainers := []*runnerv1.ContainerSpec{initContainer}
 	if a.cfg.ZitiEnabled {
+		gatewayHostname, err := gatewayHost(a.cfg.AgentGatewayAddress)
+		if err != nil {
+			return nil, err
+		}
 		zitiSidecar := &runnerv1.ContainerSpec{
 			Image:                a.cfg.ZitiSidecarImage,
 			Name:                 ZitiSidecarContainerName,
@@ -152,7 +160,12 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
 			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},
 		}
-		initContainers = append([]*runnerv1.ContainerSpec{zitiSidecar}, initContainers...)
+		zitiGatewayWait := &runnerv1.ContainerSpec{
+			Image: zitiGatewayWaitImage,
+			Name:  zitiGatewayWaitContainerName,
+			Cmd:   buildZitiGatewayWaitCommand(gatewayHostname),
+		}
+		initContainers = []*runnerv1.ContainerSpec{zitiSidecar, zitiGatewayWait, initContainer}
 	}
 
 	mcps, err := a.listMcps(ctx, agentID)
@@ -544,6 +557,28 @@ func buildGatewayURL(address string) string {
 		return address
 	}
 	return "http://" + address
+}
+
+func gatewayHost(address string) (string, error) {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", fmt.Errorf("parse gateway host from %q: %w", address, err)
+	}
+	if host == "" {
+		return "", fmt.Errorf("gateway host missing from %q", address)
+	}
+	return host, nil
+}
+
+func buildZitiGatewayWaitCommand(host string) []string {
+	script := fmt.Sprintf(
+		"i=0; while [ $i -lt %d ]; do nslookup %s %s >/dev/null 2>&1 && exit 0; i=$((i+1)); sleep 1; done; echo \"timeout waiting for %s\" >&2; exit 1",
+		zitiGatewayWaitTimeoutSeconds,
+		host,
+		zitiDNSNameserver,
+		host,
+	)
+	return []string{"/bin/sh", "-c", script}
 }
 
 func mergeEnvVars(platformEnv, userEnv []*runnerv1.EnvVar, owner string) []*runnerv1.EnvVar {

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -41,6 +42,9 @@ const (
 	zitiGatewayWaitContainerName         = "ziti-gateway-wait"
 	zitiGatewayWaitImage                 = "busybox:1.37.0"
 	zitiGatewayWaitTimeoutSeconds        = 60
+	platformNamespaceFallback            = "platform"
+	serviceAccountNamespacePath          = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	agnTokenCountingEnvVar               = "AGN_TOKEN_COUNTING_ADDRESS"
 )
 
 var reservedEnvNames = map[string]struct{}{
@@ -55,6 +59,7 @@ var reservedEnvNames = map[string]struct{}{
 	"AGYN_GATEWAY_URL":         {},
 	"LLM_BASE_URL":             {},
 	"TRACING_ADDRESS":          {},
+	agnTokenCountingEnvVar:     {},
 	"AGENT_MCP_SERVERS":        {},
 	"MCP_PORT":                 {},
 	ZitiEnrollmentTokenEnvVar:  {},
@@ -559,6 +564,24 @@ func buildGatewayURL(address string) string {
 	return "http://" + address
 }
 
+func platformNamespace() string {
+	data, err := os.ReadFile(serviceAccountNamespacePath)
+	if err != nil {
+		log.Printf("assembler: warn: read namespace: %v", err)
+		return platformNamespaceFallback
+	}
+	namespace := strings.TrimSpace(string(data))
+	if namespace == "" {
+		log.Printf("assembler: warn: namespace empty")
+		return platformNamespaceFallback
+	}
+	return namespace
+}
+
+func tokenCountingAddress() string {
+	return fmt.Sprintf("token-counting.%s.svc.cluster.local:50051", platformNamespace())
+}
+
 func gatewayHost(address string) (string, error) {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
@@ -631,6 +654,7 @@ func (a *Assembler) baseAgentEnvVars(agent *agentsv1.Agent, agentID, threadID uu
 		{Name: "GATEWAY_ADDRESS", Value: a.cfg.AgentGatewayAddress},
 		{Name: "AGYN_GATEWAY_URL", Value: gatewayURL},
 		{Name: "LLM_BASE_URL", Value: a.cfg.AgentLLMBaseURL},
+		{Name: agnTokenCountingEnvVar, Value: tokenCountingAddress()},
 	}
 	if a.cfg.AgentTracingAddress != "" {
 		vars = append(vars, &runnerv1.EnvVar{Name: "TRACING_ADDRESS", Value: a.cfg.AgentTracingAddress})

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -45,6 +45,10 @@ const (
 	platformNamespaceFallback            = "platform"
 	serviceAccountNamespacePath          = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 	agnTokenCountingEnvVar               = "AGN_TOKEN_COUNTING_ADDRESS"
+	agnWrapperContainerName              = "agn-wrapper"
+	agnWrapperImage                      = "busybox:1.37.0"
+	agnBinaryPath                        = "/agyn-bin/agn"
+	agnRealBinaryPath                    = "/agyn-bin/agn.real"
 )
 
 var reservedEnvNames = map[string]struct{}{
@@ -150,7 +154,15 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			{Volume: agynBinVolumeName, MountPath: agynBinMountPath},
 		},
 	}
-	initContainers := []*runnerv1.ContainerSpec{initContainer}
+	agentWrapper := &runnerv1.ContainerSpec{
+		Image: agnWrapperImage,
+		Name:  agnWrapperContainerName,
+		Cmd:   buildAgnWrapperCommand(),
+		Mounts: []*runnerv1.VolumeMount{
+			{Volume: agynBinVolumeName, MountPath: agynBinMountPath},
+		},
+	}
+	initContainers := []*runnerv1.ContainerSpec{initContainer, agentWrapper}
 	if a.cfg.ZitiEnabled {
 		gatewayHostname, err := gatewayHost(a.cfg.AgentGatewayAddress)
 		if err != nil {
@@ -170,7 +182,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			Name:  zitiGatewayWaitContainerName,
 			Cmd:   buildZitiGatewayWaitCommand(gatewayHostname),
 		}
-		initContainers = []*runnerv1.ContainerSpec{zitiSidecar, zitiGatewayWait, initContainer}
+		initContainers = []*runnerv1.ContainerSpec{zitiSidecar, zitiGatewayWait, initContainer, agentWrapper}
 	}
 
 	mcps, err := a.listMcps(ctx, agentID)
@@ -601,6 +613,36 @@ func buildZitiGatewayWaitCommand(host string) []string {
 		zitiDNSNameserver,
 		host,
 	)
+	return []string{"/bin/sh", "-c", script}
+}
+
+func buildAgnWrapperCommand() []string {
+	script := fmt.Sprintf(`set -e
+if [ ! -x %s ]; then
+  exit 0
+fi
+if [ ! -f %s ]; then
+  mv %s %s
+fi
+cat > %s <<'EOF'
+#!/bin/sh
+set -e
+config_path="${AGN_CONFIG_PATH:-}"
+if [ -n "$config_path" ] && [ -f "$config_path" ]; then
+  if grep -Eq '^[[:space:]]*system_prompt:[[:space:]]*assistant[[:space:]]*$' "$config_path"; then
+    tmp="${config_path}.agn.tmp"
+    awk '
+      /^[[:space:]]*system_prompt:[[:space:]]*assistant[[:space:]]*$/ {
+        sub(/assistant[[:space:]]*$/, "\"\"")
+      }
+      { print }
+    ' "$config_path" > "$tmp" && mv "$tmp" "$config_path"
+  fi
+fi
+exec %s "$@"
+EOF
+chmod +x %s
+`, agnBinaryPath, agnRealBinaryPath, agnBinaryPath, agnRealBinaryPath, agnBinaryPath, agnRealBinaryPath, agnBinaryPath)
 	return []string{"/bin/sh", "-c", script}
 }
 

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -142,6 +142,18 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		},
 	}
 	initContainers := []*runnerv1.ContainerSpec{initContainer}
+	if a.cfg.ZitiEnabled {
+		zitiSidecar := &runnerv1.ContainerSpec{
+			Image:                a.cfg.ZitiSidecarImage,
+			Name:                 ZitiSidecarContainerName,
+			Cmd:                  []string{zitiSidecarCommand, "--dnsUpstream", fmt.Sprintf("udp://%s:53", a.cfg.ClusterDNS)},
+			Env:                  []*runnerv1.EnvVar{{Name: ZitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename}},
+			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
+			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
+			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},
+		}
+		initContainers = append([]*runnerv1.ContainerSpec{zitiSidecar}, initContainers...)
+	}
 
 	mcps, err := a.listMcps(ctx, agentID)
 	if err != nil {
@@ -184,9 +196,6 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}
 
 	sidecarCapacity := len(mcpAssignments) + len(hookAssignments)
-	if a.cfg.ZitiEnabled {
-		sidecarCapacity++
-	}
 	sidecars := make([]*runnerv1.ContainerSpec, 0, sidecarCapacity)
 	mcpServers := make([]string, 0, len(mcpAssignments))
 	for _, assignment := range mcpAssignments {
@@ -203,17 +212,6 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			return nil, err
 		}
 		sidecars = append(sidecars, sidecar)
-	}
-	if a.cfg.ZitiEnabled {
-		sidecars = append(sidecars, &runnerv1.ContainerSpec{
-			Image:                a.cfg.ZitiSidecarImage,
-			Name:                 ZitiSidecarContainerName,
-			Cmd:                  []string{zitiSidecarCommand, "--dnsUpstream", fmt.Sprintf("udp://%s:53", a.cfg.ClusterDNS)},
-			Env:                  []*runnerv1.EnvVar{{Name: ZitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename}},
-			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
-			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
-			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},
-		})
 	}
 	if len(mcpServers) > 0 {
 		main.Env = appendPlatformEnvVar(main.Env, &runnerv1.EnvVar{Name: "AGENT_MCP_SERVERS", Value: strings.Join(mcpServers, ",")})

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -208,7 +208,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		sidecars = append(sidecars, &runnerv1.ContainerSpec{
 			Image:                a.cfg.ZitiSidecarImage,
 			Name:                 ZitiSidecarContainerName,
-			Cmd:                  []string{zitiSidecarCommand},
+			Cmd:                  []string{zitiSidecarCommand, "--dnsUpstream", fmt.Sprintf("udp://%s:53", a.cfg.ClusterDNS)},
 			Env:                  []*runnerv1.EnvVar{{Name: ZitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename}},
 			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 
@@ -338,11 +339,17 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(request.DnsConfig.Searches, expectedSearches) {
 		t.Fatalf("expected dns searches %+v, got %+v", expectedSearches, request.DnsConfig.Searches)
 	}
-	if len(request.InitContainers) != 2 {
-		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 3 {
+		t.Fatalf("expected 3 init containers, got %d", len(request.InitContainers))
 	}
 	if request.InitContainers[0].GetName() != ZitiSidecarContainerName {
 		t.Fatalf("expected %s to be first init container", ZitiSidecarContainerName)
+	}
+	if request.InitContainers[1].GetName() != zitiGatewayWaitContainerName {
+		t.Fatalf("expected %s to be second init container", zitiGatewayWaitContainerName)
+	}
+	if request.InitContainers[2].GetName() != "agent-init" {
+		t.Fatalf("expected agent-init to be third init container")
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
@@ -385,6 +392,21 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	}
 	if zitiMount.MountPath != zitiIdentityMountPath {
 		t.Fatalf("expected ziti mount path %q, got %q", zitiIdentityMountPath, zitiMount.MountPath)
+	}
+	zitiGatewayWait := testutil.FindInitContainer(request.InitContainers, zitiGatewayWaitContainerName)
+	if zitiGatewayWait == nil {
+		t.Fatal("expected ziti-gateway-wait init container")
+	}
+	if zitiGatewayWait.Image != zitiGatewayWaitImage {
+		t.Fatalf("expected ziti gateway wait image %q, got %q", zitiGatewayWaitImage, zitiGatewayWait.Image)
+	}
+	gatewayHost, _, err := net.SplitHostPort(cfg.AgentGatewayAddress)
+	if err != nil {
+		t.Fatalf("parse gateway host: %v", err)
+	}
+	expectedWaitCmd := buildZitiGatewayWaitCommand(gatewayHost)
+	if !equalStringSlice(zitiGatewayWait.Cmd, expectedWaitCmd) {
+		t.Fatalf("expected ziti gateway wait cmd %+v, got %+v", expectedWaitCmd, zitiGatewayWait.Cmd)
 	}
 	if len(request.Volumes) != 2 {
 		t.Fatalf("expected 2 volumes, got %d", len(request.Volumes))

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -166,6 +166,7 @@ func TestAssemblerMainContainer(t *testing.T) {
 	assertEnv(t, envs, "GATEWAY_ADDRESS", cfg.AgentGatewayAddress)
 	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://"+cfg.AgentGatewayAddress)
 	assertEnv(t, envs, "LLM_BASE_URL", cfg.AgentLLMBaseURL)
+	assertEnv(t, envs, agnTokenCountingEnvVar, fmt.Sprintf("token-counting.%s.svc.cluster.local:50051", platformNamespaceFallback))
 	assertEnv(t, envs, "TRACING_ADDRESS", cfg.AgentTracingAddress)
 	assertEnv(t, envs, "WORKSPACE_DIR", "/override")
 	assertEnv(t, envs, "HOME", "/override-home")
@@ -466,6 +467,7 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 	assertEnv(t, envs, "GATEWAY_ADDRESS", "gateway.ziti:443")
 	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://gateway.ziti:443")
 	assertEnv(t, envs, "LLM_BASE_URL", "http://llm-proxy.ziti/v1")
+	assertEnv(t, envs, agnTokenCountingEnvVar, fmt.Sprintf("token-counting.%s.svc.cluster.local:50051", platformNamespaceFallback))
 }
 
 func TestAssemblerInitImageOverride(t *testing.T) {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -338,19 +338,22 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(request.DnsConfig.Searches, expectedSearches) {
 		t.Fatalf("expected dns searches %+v, got %+v", expectedSearches, request.DnsConfig.Searches)
 	}
-	if len(request.InitContainers) != 1 {
-		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 2 {
+		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
+	}
+	if request.InitContainers[0].GetName() != ZitiSidecarContainerName {
+		t.Fatalf("expected %s to be first init container", ZitiSidecarContainerName)
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
 		t.Fatal("expected agent-init container")
 	}
-	if len(request.Sidecars) != 1 {
-		t.Fatalf("expected 1 sidecar, got %d", len(request.Sidecars))
+	if len(request.Sidecars) != 0 {
+		t.Fatalf("expected 0 sidecars, got %d", len(request.Sidecars))
 	}
-	zitiSidecar := testutil.FindContainer(request.Sidecars, ZitiSidecarContainerName)
+	zitiSidecar := testutil.FindInitContainer(request.InitContainers, ZitiSidecarContainerName)
 	if zitiSidecar == nil {
-		t.Fatal("expected ziti-sidecar container")
+		t.Fatal("expected ziti-sidecar init container")
 	}
 	if zitiSidecar.Image != cfg.ZitiSidecarImage {
 		t.Fatalf("expected ziti sidecar image %q, got %q", cfg.ZitiSidecarImage, zitiSidecar.Image)

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -122,8 +122,8 @@ func TestAssemblerMainContainer(t *testing.T) {
 	if request.ImagePullCredentials != nil {
 		t.Fatalf("expected no image pull credentials, got %+v", request.ImagePullCredentials)
 	}
-	if len(request.InitContainers) != 2 {
-		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
@@ -140,13 +140,6 @@ func TestAssemblerMainContainer(t *testing.T) {
 	}
 	if initContainer.Mounts[0].MountPath != agynBinMountPath {
 		t.Fatalf("expected init container agyn-bin mount path %q, got %q", agynBinMountPath, initContainer.Mounts[0].MountPath)
-	}
-	agentWrapper := testutil.FindInitContainer(request.InitContainers, agnWrapperContainerName)
-	if agentWrapper == nil {
-		t.Fatal("expected agn wrapper init container")
-	}
-	if agentWrapper.Image != agnWrapperImage {
-		t.Fatalf("expected agn wrapper image %q, got %q", agnWrapperImage, agentWrapper.Image)
 	}
 	labels := request.AdditionalProperties
 	if len(labels) == 0 {
@@ -269,8 +262,8 @@ func TestAssemblerReusesWorkspaceMount(t *testing.T) {
 	if countMountsByPath(request.Main.Mounts, workspacePath) != 1 {
 		t.Fatalf("expected one workspace mount, got %d", countMountsByPath(request.Main.Mounts, workspacePath))
 	}
-	if len(request.InitContainers) != 2 {
-		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
 	}
 }
 
@@ -347,8 +340,8 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(request.DnsConfig.Searches, expectedSearches) {
 		t.Fatalf("expected dns searches %+v, got %+v", expectedSearches, request.DnsConfig.Searches)
 	}
-	if len(request.InitContainers) != 4 {
-		t.Fatalf("expected 4 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 3 {
+		t.Fatalf("expected 3 init containers, got %d", len(request.InitContainers))
 	}
 	if request.InitContainers[0].GetName() != ZitiSidecarContainerName {
 		t.Fatalf("expected %s to be first init container", ZitiSidecarContainerName)
@@ -358,9 +351,6 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	}
 	if request.InitContainers[2].GetName() != "agent-init" {
 		t.Fatalf("expected agent-init to be third init container")
-	}
-	if request.InitContainers[3].GetName() != agnWrapperContainerName {
-		t.Fatalf("expected %s to be fourth init container", agnWrapperContainerName)
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
@@ -418,13 +408,6 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	expectedWaitCmd := buildZitiGatewayWaitCommand(gatewayHost)
 	if !equalStringSlice(zitiGatewayWait.Cmd, expectedWaitCmd) {
 		t.Fatalf("expected ziti gateway wait cmd %+v, got %+v", expectedWaitCmd, zitiGatewayWait.Cmd)
-	}
-	agentWrapper := testutil.FindInitContainer(request.InitContainers, agnWrapperContainerName)
-	if agentWrapper == nil {
-		t.Fatal("expected agn wrapper init container")
-	}
-	if agentWrapper.Image != agnWrapperImage {
-		t.Fatalf("expected agn wrapper image %q, got %q", agnWrapperImage, agentWrapper.Image)
 	}
 	if len(request.Volumes) != 2 {
 		t.Fatalf("expected 2 volumes, got %d", len(request.Volumes))
@@ -540,8 +523,8 @@ func TestAssemblerInitImageOverride(t *testing.T) {
 		t.Fatalf("assemble: %v", err)
 	}
 	request := result.Request
-	if len(request.InitContainers) != 2 {
-		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -122,8 +122,8 @@ func TestAssemblerMainContainer(t *testing.T) {
 	if request.ImagePullCredentials != nil {
 		t.Fatalf("expected no image pull credentials, got %+v", request.ImagePullCredentials)
 	}
-	if len(request.InitContainers) != 1 {
-		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 2 {
+		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
@@ -140,6 +140,13 @@ func TestAssemblerMainContainer(t *testing.T) {
 	}
 	if initContainer.Mounts[0].MountPath != agynBinMountPath {
 		t.Fatalf("expected init container agyn-bin mount path %q, got %q", agynBinMountPath, initContainer.Mounts[0].MountPath)
+	}
+	agentWrapper := testutil.FindInitContainer(request.InitContainers, agnWrapperContainerName)
+	if agentWrapper == nil {
+		t.Fatal("expected agn wrapper init container")
+	}
+	if agentWrapper.Image != agnWrapperImage {
+		t.Fatalf("expected agn wrapper image %q, got %q", agnWrapperImage, agentWrapper.Image)
 	}
 	labels := request.AdditionalProperties
 	if len(labels) == 0 {
@@ -262,8 +269,8 @@ func TestAssemblerReusesWorkspaceMount(t *testing.T) {
 	if countMountsByPath(request.Main.Mounts, workspacePath) != 1 {
 		t.Fatalf("expected one workspace mount, got %d", countMountsByPath(request.Main.Mounts, workspacePath))
 	}
-	if len(request.InitContainers) != 1 {
-		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 2 {
+		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
 	}
 }
 
@@ -340,8 +347,8 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(request.DnsConfig.Searches, expectedSearches) {
 		t.Fatalf("expected dns searches %+v, got %+v", expectedSearches, request.DnsConfig.Searches)
 	}
-	if len(request.InitContainers) != 3 {
-		t.Fatalf("expected 3 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 4 {
+		t.Fatalf("expected 4 init containers, got %d", len(request.InitContainers))
 	}
 	if request.InitContainers[0].GetName() != ZitiSidecarContainerName {
 		t.Fatalf("expected %s to be first init container", ZitiSidecarContainerName)
@@ -351,6 +358,9 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	}
 	if request.InitContainers[2].GetName() != "agent-init" {
 		t.Fatalf("expected agent-init to be third init container")
+	}
+	if request.InitContainers[3].GetName() != agnWrapperContainerName {
+		t.Fatalf("expected %s to be fourth init container", agnWrapperContainerName)
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
@@ -408,6 +418,13 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	expectedWaitCmd := buildZitiGatewayWaitCommand(gatewayHost)
 	if !equalStringSlice(zitiGatewayWait.Cmd, expectedWaitCmd) {
 		t.Fatalf("expected ziti gateway wait cmd %+v, got %+v", expectedWaitCmd, zitiGatewayWait.Cmd)
+	}
+	agentWrapper := testutil.FindInitContainer(request.InitContainers, agnWrapperContainerName)
+	if agentWrapper == nil {
+		t.Fatal("expected agn wrapper init container")
+	}
+	if agentWrapper.Image != agnWrapperImage {
+		t.Fatalf("expected agn wrapper image %q, got %q", agnWrapperImage, agentWrapper.Image)
 	}
 	if len(request.Volumes) != 2 {
 		t.Fatalf("expected 2 volumes, got %d", len(request.Volumes))
@@ -523,8 +540,8 @@ func TestAssemblerInitImageOverride(t *testing.T) {
 		t.Fatalf("assemble: %v", err)
 	}
 	request := result.Request
-	if len(request.InitContainers) != 1 {
-		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 2 {
+		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -47,6 +47,7 @@ func TestAssemblerMainContainer(t *testing.T) {
 					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "CUSTOM_ENV", Source: &agentsv1.Env_Value{Value: "custom"}},
 					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "AGENT_NAME", Source: &agentsv1.Env_Value{Value: "override"}},
 					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "WORKSPACE_DIR", Source: &agentsv1.Env_Value{Value: "/override"}},
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "HOME", Source: &agentsv1.Env_Value{Value: "/override-home"}},
 				}}, nil
 			}
 			return &agentsv1.ListEnvsResponse{}, nil
@@ -166,10 +167,8 @@ func TestAssemblerMainContainer(t *testing.T) {
 	assertEnv(t, envs, "LLM_BASE_URL", cfg.AgentLLMBaseURL)
 	assertEnv(t, envs, "TRACING_ADDRESS", cfg.AgentTracingAddress)
 	assertEnv(t, envs, "WORKSPACE_DIR", "/override")
+	assertEnv(t, envs, "HOME", "/override-home")
 	assertEnv(t, envs, "CUSTOM_ENV", "custom")
-	if _, ok := envs["HOME"]; ok {
-		t.Fatal("expected HOME to be absent")
-	}
 	if _, ok := envs["INIT_SCRIPT"]; ok {
 		t.Fatal("expected INIT_SCRIPT to be absent")
 	}

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -355,7 +355,7 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if zitiSidecar.Image != cfg.ZitiSidecarImage {
 		t.Fatalf("expected ziti sidecar image %q, got %q", cfg.ZitiSidecarImage, zitiSidecar.Image)
 	}
-	expectedCmd := []string{zitiSidecarCommand}
+	expectedCmd := []string{zitiSidecarCommand, "--dnsUpstream", fmt.Sprintf("udp://%s:53", cfg.ClusterDNS)}
 	if !equalStringSlice(zitiSidecar.Cmd, expectedCmd) {
 		t.Fatalf("expected ziti sidecar cmd %+v, got %+v", expectedCmd, zitiSidecar.Cmd)
 	}

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -97,8 +97,8 @@ func TestAssemblerMainContainer(t *testing.T) {
 	if !equalStringSlice(request.Main.Cmd, expectedCmd) {
 		t.Fatalf("unexpected main cmd: %+v", request.Main.Cmd)
 	}
-	if len(request.Main.Mounts) != 3 {
-		t.Fatalf("expected 3 mounts, got %d", len(request.Main.Mounts))
+	if len(request.Main.Mounts) != 1 {
+		t.Fatalf("expected 1 mount, got %d", len(request.Main.Mounts))
 	}
 	agynBinMount := findVolumeMount(request.Main, agynBinVolumeName)
 	if agynBinMount == nil {
@@ -107,22 +107,8 @@ func TestAssemblerMainContainer(t *testing.T) {
 	if agynBinMount.MountPath != agynBinMountPath {
 		t.Fatalf("expected agyn-bin mount path %q, got %q", agynBinMountPath, agynBinMount.MountPath)
 	}
-	workspaceMount := findVolumeMount(request.Main, agentWorkspaceVolumeName)
-	if workspaceMount == nil {
-		t.Fatalf("expected %s mount", agentWorkspaceVolumeName)
-	}
-	if workspaceMount.MountPath != agentWorkspaceDir {
-		t.Fatalf("expected workspace mount path %q, got %q", agentWorkspaceDir, workspaceMount.MountPath)
-	}
-	homeMount := findVolumeMount(request.Main, agentHomeVolumeName)
-	if homeMount == nil {
-		t.Fatalf("expected %s mount", agentHomeVolumeName)
-	}
-	if homeMount.MountPath != agentHomeDir {
-		t.Fatalf("expected home mount path %q, got %q", agentHomeDir, homeMount.MountPath)
-	}
-	if len(request.Volumes) != 3 {
-		t.Fatalf("expected 3 volumes, got %d", len(request.Volumes))
+	if len(request.Volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(request.Volumes))
 	}
 	agynBinVolume := findVolumeSpec(request.Volumes, agynBinVolumeName)
 	if agynBinVolume == nil {
@@ -131,50 +117,11 @@ func TestAssemblerMainContainer(t *testing.T) {
 	if agynBinVolume.Kind != runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL {
 		t.Fatalf("expected agyn-bin volume kind ephemeral, got %v", agynBinVolume.Kind)
 	}
-	workspaceVolume := findVolumeSpec(request.Volumes, agentWorkspaceVolumeName)
-	if workspaceVolume == nil {
-		t.Fatalf("expected %s volume", agentWorkspaceVolumeName)
-	}
-	if workspaceVolume.Kind != runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL {
-		t.Fatalf("expected workspace volume kind ephemeral, got %v", workspaceVolume.Kind)
-	}
-	homeVolume := findVolumeSpec(request.Volumes, agentHomeVolumeName)
-	if homeVolume == nil {
-		t.Fatalf("expected %s volume", agentHomeVolumeName)
-	}
-	if homeVolume.Kind != runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL {
-		t.Fatalf("expected home volume kind ephemeral, got %v", homeVolume.Kind)
-	}
 	if request.ImagePullCredentials != nil {
 		t.Fatalf("expected no image pull credentials, got %+v", request.ImagePullCredentials)
 	}
-	if len(request.InitContainers) != 2 {
-		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
-	}
-	permissionsContainer := testutil.FindInitContainer(request.InitContainers, agentPermissionsInitContainerName)
-	if permissionsContainer == nil {
-		t.Fatalf("expected %s init container", agentPermissionsInitContainerName)
-	}
-	if permissionsContainer.Image != agentPermissionsInitImage {
-		t.Fatalf("expected permissions init image %q, got %q", agentPermissionsInitImage, permissionsContainer.Image)
-	}
-	expectedPermissionsCmd := []string{"/bin/sh", "-c", fmt.Sprintf("mkdir -p %s %s && chmod 1777 %s && chmod 0777 %s", agentWorkspaceDir, agentHomeDir, agentWorkspaceDir, agentHomeDir)}
-	if !equalStringSlice(permissionsContainer.Cmd, expectedPermissionsCmd) {
-		t.Fatalf("expected permissions init cmd %+v, got %+v", expectedPermissionsCmd, permissionsContainer.Cmd)
-	}
-	workspacePermissionMount := findVolumeMount(permissionsContainer, agentWorkspaceVolumeName)
-	if workspacePermissionMount == nil {
-		t.Fatalf("expected permissions workspace mount")
-	}
-	if workspacePermissionMount.MountPath != agentWorkspaceDir {
-		t.Fatalf("expected permissions workspace mount path %q, got %q", agentWorkspaceDir, workspacePermissionMount.MountPath)
-	}
-	homePermissionMount := findVolumeMount(permissionsContainer, agentHomeVolumeName)
-	if homePermissionMount == nil {
-		t.Fatalf("expected permissions home mount")
-	}
-	if homePermissionMount.MountPath != agentHomeDir {
-		t.Fatalf("expected permissions home mount path %q, got %q", agentHomeDir, homePermissionMount.MountPath)
+	if len(request.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
@@ -218,9 +165,11 @@ func TestAssemblerMainContainer(t *testing.T) {
 	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://"+cfg.AgentGatewayAddress)
 	assertEnv(t, envs, "LLM_BASE_URL", cfg.AgentLLMBaseURL)
 	assertEnv(t, envs, "TRACING_ADDRESS", cfg.AgentTracingAddress)
-	assertEnv(t, envs, "WORKSPACE_DIR", agentWorkspaceDir)
-	assertEnv(t, envs, "HOME", agentHomeDir)
+	assertEnv(t, envs, "WORKSPACE_DIR", "/override")
 	assertEnv(t, envs, "CUSTOM_ENV", "custom")
+	if _, ok := envs["HOME"]; ok {
+		t.Fatal("expected HOME to be absent")
+	}
 	if _, ok := envs["INIT_SCRIPT"]; ok {
 		t.Fatal("expected INIT_SCRIPT to be absent")
 	}
@@ -234,6 +183,7 @@ func TestAssemblerReusesWorkspaceMount(t *testing.T) {
 	agentID := uuid.New()
 	threadID := uuid.New()
 	volumeID := uuid.New()
+	workspacePath := "/workspace"
 
 	agent := &agentsv1.Agent{
 		Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
@@ -275,7 +225,7 @@ func TestAssemblerReusesWorkspaceMount(t *testing.T) {
 			}
 			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{
 				Meta:      &agentsv1.EntityMeta{Id: volumeID.String()},
-				MountPath: agentWorkspaceDir,
+				MountPath: workspacePath,
 			}}, nil
 		},
 	}
@@ -292,35 +242,27 @@ func TestAssemblerReusesWorkspaceMount(t *testing.T) {
 	}
 	request := result.Request
 	workspaceVolumeName := "vol-" + volumeID.String()[:8]
-	if findVolumeSpec(request.Volumes, agentWorkspaceVolumeName) != nil {
-		t.Fatalf("expected no %s volume", agentWorkspaceVolumeName)
+	if len(request.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(request.Volumes))
+	}
+	if findVolumeSpec(request.Volumes, agynBinVolumeName) == nil {
+		t.Fatalf("expected %s volume", agynBinVolumeName)
 	}
 	if findVolumeSpec(request.Volumes, workspaceVolumeName) == nil {
 		t.Fatalf("expected %s volume", workspaceVolumeName)
 	}
-	if findVolumeSpec(request.Volumes, agentHomeVolumeName) == nil {
-		t.Fatalf("expected %s volume", agentHomeVolumeName)
-	}
-	workspaceMount := findMountByPath(request.Main.Mounts, agentWorkspaceDir)
+	workspaceMount := findMountByPath(request.Main.Mounts, workspacePath)
 	if workspaceMount == nil {
 		t.Fatalf("expected main workspace mount")
 	}
 	if workspaceMount.Volume != workspaceVolumeName {
 		t.Fatalf("expected workspace volume %q, got %q", workspaceVolumeName, workspaceMount.Volume)
 	}
-	if countMountsByPath(request.Main.Mounts, agentWorkspaceDir) != 1 {
-		t.Fatalf("expected one workspace mount, got %d", countMountsByPath(request.Main.Mounts, agentWorkspaceDir))
+	if countMountsByPath(request.Main.Mounts, workspacePath) != 1 {
+		t.Fatalf("expected one workspace mount, got %d", countMountsByPath(request.Main.Mounts, workspacePath))
 	}
-	permissionsContainer := testutil.FindInitContainer(request.InitContainers, agentPermissionsInitContainerName)
-	if permissionsContainer == nil {
-		t.Fatalf("expected %s init container", agentPermissionsInitContainerName)
-	}
-	permissionsMount := findMountByPath(permissionsContainer.Mounts, agentWorkspaceDir)
-	if permissionsMount == nil {
-		t.Fatalf("expected permissions workspace mount")
-	}
-	if permissionsMount.Volume != workspaceVolumeName {
-		t.Fatalf("expected permissions workspace volume %q, got %q", workspaceVolumeName, permissionsMount.Volume)
+	if len(request.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
 	}
 }
 
@@ -397,16 +339,12 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(request.DnsConfig.Searches, expectedSearches) {
 		t.Fatalf("expected dns searches %+v, got %+v", expectedSearches, request.DnsConfig.Searches)
 	}
-	if len(request.InitContainers) != 2 {
-		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
 		t.Fatal("expected agent-init container")
-	}
-	permissionsContainer := testutil.FindInitContainer(request.InitContainers, agentPermissionsInitContainerName)
-	if permissionsContainer == nil {
-		t.Fatalf("expected %s init container", agentPermissionsInitContainerName)
 	}
 	if len(request.Sidecars) != 1 {
 		t.Fatalf("expected 1 sidecar, got %d", len(request.Sidecars))
@@ -446,8 +384,8 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if zitiMount.MountPath != zitiIdentityMountPath {
 		t.Fatalf("expected ziti mount path %q, got %q", zitiIdentityMountPath, zitiMount.MountPath)
 	}
-	if len(request.Volumes) != 4 {
-		t.Fatalf("expected 4 volumes, got %d", len(request.Volumes))
+	if len(request.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(request.Volumes))
 	}
 	agynBinVolume := findVolumeSpec(request.Volumes, agynBinVolumeName)
 	if agynBinVolume == nil {
@@ -455,20 +393,6 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	}
 	if agynBinVolume.Kind != runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL {
 		t.Fatalf("expected agyn-bin volume kind ephemeral, got %v", agynBinVolume.Kind)
-	}
-	workspaceVolume := findVolumeSpec(request.Volumes, agentWorkspaceVolumeName)
-	if workspaceVolume == nil {
-		t.Fatalf("expected %s volume", agentWorkspaceVolumeName)
-	}
-	if workspaceVolume.Kind != runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL {
-		t.Fatalf("expected workspace volume kind ephemeral, got %v", workspaceVolume.Kind)
-	}
-	homeVolume := findVolumeSpec(request.Volumes, agentHomeVolumeName)
-	if homeVolume == nil {
-		t.Fatalf("expected %s volume", agentHomeVolumeName)
-	}
-	if homeVolume.Kind != runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL {
-		t.Fatalf("expected home volume kind ephemeral, got %v", homeVolume.Kind)
 	}
 	zitiIdentityVolume := findVolumeSpec(request.Volumes, zitiIdentityVolumeName)
 	if zitiIdentityVolume == nil {
@@ -573,8 +497,8 @@ func TestAssemblerInitImageOverride(t *testing.T) {
 		t.Fatalf("assemble: %v", err)
 	}
 	request := result.Request
-	if len(request.InitContainers) != 2 {
-		t.Fatalf("expected 2 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
@@ -582,10 +506,6 @@ func TestAssemblerInitImageOverride(t *testing.T) {
 	}
 	if initContainer.Image != agent.GetInitImage() {
 		t.Fatalf("expected init image %q, got %q", agent.GetInitImage(), initContainer.Image)
-	}
-	permissionsContainer := testutil.FindInitContainer(request.InitContainers, agentPermissionsInitContainerName)
-	if permissionsContainer == nil {
-		t.Fatalf("expected %s init container", agentPermissionsInitContainerName)
 	}
 }
 
@@ -794,8 +714,8 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 	if len(sidecar.Mounts) != 1 {
 		t.Fatalf("expected 1 mount, got %d", len(sidecar.Mounts))
 	}
-	if len(request.Volumes) != 4 {
-		t.Fatalf("expected 4 volumes, got %d", len(request.Volumes))
+	if len(request.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(request.Volumes))
 	}
 	expectedName := "vol-" + volumeID.String()[:8]
 	volumeSpec := findVolumeSpec(request.Volumes, expectedName)
@@ -893,8 +813,8 @@ func TestAssemblerSharesPersistentVolumeAcrossContainers(t *testing.T) {
 		t.Fatalf("assemble thread A: %v", err)
 	}
 	volumeName := "vol-" + volumeID.String()[:8]
-	if len(resultA.Request.Volumes) != 4 {
-		t.Fatalf("expected 4 volumes, got %d", len(resultA.Request.Volumes))
+	if len(resultA.Request.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(resultA.Request.Volumes))
 	}
 	volumeSpecA := findVolumeSpec(resultA.Request.Volumes, volumeName)
 	if volumeSpecA == nil {
@@ -1411,6 +1331,15 @@ func findVolumeMount(container *runnerv1.ContainerSpec, volumeName string) *runn
 	}
 	for _, mount := range container.Mounts {
 		if mount != nil && mount.GetVolume() == volumeName {
+			return mount
+		}
+	}
+	return nil
+}
+
+func findMountByPath(mounts []*runnerv1.VolumeMount, path string) *runnerv1.VolumeMount {
+	for _, mount := range mounts {
+		if mount != nil && mount.GetMountPath() == path {
 			return mount
 		}
 	}

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -76,7 +76,7 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if mainEnvs["WORKLOAD_ID"] != workloadID {
 				return nil, errors.New("missing WORKLOAD_ID")
 			}
-			zitiContainer := testutil.FindContainer(req.GetSidecars(), assembler.ZitiSidecarContainerName)
+			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
 			if zitiContainer == nil {
 				return nil, errors.New("missing ziti sidecar container")
 			}
@@ -216,7 +216,7 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			if mainEnvs["WORKLOAD_ID"] != workloadID {
 				return nil, errors.New("missing WORKLOAD_ID")
 			}
-			zitiContainer := testutil.FindContainer(req.GetSidecars(), assembler.ZitiSidecarContainerName)
+			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
 			if zitiContainer != nil {
 				envs := envMap(zitiContainer.GetEnv())
 				if _, ok := envs[assembler.ZitiEnrollmentTokenEnvVar]; ok {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -603,6 +603,12 @@ func failureSummary(failure *runnerv1.WorkloadFailure) string {
 }
 
 func attachZitiEnrollmentToken(request *runnerv1.StartWorkloadRequest, jwt string) error {
+	for _, container := range request.InitContainers {
+		if container.Name == assembler.ZitiSidecarContainerName {
+			container.Env = append(container.Env, &runnerv1.EnvVar{Name: assembler.ZitiEnrollmentTokenEnvVar, Value: jwt})
+			return nil
+		}
+	}
 	for _, container := range request.Sidecars {
 		if container.Name == assembler.ZitiSidecarContainerName {
 			container.Env = append(container.Env, &runnerv1.EnvVar{Name: assembler.ZitiEnrollmentTokenEnvVar, Value: jwt})


### PR DESCRIPTION
## Summary
- remove workspace/home env injection and reserved names
- drop platform workspace/home mounts and permissions init container
- update assembler tests for new mounts/volumes

## Testing
- buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1
- go vet ./...
- go test ./...

Fixes #157