### PR TITLE
feat(orchestrator): workload retry policy

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,9 +35,6 @@ jobs:
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@1aa5e1ad1f7ee6c874318e3049688408ad23e2eb
-        env:
-          AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.15
-          AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.15
         with:
           service: agents_orchestrator
 

--- a/internal/reconciler/degrade.go
+++ b/internal/reconciler/degrade.go
@@ -10,6 +10,7 @@ import (
 const (
 	degradeReasonRunnerDeprovisioned = "runner_deprovisioned"
 	degradeReasonVolumeLost          = "volume_lost"
+	degradeReasonStartFailures       = "agent_start_failures_exhausted"
 )
 
 type degradeTracker struct {

--- a/internal/reconciler/desired.go
+++ b/internal/reconciler/desired.go
@@ -18,43 +18,52 @@ type AgentThread struct {
 	ThreadID uuid.UUID
 }
 
-func (r *Reconciler) fetchDesired(ctx context.Context) ([]AgentThread, map[uuid.UUID]time.Duration, error) {
+func (r *Reconciler) fetchDesired(ctx context.Context) ([]AgentThread, map[uuid.UUID]time.Duration, map[uuid.UUID]time.Time, error) {
 	agents, err := r.listAgents(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	unique := make(map[AgentThread]struct{})
 	idleTimeouts := make(map[uuid.UUID]time.Duration, len(agents))
+	agentUpdatedAt := make(map[uuid.UUID]time.Time, len(agents))
 	for _, agent := range agents {
 		if agent == nil {
-			return nil, nil, fmt.Errorf("agent is nil")
+			return nil, nil, nil, fmt.Errorf("agent is nil")
 		}
 		meta := agent.GetMeta()
 		if meta == nil {
-			return nil, nil, fmt.Errorf("agent meta missing")
+			return nil, nil, nil, fmt.Errorf("agent meta missing")
 		}
 		agentID, err := uuidutil.ParseUUID(meta.GetId(), "agent.meta.id")
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		idleTimeout, err := agentIdleTimeout(agent, agentID, r.idle)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
+		}
+		updatedAt := meta.GetUpdatedAt()
+		if updatedAt == nil {
+			return nil, nil, nil, fmt.Errorf("agent %s updated_at missing", agentID.String())
 		}
 		idleTimeouts[agentID] = idleTimeout
+		agentUpdatedAt[agentID] = updatedAt.AsTime().UTC()
 		threadIDs, err := r.listUnackedThreads(ctx, agentID)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if len(threadIDs) == 0 {
 			continue
 		}
-		passiveThreads, err := r.fetchPassiveThreads(ctx, agentID)
+		passiveThreads, degradedThreads, err := r.fetchThreadParticipation(ctx, agentID)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		for _, threadID := range threadIDs {
 			if _, ok := passiveThreads[threadID]; ok {
+				continue
+			}
+			if _, ok := degradedThreads[threadID]; ok {
 				continue
 			}
 			unique[AgentThread{AgentID: agentID, ThreadID: threadID}] = struct{}{}
@@ -64,7 +73,7 @@ func (r *Reconciler) fetchDesired(ctx context.Context) ([]AgentThread, map[uuid.
 	for key := range unique {
 		result = append(result, key)
 	}
-	return result, idleTimeouts, nil
+	return result, idleTimeouts, agentUpdatedAt, nil
 }
 
 func agentIdleTimeout(agent *agentsv1.Agent, agentID uuid.UUID, fallback time.Duration) (time.Duration, error) {
@@ -131,11 +140,12 @@ func (r *Reconciler) listUnackedThreads(ctx context.Context, agentID uuid.UUID) 
 	}
 }
 
-func (r *Reconciler) fetchPassiveThreads(ctx context.Context, agentID uuid.UUID) (map[uuid.UUID]struct{}, error) {
+func (r *Reconciler) fetchThreadParticipation(ctx context.Context, agentID uuid.UUID) (map[uuid.UUID]struct{}, map[uuid.UUID]struct{}, error) {
 	passiveThreads := make(map[uuid.UUID]struct{})
+	degradedThreads := make(map[uuid.UUID]struct{})
 	runnerCtx, err := r.runnerIdentityContextForAgent(ctx, agentID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	token := ""
 	agentIDString := agentID.String()
@@ -146,27 +156,30 @@ func (r *Reconciler) fetchPassiveThreads(ctx context.Context, agentID uuid.UUID)
 			PageToken:     token,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("get threads for agent %s: %w", agentIDString, err)
+			return nil, nil, fmt.Errorf("get threads for agent %s: %w", agentIDString, err)
 		}
 		for _, thread := range page.GetThreads() {
 			if thread == nil {
-				return nil, fmt.Errorf("thread is nil")
+				return nil, nil, fmt.Errorf("thread is nil")
 			}
 			threadID, err := uuidutil.ParseUUID(thread.GetId(), "thread.id")
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			participant, err := findThreadParticipant(thread, agentID, threadID)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if participant.GetPassive() {
 				passiveThreads[threadID] = struct{}{}
 			}
+			if thread.GetStatus() == threadsv1.ThreadStatus_THREAD_STATUS_DEGRADED {
+				degradedThreads[threadID] = struct{}{}
+			}
 		}
 		token = page.GetNextPageToken()
 		if token == "" {
-			return passiveThreads, nil
+			return passiveThreads, degradedThreads, nil
 		}
 	}
 }

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -68,6 +68,9 @@ func (f *fakeThreadsClient) ListOrganizationThreads(ctx context.Context, req *th
 func (f *fakeThreadsClient) GetThread(context.Context, *threadsv1.GetThreadRequest, ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }
+func (f *fakeThreadsClient) ListOrganizationThreads(context.Context, *threadsv1.ListOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.ListOrganizationThreadsResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
 func (f *fakeThreadsClient) GetOrganizationThreads(context.Context, *threadsv1.GetOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.GetOrganizationThreadsResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }
@@ -147,6 +150,73 @@ func TestFetchDesiredSkipsPassiveThreads(t *testing.T) {
 
 	if !reflect.DeepEqual(result, expected) {
 		t.Fatalf("expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestFetchDesiredSkipsDegradedThreads(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	activeThreadID := uuid.New()
+	degradedThreadID := uuid.New()
+	otherParticipantID := uuid.New()
+
+	agents := &fakeAgentsClient{
+		listAgents: func(_ context.Context, _ *agentsv1.ListAgentsRequest, _ ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+			updatedAt := timestamppb.New(time.Now().UTC())
+			return &agentsv1.ListAgentsResponse{Agents: []*agentsv1.Agent{
+				{Meta: &agentsv1.EntityMeta{Id: agentID.String(), UpdatedAt: updatedAt}},
+			}}, nil
+		},
+	}
+
+	threads := &fakeThreadsClient{
+		getUnackedMessages: func(_ context.Context, req *threadsv1.GetUnackedMessagesRequest, _ ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error) {
+			if req.GetParticipantId() != agentID.String() {
+				return nil, errors.New("unexpected participant id")
+			}
+			return &threadsv1.GetUnackedMessagesResponse{Messages: []*threadsv1.Message{
+				{Id: uuid.NewString(), ThreadId: activeThreadID.String()},
+				{Id: uuid.NewString(), ThreadId: degradedThreadID.String()},
+			}}, nil
+		},
+		getThreads: func(_ context.Context, req *threadsv1.GetThreadsRequest, _ ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error) {
+			if req.GetParticipantId() != agentID.String() {
+				return nil, errors.New("unexpected participant id")
+			}
+			return &threadsv1.GetThreadsResponse{Threads: []*threadsv1.Thread{
+				{
+					Id: activeThreadID.String(),
+					Participants: []*threadsv1.Participant{
+						{Id: agentID.String(), Passive: false},
+						{Id: otherParticipantID.String(), Passive: false},
+					},
+				},
+				{
+					Id: degradedThreadID.String(),
+					Participants: []*threadsv1.Participant{
+						{Id: agentID.String(), Passive: false},
+						{Id: otherParticipantID.String(), Passive: false},
+					},
+					Status: threadsv1.ThreadStatus_THREAD_STATUS_DEGRADED,
+				},
+			}}, nil
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		Agents:  agents,
+		Threads: threads,
+	})
+
+	result, _, _, err := reconciler.fetchDesired(ctx)
+	if err != nil {
+		t.Fatalf("fetch desired: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 thread, got %d", len(result))
+	}
+	if result[0].ThreadID != activeThreadID {
+		t.Fatalf("expected thread %s, got %s", activeThreadID, result[0].ThreadID)
 	}
 }
 

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -68,9 +68,6 @@ func (f *fakeThreadsClient) ListOrganizationThreads(ctx context.Context, req *th
 func (f *fakeThreadsClient) GetThread(context.Context, *threadsv1.GetThreadRequest, ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }
-func (f *fakeThreadsClient) ListOrganizationThreads(context.Context, *threadsv1.ListOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.ListOrganizationThreadsResponse, error) {
-	return nil, testutil.ErrNotImplemented
-}
 func (f *fakeThreadsClient) GetOrganizationThreads(context.Context, *threadsv1.GetOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.GetOrganizationThreadsResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/agynio/agents-orchestrator/internal/testutil"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type fakeAgentsClient struct {
@@ -93,8 +95,9 @@ func TestFetchDesiredSkipsPassiveThreads(t *testing.T) {
 
 	agents := &fakeAgentsClient{
 		listAgents: func(_ context.Context, _ *agentsv1.ListAgentsRequest, _ ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+			updatedAt := timestamppb.New(time.Now().UTC())
 			return &agentsv1.ListAgentsResponse{Agents: []*agentsv1.Agent{
-				{Meta: &agentsv1.EntityMeta{Id: agentID.String()}},
+				{Meta: &agentsv1.EntityMeta{Id: agentID.String(), UpdatedAt: updatedAt}},
 			}}, nil
 		},
 	}
@@ -133,7 +136,7 @@ func TestFetchDesiredSkipsPassiveThreads(t *testing.T) {
 	}
 
 	reconciler := New(Config{Agents: agents, Threads: threads})
-	result, _, err := reconciler.fetchDesired(ctx)
+	result, _, _, err := reconciler.fetchDesired(ctx)
 	if err != nil {
 		t.Fatalf("fetch desired: %v", err)
 	}
@@ -154,8 +157,9 @@ func TestFetchDesiredSkipsPassiveLookupWithoutMessages(t *testing.T) {
 
 	agents := &fakeAgentsClient{
 		listAgents: func(_ context.Context, _ *agentsv1.ListAgentsRequest, _ ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+			updatedAt := timestamppb.New(time.Now().UTC())
 			return &agentsv1.ListAgentsResponse{Agents: []*agentsv1.Agent{
-				{Meta: &agentsv1.EntityMeta{Id: agentID.String()}},
+				{Meta: &agentsv1.EntityMeta{Id: agentID.String(), UpdatedAt: updatedAt}},
 			}}, nil
 		},
 	}
@@ -174,7 +178,7 @@ func TestFetchDesiredSkipsPassiveLookupWithoutMessages(t *testing.T) {
 	}
 
 	reconciler := New(Config{Agents: agents, Threads: threads})
-	result, _, err := reconciler.fetchDesired(ctx)
+	result, _, _, err := reconciler.fetchDesired(ctx)
 	if err != nil {
 		t.Fatalf("fetch desired: %v", err)
 	}

--- a/internal/reconciler/lifecycle_helpers.go
+++ b/internal/reconciler/lifecycle_helpers.go
@@ -28,15 +28,23 @@ func boolPtr(value bool) *bool {
 	return &value
 }
 
-func (r *Reconciler) markWorkloadFailed(ctx context.Context, workloadID string, instanceID *string) {
+func (r *Reconciler) markWorkloadFailed(ctx context.Context, workloadID string, instanceID *string, reason runnersv1.WorkloadFailureReason, message string, containers []*runnersv1.Container) {
 	status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED
+	reasonValue := reason
 	req := &runnersv1.UpdateWorkloadRequest{
-		Id:        workloadID,
-		Status:    &status,
-		RemovedAt: timestamppb.New(time.Now().UTC()),
+		Id:            workloadID,
+		Status:        &status,
+		RemovedAt:     timestamppb.New(time.Now().UTC()),
+		FailureReason: &reasonValue,
 	}
 	if instanceID != nil && *instanceID != "" {
 		req.InstanceId = instanceID
+	}
+	if message != "" {
+		req.FailureMessage = stringPtr(message)
+	}
+	if len(containers) > 0 {
+		req.Containers = containers
 	}
 	if _, err := r.runners.UpdateWorkload(ctx, req); err != nil {
 		log.Printf("reconciler: update workload %s to failed: %v", workloadID, err)

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -3,7 +3,6 @@ package reconciler
 import (
 	"context"
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -146,25 +145,14 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if req.GetId() != workloadID {
 				return nil, errors.New("unexpected workload id")
 			}
-			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+			if req.Status != nil {
 				return nil, errors.New("unexpected workload status")
 			}
 			if req.GetInstanceId() != workloadID {
 				return nil, errors.New("unexpected instance id")
 			}
-			if len(req.GetContainers()) != 1 {
+			if len(req.GetContainers()) != 0 {
 				return nil, errors.New("unexpected containers")
-			}
-			container := req.GetContainers()[0]
-			expectedName := fmt.Sprintf("agent-%s-%s", agentID.String()[:8], threadID.String()[:8])
-			if container.GetContainerId() != mainContainerID || container.GetRole() != runnersv1.ContainerRole_CONTAINER_ROLE_MAIN {
-				return nil, errors.New("unexpected main container")
-			}
-			if container.GetName() != expectedName {
-				return nil, errors.New("unexpected main container name")
-			}
-			if container.GetImage() != "agent-image" {
-				return nil, errors.New("unexpected main container image")
 			}
 			return &runnersv1.UpdateWorkloadResponse{}, nil
 		},
@@ -268,13 +256,13 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			if req.GetId() != workloadID {
 				return nil, errors.New("unexpected workload id")
 			}
-			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+			if req.Status != nil {
 				return nil, errors.New("unexpected workload status")
 			}
 			if req.GetInstanceId() != workloadID {
 				return nil, errors.New("unexpected instance id")
 			}
-			if len(req.GetContainers()) != 1 || req.GetContainers()[0].GetContainerId() != mainContainerID {
+			if len(req.GetContainers()) != 0 {
 				return nil, errors.New("unexpected containers")
 			}
 			return &runnersv1.UpdateWorkloadResponse{}, nil
@@ -511,6 +499,12 @@ func TestStartWorkloadDeletesIdentityOnRunnerError(t *testing.T) {
 			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
 				return nil, errors.New("unexpected workload status")
 			}
+			if req.GetFailureReason() != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED {
+				return nil, errors.New("unexpected failure reason")
+			}
+			if req.GetFailureMessage() != "runner error" {
+				return nil, errors.New("unexpected failure message")
+			}
 			if req.GetRemovedAt() == nil {
 				return nil, errors.New("missing removed_at")
 			}
@@ -620,6 +614,12 @@ func TestStartWorkloadRollsBackOnWorkloadIDMismatch(t *testing.T) {
 			}
 			if req.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
 				return nil, errors.New("unexpected workload status")
+			}
+			if req.GetFailureReason() != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED {
+				return nil, errors.New("unexpected failure reason")
+			}
+			if req.GetFailureMessage() != "workload id mismatch" {
+				return nil, errors.New("unexpected failure message")
 			}
 			if req.GetInstanceId() != instanceID {
 				return nil, errors.New("unexpected instance id")
@@ -829,6 +829,12 @@ func TestStopWorkloadMarksMissingRunnerOnNoTerminators(t *testing.T) {
 	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
 		t.Fatalf("unexpected workload status: %v", updateReq.GetStatus())
 	}
+	if updateReq.GetFailureReason() != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST {
+		t.Fatalf("unexpected failure reason: %v", updateReq.GetFailureReason())
+	}
+	if updateReq.GetFailureMessage() != "workload missing on runner" {
+		t.Fatalf("unexpected failure message: %v", updateReq.GetFailureMessage())
+	}
 	if updateReq.GetRemovedAt() == nil {
 		t.Fatal("expected removed_at")
 	}
@@ -936,6 +942,12 @@ func TestStopWorkloadMarksFailedWhenInstanceMissing(t *testing.T) {
 	}
 	if updateRequest.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
 		t.Fatalf("unexpected workload status: %v", updateRequest.GetStatus())
+	}
+	if updateRequest.GetFailureReason() != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST {
+		t.Fatalf("unexpected failure reason: %v", updateRequest.GetFailureReason())
+	}
+	if updateRequest.GetFailureMessage() != "missing instance id" {
+		t.Fatalf("unexpected failure message: %v", updateRequest.GetFailureMessage())
 	}
 	if updateRequest.GetRemovedAt() == nil {
 		t.Fatal("expected removed_at")

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -22,6 +22,7 @@ func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 	workloadKey := "workload-1"
 	rawInstanceID := uuid.New().String()
 	instanceID := "workload-" + rawInstanceID
+	createdAt := timestamppb.New(time.Date(2024, time.January, 1, 1, 2, 3, 0, time.UTC))
 	startTime := timestamppb.New(time.Date(2024, time.January, 1, 2, 3, 4, 0, time.UTC))
 	finishTime := timestamppb.New(time.Date(2024, time.January, 1, 3, 4, 5, 0, time.UTC))
 	reason := "Completed"
@@ -32,7 +33,7 @@ func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 	runners := &fakeRunnersClient{
 		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
 			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
-				{Meta: &runnersv1.EntityMeta{Id: workloadKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING},
+				{Meta: &runnersv1.EntityMeta{Id: workloadKey, CreatedAt: createdAt}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
@@ -259,12 +260,13 @@ func TestReconcileWorkloadsTransitionsStartingToRunningOnInspectError(t *testing
 	workloadKey := "workload-1"
 	rawInstanceID := uuid.New().String()
 	instanceID := "workload-" + rawInstanceID
+	createdAt := timestamppb.New(time.Date(2024, time.January, 1, 1, 2, 3, 0, time.UTC))
 
 	var updateReq *runnersv1.UpdateWorkloadRequest
 	runners := &fakeRunnersClient{
 		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
 			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
-				{Meta: &runnersv1.EntityMeta{Id: workloadKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING},
+				{Meta: &runnersv1.EntityMeta{Id: workloadKey, CreatedAt: createdAt}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING},
 			}}, nil
 		},
 		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
@@ -313,7 +315,7 @@ func TestReconcileWorkloadsTransitionsStartingToRunningOnInspectError(t *testing
 	if updateReq == nil {
 		t.Fatal("expected update workload")
 	}
-	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+	if updateReq.Status != nil {
 		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
 	}
 	if updateReq.GetInstanceId() != rawInstanceID {

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -10,6 +10,7 @@ import (
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
+	zitimgmtv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/agents-orchestrator/internal/testutil"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
@@ -251,6 +252,117 @@ func TestReconcileWorkloadsRefreshesContainersOnRunning(t *testing.T) {
 	}
 	if mainContainer.GetStartedAt().AsTime() != startTime.AsTime() {
 		t.Fatalf("unexpected main started_at")
+	}
+}
+
+func TestReconcileWorkloadsFailsCrashloop(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadKey := "workload-1"
+	rawInstanceID := uuid.New().String()
+	instanceID := "workload-" + rawInstanceID
+	zitiID := "ziti-identity"
+	message := "crashloop"
+
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING, InstanceId: stringPtr(rawInstanceID), ZitiIdentityId: zitiID},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	stopCalled := false
+	runner := &fakeRunnerClient{
+		listWorkloads: func(_ context.Context, _ *runnerv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnerv1.ListWorkloadsResponse, error) {
+			return &runnerv1.ListWorkloadsResponse{Workloads: []*runnerv1.WorkloadListItem{
+				{WorkloadKey: workloadKey, InstanceId: instanceID},
+			}}, nil
+		},
+		inspectWorkload: func(_ context.Context, req *runnerv1.InspectWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+			if req.GetWorkloadId() != rawInstanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return &runnerv1.InspectWorkloadResponse{Containers: []*runnerv1.WorkloadContainer{
+				{
+					ContainerId:  "main-id",
+					Name:         "main",
+					Role:         runnerv1.ContainerRole_CONTAINER_ROLE_MAIN,
+					Image:        "main-image",
+					Status:       runnerv1.ContainerStatus_CONTAINER_STATUS_WAITING,
+					Reason:       stringPtr(crashLoopBackoffFlag),
+					Message:      stringPtr(message),
+					RestartCount: crashloopThreshold,
+				},
+			}}, nil
+		},
+		stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+			if req.GetWorkloadId() != rawInstanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			stopCalled = true
+			return &runnerv1.StopWorkloadResponse{}, nil
+		},
+	}
+	deleteCalled := false
+	zitiMgmt := &fakeZitiMgmtClient{
+		deleteIdentity: func(_ context.Context, req *zitimgmtv1.DeleteIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.DeleteIdentityResponse, error) {
+			if req.GetZitiIdentityId() != zitiID {
+				return nil, errors.New("unexpected ziti identity id")
+			}
+			deleteCalled = true
+			return &zitimgmtv1.DeleteIdentityResponse{}, nil
+		},
+	}
+
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+		ZitiMgmt:     zitiMgmt,
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected update workload")
+	}
+	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
+		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
+	}
+	if updateReq.GetFailureReason() != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CRASHLOOP {
+		t.Fatalf("unexpected failure reason: %v", updateReq.GetFailureReason())
+	}
+	if updateReq.GetFailureMessage() != message {
+		t.Fatalf("unexpected failure message: %s", updateReq.GetFailureMessage())
+	}
+	if updateReq.GetInstanceId() != rawInstanceID {
+		t.Fatalf("unexpected instance id: %s", updateReq.GetInstanceId())
+	}
+	if !stopCalled {
+		t.Fatal("expected stop workload")
+	}
+	if !deleteCalled {
+		t.Fatal("expected delete identity")
 	}
 }
 
@@ -575,6 +687,63 @@ func TestReconcileWorkloadsMarksMissingRunnerOnNoTerminatorsListError(t *testing
 	}
 	if updateReq.GetRemovedAt() == nil {
 		t.Fatal("expected removed_at")
+	}
+}
+
+func TestReconcileWorkloadsMarksMissingRunnerOnMissingWorkload(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadID := "workload-1"
+	instanceID := uuid.New().String()
+
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadID}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING, InstanceId: stringPtr(instanceID)},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	runner := &fakeRunnerClient{
+		listWorkloads: func(_ context.Context, _ *runnerv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnerv1.ListWorkloadsResponse, error) {
+			return &runnerv1.ListWorkloadsResponse{}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected update workload")
+	}
+	if updateReq.GetFailureReason() != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST {
+		t.Fatalf("unexpected failure reason: %v", updateReq.GetFailureReason())
+	}
+	if updateReq.GetFailureMessage() != "workload missing on runner" {
+		t.Fatalf("unexpected failure message: %s", updateReq.GetFailureMessage())
 	}
 }
 

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -366,7 +366,7 @@ func TestReconcileWorkloadsFailsCrashloop(t *testing.T) {
 	}
 }
 
-func TestReconcileWorkloadsTransitionsStartingToRunningOnInspectError(t *testing.T) {
+func TestReconcileWorkloadsDoesNotPromoteStartingOnInspectError(t *testing.T) {
 	ctx := context.Background()
 	runnerID := "runner-1"
 	workloadKey := "workload-1"

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -112,7 +112,7 @@ func (r *Reconciler) runCycle(ctx context.Context) {
 }
 
 func (r *Reconciler) reconcile(ctx context.Context) error {
-	desired, idleTimeouts, err := r.fetchDesired(ctx)
+	desired, idleTimeouts, agentUpdatedAt, err := r.fetchDesired(ctx)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,16 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 		return err
 	}
 	degraded := newDegradeTracker()
+	now := time.Now().UTC()
 	for _, candidate := range actions.ToStart {
+		ok, err := r.shouldStartWorkload(ctx, candidate, now, agentUpdatedAt, degraded)
+		if err != nil {
+			log.Printf("reconciler: start decision for agent %s thread %s: %v", candidate.AgentID.String(), candidate.ThreadID.String(), err)
+			continue
+		}
+		if !ok {
+			continue
+		}
 		r.startWorkload(ctx, candidate, degraded)
 	}
 	for _, workload := range actions.ToStop {
@@ -279,28 +288,30 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 	resp, err := runnerClient.StartWorkload(runnerCtx, request)
 	if err != nil {
 		log.Printf("reconciler: start workload for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
-		r.markWorkloadFailed(runnerCtx, workloadIDValue, nil)
+		r.markWorkloadFailed(runnerCtx, workloadIDValue, nil, runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, err.Error(), nil)
 		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "start failure")
 		return
 	}
 	rawInstanceID := resp.GetId()
 	instanceID := normalizeRunnerWorkloadID(rawInstanceID)
+	containers := buildContainers(request, resp)
 	if resp.GetStatus() == runnerv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
-		log.Printf("reconciler: workload failed for agent %s thread %s: %s", target.AgentID.String(), target.ThreadID.String(), failureSummary(resp.GetFailure()))
+		failureMessage := failureSummary(resp.GetFailure())
+		log.Printf("reconciler: workload failed for agent %s thread %s: %s", target.AgentID.String(), target.ThreadID.String(), failureMessage)
 		if instanceID != "" {
 			if err := r.stopRunnerWorkload(runnerCtx, runnerClient, instanceID); err != nil {
 				log.Printf("reconciler: stop workload %s after failure: %v", instanceID, err)
 			}
 		}
-		r.markWorkloadFailed(runnerCtx, workloadIDValue, stringPtr(instanceID))
+		r.markWorkloadFailed(runnerCtx, workloadIDValue, stringPtr(instanceID), runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, failureMessage, containers)
 		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload failure")
 		return
 	}
 	if rawInstanceID == "" {
 		log.Printf("reconciler: workload started without id for agent %s thread %s", target.AgentID.String(), target.ThreadID.String())
-		r.markWorkloadFailed(runnerCtx, workloadIDValue, nil)
+		r.markWorkloadFailed(runnerCtx, workloadIDValue, nil, runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, "missing workload id", containers)
 		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "missing workload id")
 		return
@@ -311,30 +322,14 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 		if err := r.stopRunnerWorkload(runnerCtx, runnerClient, instanceID); err != nil {
 			log.Printf("reconciler: stop workload %s after id mismatch: %v", instanceID, err)
 		}
-		r.markWorkloadFailed(runnerCtx, workloadIDValue, stringPtr(instanceID))
+		r.markWorkloadFailed(runnerCtx, workloadIDValue, stringPtr(instanceID), runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, "workload id mismatch", containers)
 		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
 		r.compensateIdentity(ctx, zitiIdentityID, "workload id mismatch")
 		return
 	}
-	status, err := runnerStatus(resp.GetStatus())
-	if err != nil {
-		log.Printf("reconciler: map workload status for workload %s: %v", rawInstanceID, err)
-		if err := r.stopRunnerWorkload(runnerCtx, runnerClient, instanceID); err != nil {
-			log.Printf("reconciler: stop workload %s after status map failure: %v", instanceID, err)
-		}
-		r.markWorkloadFailed(runnerCtx, workloadIDValue, stringPtr(instanceID))
-		r.markVolumeRecordsFailed(runnerCtx, createdVolumes)
-		r.compensateIdentity(ctx, zitiIdentityID, "status map failure")
-		return
-	}
-	containers := buildContainers(request, resp)
 	updateReq := &runnersv1.UpdateWorkloadRequest{
 		Id:         workloadIDValue,
-		Status:     workloadStatusPtr(status),
 		InstanceId: stringPtr(instanceID),
-	}
-	if containers != nil {
-		updateReq.Containers = containers
 	}
 	if _, err := r.runners.UpdateWorkload(runnerCtx, updateReq); err != nil {
 		log.Printf("reconciler: update workload record %s after start: %v", workloadIDValue, err)
@@ -355,7 +350,7 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 	instanceID := normalizeRunnerWorkloadID(workload.GetInstanceId())
 	if instanceID == "" {
 		log.Printf("reconciler: workload %s missing instance id", workloadID)
-		r.markWorkloadFailed(runnerCtx, workloadID, nil)
+		r.markWorkloadFailed(runnerCtx, workloadID, nil, runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST, "missing instance id", nil)
 		return
 	}
 	runnerID := workload.GetRunnerId()

--- a/internal/reconciler/start_decision.go
+++ b/internal/reconciler/start_decision.go
@@ -1,0 +1,196 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/google/uuid"
+)
+
+const maxStartAttempts = 10
+
+var startBackoffSchedule = []time.Duration{
+	10 * time.Second,
+	30 * time.Second,
+	1 * time.Minute,
+	5 * time.Minute,
+	15 * time.Minute,
+}
+
+func (r *Reconciler) shouldStartWorkload(ctx context.Context, target AgentThread, now time.Time, agentUpdatedAt map[uuid.UUID]time.Time, degraded *degradeTracker) (bool, error) {
+	threadID := target.ThreadID.String()
+	agentID := target.AgentID.String()
+	active, err := r.listWorkloadsByThread(ctx, threadID, &agentID, []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING,
+	}, 1)
+	if err != nil {
+		return false, err
+	}
+	if len(active) > 0 {
+		return false, nil
+	}
+	latest, err := r.latestWorkloadByThread(ctx, threadID, &agentID, []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED,
+	})
+	if err != nil {
+		return false, err
+	}
+	if latest == nil || latest.GetStatus() == runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED {
+		return true, nil
+	}
+	updatedAt, ok := agentUpdatedAt[target.AgentID]
+	if !ok {
+		return false, fmt.Errorf("agent %s updated_at missing", target.AgentID.String())
+	}
+	latestRemovedAt, err := workloadRemovedAt(latest)
+	if err != nil {
+		return false, err
+	}
+	if updatedAt.After(latestRemovedAt) {
+		return true, nil
+	}
+	lastStopped, err := r.latestWorkloadByThread(ctx, threadID, &agentID, []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
+	})
+	if err != nil {
+		return false, err
+	}
+	resetFloor := updatedAt
+	if lastStopped != nil {
+		stoppedAt, err := workloadCreatedAt(lastStopped)
+		if err != nil {
+			return false, err
+		}
+		if stoppedAt.After(resetFloor) {
+			resetFloor = stoppedAt
+		}
+	}
+	recentFailures, err := r.listWorkloadsByThread(ctx, threadID, &agentID, []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED,
+	}, maxStartAttempts+1)
+	if err != nil {
+		return false, err
+	}
+	consecutiveFailures := 0
+	for _, failure := range recentFailures {
+		failureAt, err := workloadCreatedAt(failure)
+		if err != nil {
+			return false, err
+		}
+		if !failureAt.After(resetFloor) {
+			break
+		}
+		consecutiveFailures++
+	}
+	if consecutiveFailures >= maxStartAttempts {
+		r.degradeThread(ctx, threadID, degradeReasonStartFailures, degraded)
+		return false, nil
+	}
+	if consecutiveFailures == 0 {
+		return true, nil
+	}
+	backoffIndex := consecutiveFailures - 1
+	if backoffIndex >= len(startBackoffSchedule) {
+		backoffIndex = len(startBackoffSchedule) - 1
+	}
+	backoff := startBackoffSchedule[backoffIndex]
+	if now.Sub(latestRemovedAt) < backoff {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (r *Reconciler) latestWorkloadByThread(ctx context.Context, threadID string, agentID *string, statuses []runnersv1.WorkloadStatus) (*runnersv1.Workload, error) {
+	workloads, err := r.listWorkloadsByThread(ctx, threadID, agentID, statuses, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(workloads) == 0 {
+		return nil, nil
+	}
+	return workloads[0], nil
+}
+
+func (r *Reconciler) listWorkloadsByThread(ctx context.Context, threadID string, agentID *string, statuses []runnersv1.WorkloadStatus, limit int) ([]*runnersv1.Workload, error) {
+	if threadID == "" {
+		return nil, fmt.Errorf("thread id missing")
+	}
+	workloads := []*runnersv1.Workload{}
+	pageToken := ""
+	for {
+		pageSize := workloadHistoryPageSize
+		if limit > 0 {
+			remaining := limit - len(workloads)
+			if remaining <= 0 {
+				break
+			}
+			if remaining < int(pageSize) {
+				pageSize = int32(remaining)
+			}
+		}
+		req := &runnersv1.ListWorkloadsByThreadRequest{
+			ThreadId:  threadID,
+			PageSize:  pageSize,
+			PageToken: pageToken,
+		}
+		if agentID != nil {
+			req.AgentId = agentID
+		}
+		if len(statuses) > 0 {
+			req.StatusIn = statuses
+		}
+		resp, err := r.runners.ListWorkloadsByThread(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("list workloads for thread %s: %w", threadID, err)
+		}
+		for _, workload := range resp.GetWorkloads() {
+			if workload == nil {
+				return nil, fmt.Errorf("workload is nil")
+			}
+			meta := workload.GetMeta()
+			if meta == nil {
+				return nil, fmt.Errorf("workload meta missing")
+			}
+			if meta.GetId() == "" {
+				return nil, fmt.Errorf("workload meta id missing")
+			}
+			workloads = append(workloads, workload)
+			if limit > 0 && len(workloads) >= limit {
+				break
+			}
+		}
+		if limit > 0 && len(workloads) >= limit {
+			break
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	return workloads, nil
+}
+
+func workloadCreatedAt(workload *runnersv1.Workload) (time.Time, error) {
+	meta := workload.GetMeta()
+	if meta == nil {
+		return time.Time{}, fmt.Errorf("workload meta missing")
+	}
+	createdAt := meta.GetCreatedAt()
+	if createdAt == nil {
+		return time.Time{}, fmt.Errorf("workload created_at missing")
+	}
+	return createdAt.AsTime().UTC(), nil
+}
+
+func workloadRemovedAt(workload *runnersv1.Workload) (time.Time, error) {
+	removedAt := workload.GetRemovedAt()
+	if removedAt == nil {
+		return time.Time{}, fmt.Errorf("workload removed_at missing")
+	}
+	return removedAt.AsTime().UTC(), nil
+}

--- a/internal/reconciler/start_decision.go
+++ b/internal/reconciler/start_decision.go
@@ -142,7 +142,7 @@ func (r *Reconciler) listWorkloadsByThread(ctx context.Context, threadID string,
 			req.AgentId = agentID
 		}
 		if len(statuses) > 0 {
-			req.StatusIn = statuses
+			req.Statuses = statuses
 		}
 		resp, err := r.runners.ListWorkloadsByThread(ctx, req)
 		if err != nil {

--- a/internal/reconciler/start_decision.go
+++ b/internal/reconciler/start_decision.go
@@ -20,9 +20,13 @@ var startBackoffSchedule = []time.Duration{
 }
 
 func (r *Reconciler) shouldStartWorkload(ctx context.Context, target AgentThread, now time.Time, agentUpdatedAt map[uuid.UUID]time.Time, degraded *degradeTracker) (bool, error) {
+	runnerCtx, err := r.runnerIdentityContextForAgent(ctx, target.AgentID)
+	if err != nil {
+		return false, err
+	}
 	threadID := target.ThreadID.String()
 	agentID := target.AgentID.String()
-	active, err := r.listWorkloadsByThread(ctx, threadID, &agentID, []runnersv1.WorkloadStatus{
+	active, err := r.listWorkloadsByThread(runnerCtx, threadID, &agentID, []runnersv1.WorkloadStatus{
 		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
 		runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
 		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING,
@@ -33,7 +37,7 @@ func (r *Reconciler) shouldStartWorkload(ctx context.Context, target AgentThread
 	if len(active) > 0 {
 		return false, nil
 	}
-	latest, err := r.latestWorkloadByThread(ctx, threadID, &agentID, []runnersv1.WorkloadStatus{
+	latest, err := r.latestWorkloadByThread(runnerCtx, threadID, &agentID, []runnersv1.WorkloadStatus{
 		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
 		runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED,
 	})
@@ -54,7 +58,7 @@ func (r *Reconciler) shouldStartWorkload(ctx context.Context, target AgentThread
 	if updatedAt.After(latestRemovedAt) {
 		return true, nil
 	}
-	lastStopped, err := r.latestWorkloadByThread(ctx, threadID, &agentID, []runnersv1.WorkloadStatus{
+	lastStopped, err := r.latestWorkloadByThread(runnerCtx, threadID, &agentID, []runnersv1.WorkloadStatus{
 		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
 	})
 	if err != nil {
@@ -70,7 +74,7 @@ func (r *Reconciler) shouldStartWorkload(ctx context.Context, target AgentThread
 			resetFloor = stoppedAt
 		}
 	}
-	recentFailures, err := r.listWorkloadsByThread(ctx, threadID, &agentID, []runnersv1.WorkloadStatus{
+	recentFailures, err := r.listWorkloadsByThread(runnerCtx, threadID, &agentID, []runnersv1.WorkloadStatus{
 		runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED,
 	}, maxStartAttempts+1)
 	if err != nil {
@@ -88,7 +92,7 @@ func (r *Reconciler) shouldStartWorkload(ctx context.Context, target AgentThread
 		consecutiveFailures++
 	}
 	if consecutiveFailures >= maxStartAttempts {
-		r.degradeThread(ctx, threadID, degradeReasonStartFailures, degraded)
+		r.degradeThread(runnerCtx, threadID, degradeReasonStartFailures, degraded)
 		return false, nil
 	}
 	if consecutiveFailures == 0 {

--- a/internal/reconciler/start_decision_test.go
+++ b/internal/reconciler/start_decision_test.go
@@ -1,0 +1,51 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestShouldStartWorkloadUsesRunnerIdentityContext(t *testing.T) {
+	ctx := context.Background()
+	threadID := uuid.New()
+	agentID := uuid.MustParse(testAgentID)
+	listCalls := 0
+
+	runners := &fakeRunnersClient{
+		listWorkloadsByThread: func(ctx context.Context, req *runnersv1.ListWorkloadsByThreadRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsByThreadResponse, error) {
+			listCalls++
+			if req.GetThreadId() != threadID.String() {
+				return nil, errors.New("unexpected thread id")
+			}
+			metadataValues, ok := metadata.FromOutgoingContext(ctx)
+			if !ok {
+				return nil, errors.New("missing outgoing metadata")
+			}
+			identityValues := metadataValues.Get(identityMetadataKey)
+			if len(identityValues) != 1 || identityValues[0] != agentID.String() {
+				return nil, fmt.Errorf("unexpected identity metadata: %v", identityValues)
+			}
+			return &runnersv1.ListWorkloadsByThreadResponse{}, nil
+		},
+	}
+
+	reconciler := newTestReconciler(Config{Runners: runners})
+	shouldStart, err := reconciler.shouldStartWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, time.Now().UTC(), map[uuid.UUID]time.Time{}, nil)
+	if err != nil {
+		t.Fatalf("should start workload: %v", err)
+	}
+	if !shouldStart {
+		t.Fatal("expected start decision to allow workload")
+	}
+	if listCalls == 0 {
+		t.Fatal("expected list workloads calls")
+	}
+}

--- a/internal/reconciler/start_decision_test.go
+++ b/internal/reconciler/start_decision_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestShouldStartWorkloadUsesRunnerIdentityContext(t *testing.T) {
@@ -48,4 +51,298 @@ func TestShouldStartWorkloadUsesRunnerIdentityContext(t *testing.T) {
 	if listCalls == 0 {
 		t.Fatal("expected list workloads calls")
 	}
+}
+
+func TestShouldStartWorkloadSkipsActiveWorkloads(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+	agentID := uuid.New()
+	threadID := uuid.New()
+	fixture := startDecisionFixture{
+		t:        t,
+		agentID:  agentID,
+		threadID: threadID,
+		active: []*runnersv1.Workload{
+			makeDecisionWorkload("active", runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING, now.Add(-2*time.Minute), time.Time{}),
+		},
+	}
+
+	runners := &fakeRunnersClient{listWorkloadsByThread: fixture.list}
+	reconciler := newTestReconciler(Config{Runners: runners})
+
+	shouldStart, err := reconciler.shouldStartWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, now, map[uuid.UUID]time.Time{agentID: now.Add(-time.Hour)}, nil)
+	if err != nil {
+		t.Fatalf("should start workload: %v", err)
+	}
+	if shouldStart {
+		t.Fatal("expected start decision to be blocked")
+	}
+}
+
+func TestShouldStartWorkloadAllowsStoppedOrEmpty(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+	agentID := uuid.New()
+	threadID := uuid.New()
+	fixture := startDecisionFixture{
+		t:        t,
+		agentID:  agentID,
+		threadID: threadID,
+		latest: []*runnersv1.Workload{
+			makeDecisionWorkload("stopped", runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED, now.Add(-time.Hour), now.Add(-time.Hour)),
+		},
+	}
+
+	runners := &fakeRunnersClient{listWorkloadsByThread: fixture.list}
+	reconciler := newTestReconciler(Config{Runners: runners})
+
+	shouldStart, err := reconciler.shouldStartWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, now, map[uuid.UUID]time.Time{}, nil)
+	if err != nil {
+		t.Fatalf("should start workload: %v", err)
+	}
+	if !shouldStart {
+		t.Fatal("expected start decision to allow workload")
+	}
+}
+
+func TestShouldStartWorkloadRetriesAfterAgentUpdate(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+	agentID := uuid.New()
+	threadID := uuid.New()
+	removedAt := now.Add(-5 * time.Minute)
+	fixture := startDecisionFixture{
+		t:        t,
+		agentID:  agentID,
+		threadID: threadID,
+		latest: []*runnersv1.Workload{
+			makeDecisionWorkload("failed", runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED, removedAt.Add(-time.Minute), removedAt),
+		},
+	}
+
+	runners := &fakeRunnersClient{listWorkloadsByThread: fixture.list}
+	reconciler := newTestReconciler(Config{Runners: runners})
+
+	shouldStart, err := reconciler.shouldStartWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, now, map[uuid.UUID]time.Time{agentID: removedAt.Add(time.Minute)}, nil)
+	if err != nil {
+		t.Fatalf("should start workload: %v", err)
+	}
+	if !shouldStart {
+		t.Fatal("expected start decision to allow workload")
+	}
+}
+
+func TestShouldStartWorkloadBackoffSchedule(t *testing.T) {
+	ctx := context.Background()
+	base := time.Date(2024, 10, 10, 9, 0, 0, 0, time.UTC)
+	agentID := uuid.New()
+	threadID := uuid.New()
+	updatedAt := base.Add(-24 * time.Hour)
+
+	for failures := 1; failures <= 6; failures++ {
+		backoffIndex := failures - 1
+		if backoffIndex >= len(startBackoffSchedule) {
+			backoffIndex = len(startBackoffSchedule) - 1
+		}
+		backoff := startBackoffSchedule[backoffIndex]
+
+		for _, delta := range []struct {
+			name        string
+			removedAt   time.Time
+			shouldStart bool
+		}{
+			{name: "before", removedAt: base.Add(-backoff + time.Second), shouldStart: false},
+			{name: "after", removedAt: base.Add(-backoff - time.Second), shouldStart: true},
+		} {
+			t.Run(fmt.Sprintf("failures-%d-%s", failures, delta.name), func(t *testing.T) {
+				failuresList := makeDecisionFailures(failures, delta.removedAt)
+				fixture := startDecisionFixture{
+					t:        t,
+					agentID:  agentID,
+					threadID: threadID,
+					latest:   []*runnersv1.Workload{failuresList[0]},
+					failed:   failuresList,
+				}
+
+				runners := &fakeRunnersClient{listWorkloadsByThread: fixture.list}
+				reconciler := newTestReconciler(Config{Runners: runners})
+
+				shouldStart, err := reconciler.shouldStartWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, base, map[uuid.UUID]time.Time{agentID: updatedAt}, nil)
+				if err != nil {
+					t.Fatalf("should start workload: %v", err)
+				}
+				if shouldStart != delta.shouldStart {
+					t.Fatalf("expected shouldStart=%v, got %v", delta.shouldStart, shouldStart)
+				}
+			})
+		}
+	}
+}
+
+func TestShouldStartWorkloadResetsOnLastStopped(t *testing.T) {
+	ctx := context.Background()
+	base := time.Date(2024, 10, 10, 9, 0, 0, 0, time.UTC)
+	agentID := uuid.New()
+	threadID := uuid.New()
+	updatedAt := base
+	lastStoppedAt := base.Add(2 * time.Minute)
+	latestRemovedAt := base.Add(4*time.Minute + 15*time.Second)
+
+	fixture := startDecisionFixture{
+		t:        t,
+		agentID:  agentID,
+		threadID: threadID,
+		latest: []*runnersv1.Workload{
+			makeDecisionWorkload("latest", runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED, latestRemovedAt.Add(-time.Minute), latestRemovedAt),
+		},
+		stopped: []*runnersv1.Workload{
+			makeDecisionWorkload("stopped", runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED, lastStoppedAt, lastStoppedAt),
+		},
+		failed: []*runnersv1.Workload{
+			makeDecisionWorkload("recent", runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED, latestRemovedAt.Add(-2*time.Second), latestRemovedAt),
+			makeDecisionWorkload("old", runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED, base.Add(time.Minute), base.Add(time.Minute)),
+		},
+	}
+
+	runners := &fakeRunnersClient{listWorkloadsByThread: fixture.list}
+	reconciler := newTestReconciler(Config{Runners: runners})
+
+	shouldStart, err := reconciler.shouldStartWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, base.Add(4*time.Minute+30*time.Second), map[uuid.UUID]time.Time{agentID: updatedAt}, nil)
+	if err != nil {
+		t.Fatalf("should start workload: %v", err)
+	}
+	if !shouldStart {
+		t.Fatal("expected start decision to allow workload")
+	}
+}
+
+func TestShouldStartWorkloadDegradesAfterMaxFailures(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+	agentID := uuid.New()
+	threadID := uuid.New()
+
+	var degradedRequest *threadsv1.DegradeThreadRequest
+	threads := &fakeThreadsClient{
+		degradeThread: func(_ context.Context, req *threadsv1.DegradeThreadRequest, _ ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error) {
+			degradedRequest = req
+			return &threadsv1.DegradeThreadResponse{}, nil
+		},
+	}
+
+	failures := makeDecisionFailures(maxStartAttempts, now.Add(-2*time.Minute))
+	fixture := startDecisionFixture{
+		t:        t,
+		agentID:  agentID,
+		threadID: threadID,
+		latest:   []*runnersv1.Workload{failures[0]},
+		failed:   failures,
+	}
+
+	runners := &fakeRunnersClient{listWorkloadsByThread: fixture.list}
+	reconciler := newTestReconciler(Config{Runners: runners, Threads: threads})
+
+	shouldStart, err := reconciler.shouldStartWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, now, map[uuid.UUID]time.Time{agentID: now.Add(-time.Hour)}, newDegradeTracker())
+	if err != nil {
+		t.Fatalf("should start workload: %v", err)
+	}
+	if shouldStart {
+		t.Fatal("expected start decision to be blocked")
+	}
+	if degradedRequest == nil {
+		t.Fatal("expected degraded thread request")
+	}
+	if degradedRequest.GetThreadId() != threadID.String() {
+		t.Fatalf("unexpected degraded thread id: %s", degradedRequest.GetThreadId())
+	}
+	if degradedRequest.GetReason() != degradeReasonStartFailures {
+		t.Fatalf("unexpected degraded reason: %s", degradedRequest.GetReason())
+	}
+}
+
+type startDecisionFixture struct {
+	t        *testing.T
+	agentID  uuid.UUID
+	threadID uuid.UUID
+	active   []*runnersv1.Workload
+	latest   []*runnersv1.Workload
+	stopped  []*runnersv1.Workload
+	failed   []*runnersv1.Workload
+}
+
+func (f startDecisionFixture) list(_ context.Context, req *runnersv1.ListWorkloadsByThreadRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsByThreadResponse, error) {
+	f.t.Helper()
+	if req.GetThreadId() != f.threadID.String() {
+		return nil, fmt.Errorf("unexpected thread id: %s", req.GetThreadId())
+	}
+	if req.GetAgentId() != f.agentID.String() {
+		return nil, fmt.Errorf("unexpected agent id: %s", req.GetAgentId())
+	}
+	statuses := req.GetStatuses()
+	switch {
+	case matchStatuses(statuses, []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING,
+	}):
+		return &runnersv1.ListWorkloadsByThreadResponse{Workloads: f.active}, nil
+	case matchStatuses(statuses, []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED,
+	}):
+		return &runnersv1.ListWorkloadsByThreadResponse{Workloads: f.latest}, nil
+	case matchStatuses(statuses, []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
+	}):
+		return &runnersv1.ListWorkloadsByThreadResponse{Workloads: f.stopped}, nil
+	case matchStatuses(statuses, []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED,
+	}):
+		return &runnersv1.ListWorkloadsByThreadResponse{Workloads: f.failed}, nil
+	default:
+		return nil, fmt.Errorf("unexpected statuses: %v", statuses)
+	}
+}
+
+func matchStatuses(got, want []runnersv1.WorkloadStatus) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	gotCopy := append([]runnersv1.WorkloadStatus(nil), got...)
+	wantCopy := append([]runnersv1.WorkloadStatus(nil), want...)
+	sort.Slice(gotCopy, func(i, j int) bool { return gotCopy[i] < gotCopy[j] })
+	sort.Slice(wantCopy, func(i, j int) bool { return wantCopy[i] < wantCopy[j] })
+	for i := range gotCopy {
+		if gotCopy[i] != wantCopy[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func makeDecisionWorkload(id string, status runnersv1.WorkloadStatus, createdAt time.Time, removedAt time.Time) *runnersv1.Workload {
+	workload := &runnersv1.Workload{
+		Meta:   &runnersv1.EntityMeta{Id: id, CreatedAt: timestamppb.New(createdAt)},
+		Status: status,
+	}
+	if !removedAt.IsZero() {
+		workload.RemovedAt = timestamppb.New(removedAt)
+	}
+	return workload
+}
+
+func makeDecisionFailures(count int, latestRemovedAt time.Time) []*runnersv1.Workload {
+	if count <= 0 {
+		return nil
+	}
+	failures := make([]*runnersv1.Workload, 0, count)
+	for i := 0; i < count; i++ {
+		createdAt := latestRemovedAt.Add(-time.Duration(i) * time.Minute)
+		removedAt := time.Time{}
+		if i == 0 {
+			removedAt = latestRemovedAt
+		}
+		failures = append(failures, makeDecisionWorkload(fmt.Sprintf("failure-%d", i), runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED, createdAt, removedAt))
+	}
+	return failures
 }

--- a/internal/reconciler/volume_reconcile.go
+++ b/internal/reconciler/volume_reconcile.go
@@ -398,7 +398,7 @@ func (r *Reconciler) threadActivity(ctx context.Context, threadID string, cache 
 	if cached, ok := cache[threadID]; ok {
 		return cached, nil
 	}
-	workloads, err := r.listWorkloadsByThread(ctx, threadID)
+	workloads, err := r.listWorkloadsByThread(ctx, threadID, nil, nil, 0)
 	if err != nil {
 		return threadActivity{}, err
 	}
@@ -422,42 +422,6 @@ func (r *Reconciler) threadActivity(ctx context.Context, threadID string, cache 
 	}
 	cache[threadID] = activity
 	return activity, nil
-}
-
-func (r *Reconciler) listWorkloadsByThread(ctx context.Context, threadID string) ([]*runnersv1.Workload, error) {
-	if threadID == "" {
-		return nil, fmt.Errorf("thread id missing")
-	}
-	workloads := []*runnersv1.Workload{}
-	pageToken := ""
-	for {
-		resp, err := r.runners.ListWorkloadsByThread(ctx, &runnersv1.ListWorkloadsByThreadRequest{
-			ThreadId:  threadID,
-			PageSize:  workloadHistoryPageSize,
-			PageToken: pageToken,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("list workloads for thread %s: %w", threadID, err)
-		}
-		for _, workload := range resp.GetWorkloads() {
-			if workload == nil {
-				return nil, fmt.Errorf("workload is nil")
-			}
-			meta := workload.GetMeta()
-			if meta == nil {
-				return nil, fmt.Errorf("workload meta missing")
-			}
-			if meta.GetId() == "" {
-				return nil, fmt.Errorf("workload meta id missing")
-			}
-			workloads = append(workloads, workload)
-		}
-		pageToken = resp.GetNextPageToken()
-		if pageToken == "" {
-			break
-		}
-	}
-	return workloads, nil
 }
 
 func parseVolumeTTL(value string) (time.Duration, error) {

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -189,23 +189,46 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 	return nil
 }
 
+const (
+	startGracePeriod     = 60 * time.Second
+	initRetryThreshold   = 3
+	crashloopThreshold   = 3
+	crashLoopBackoffFlag = "CrashLoopBackOff"
+)
+
+var imagePullReasons = map[string]struct{}{
+	"ImagePullBackOff": {},
+	"ErrImagePull":     {},
+}
+
+var configInvalidReasons = map[string]struct{}{
+	"CreateContainerConfigError": {},
+	"CreateContainerError":       {},
+	"InvalidImageName":           {},
+}
+
 func (r *Reconciler) handleMissingRunnerWorkload(ctx context.Context, workload *runnersv1.Workload) error {
 	workloadID := workload.GetMeta().GetId()
 	if workloadID == "" {
 		return nil
 	}
-	missingAt := timestamppb.New(time.Now().UTC())
 	switch workload.GetStatus() {
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
 		runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING:
-		status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED
-		_, err := r.runners.UpdateWorkload(ctx, &runnersv1.UpdateWorkloadRequest{
-			Id:        workloadID,
-			Status:    &status,
-			RemovedAt: missingAt,
-		})
-		return err
+		failureReason := runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED
+		failureMessage := "workload missing on runner"
+		if workload.GetStatus() == runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+			failureReason = runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST
+		}
+		r.markWorkloadFailed(ctx, workloadID, stringPtr(workload.GetInstanceId()), failureReason, failureMessage, nil)
+		if r.zitiMgmt != nil && workload.GetZitiIdentityId() != "" {
+			if err := r.deleteIdentity(ctx, workload.GetZitiIdentityId()); err != nil {
+				log.Printf("reconciler: delete ziti identity %s after missing workload %s: %v", workload.GetZitiIdentityId(), workloadID, err)
+			}
+		}
+		return nil
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING:
+		missingAt := timestamppb.New(time.Now().UTC())
 		status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED
 		_, err := r.runners.UpdateWorkload(ctx, &runnersv1.UpdateWorkloadRequest{
 			Id:        workloadID,
@@ -229,34 +252,51 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 	}
 	updateReq := &runnersv1.UpdateWorkloadRequest{Id: workloadID}
 	shouldUpdate := false
-	switch workload.GetStatus() {
-	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING:
-		status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING
-		updateReq.Status = &status
+	if workload.GetInstanceId() != instanceID {
 		updateReq.InstanceId = stringPtr(instanceID)
 		shouldUpdate = true
-	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING:
-		if workload.GetInstanceId() != instanceID {
-			updateReq.InstanceId = stringPtr(instanceID)
-			shouldUpdate = true
-		}
-	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING:
-		if workload.GetInstanceId() != instanceID {
-			updateReq.InstanceId = stringPtr(instanceID)
-			shouldUpdate = true
-		}
 	}
 	inspectResp, err := r.inspectRunnerWorkload(ctx, runnerClient, instanceID)
+	var containers []*runnersv1.Container
 	if err != nil {
 		log.Printf("reconciler: warn: inspect workload %s: %v", workloadID, err)
 	} else {
-		containers, err := mapRunnerContainers(inspectResp.GetContainers())
-		if err != nil {
-			log.Printf("reconciler: warn: map workload %s containers: %v", workloadID, err)
+		mapped, mapErr := mapRunnerContainers(inspectResp.GetContainers())
+		if mapErr != nil {
+			log.Printf("reconciler: warn: map workload %s containers: %v", workloadID, mapErr)
 		} else {
+			containers = mapped
 			updateReq.Containers = containers
 			shouldUpdate = true
 		}
+	}
+	switch workload.GetStatus() {
+	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING:
+		if containers != nil {
+			ready, failure, err := classifyStartingContainers(containers, workload, time.Now().UTC())
+			if err != nil {
+				return err
+			}
+			if failure != nil {
+				r.failWorkloadOnRunner(ctx, runnerClient, workload, instanceID, failure, containers)
+				return nil
+			}
+			if ready {
+				status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING
+				updateReq.Status = &status
+				shouldUpdate = true
+			}
+		}
+	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING:
+		if containers != nil {
+			if failure := classifyRunningContainers(containers); failure != nil {
+				r.failWorkloadOnRunner(ctx, runnerClient, workload, instanceID, failure, containers)
+				return nil
+			}
+		}
+	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING:
+		// stop below
+	default:
 	}
 	if shouldUpdate {
 		if _, err := r.runners.UpdateWorkload(ctx, updateReq); err != nil {
@@ -267,4 +307,116 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 		return r.stopRunnerWorkload(ctx, runnerClient, instanceID)
 	}
 	return nil
+}
+
+type workloadFailure struct {
+	reason  runnersv1.WorkloadFailureReason
+	message string
+}
+
+func classifyStartingContainers(containers []*runnersv1.Container, workload *runnersv1.Workload, now time.Time) (bool, *workloadFailure, error) {
+	createdAt, err := workloadCreatedAt(workload)
+	if err != nil {
+		return false, nil, err
+	}
+	startAge := now.Sub(createdAt)
+	initComplete := true
+	mainRunning := true
+	foundMain := false
+	for _, container := range containers {
+		if container == nil {
+			return false, nil, fmt.Errorf("workload %s has nil container", workload.GetMeta().GetId())
+		}
+		switch container.GetRole() {
+		case runnersv1.ContainerRole_CONTAINER_ROLE_INIT:
+			switch container.GetStatus() {
+			case runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING:
+				if isImagePullFailure(container) && startAge > startGracePeriod {
+					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_IMAGE_PULL_FAILED, message: containerFailureMessage(container)}, nil
+				}
+				initComplete = false
+			case runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED:
+				if container.GetExitCode() != 0 && container.GetRestartCount() >= initRetryThreshold {
+					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, message: containerFailureMessage(container)}, nil
+				}
+				if container.GetExitCode() != 0 {
+					initComplete = false
+				}
+			default:
+				initComplete = false
+			}
+		case runnersv1.ContainerRole_CONTAINER_ROLE_MAIN:
+			foundMain = true
+			if container.GetStatus() != runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING {
+				mainRunning = false
+			}
+			if container.GetStatus() == runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING {
+				if isImagePullFailure(container) && startAge > startGracePeriod {
+					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_IMAGE_PULL_FAILED, message: containerFailureMessage(container)}, nil
+				}
+				if isConfigInvalidFailure(container) && startAge > startGracePeriod {
+					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CONFIG_INVALID, message: containerFailureMessage(container)}, nil
+				}
+			}
+		default:
+		}
+	}
+	if !foundMain {
+		return false, nil, fmt.Errorf("workload %s missing main container", workload.GetMeta().GetId())
+	}
+	if initComplete && mainRunning {
+		return true, nil, nil
+	}
+	return false, nil, nil
+}
+
+func classifyRunningContainers(containers []*runnersv1.Container) *workloadFailure {
+	for _, container := range containers {
+		if container == nil {
+			continue
+		}
+		if container.GetRole() != runnersv1.ContainerRole_CONTAINER_ROLE_MAIN {
+			continue
+		}
+		if container.GetStatus() == runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING && container.GetReason() == crashLoopBackoffFlag && container.GetRestartCount() >= crashloopThreshold {
+			return &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CRASHLOOP, message: containerFailureMessage(container)}
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) failWorkloadOnRunner(ctx context.Context, runnerClient runnerv1.RunnerServiceClient, workload *runnersv1.Workload, instanceID string, failure *workloadFailure, containers []*runnersv1.Container) {
+	if failure == nil {
+		return
+	}
+	workloadID := workload.GetMeta().GetId()
+	if workloadID == "" {
+		return
+	}
+	r.markWorkloadFailed(ctx, workloadID, stringPtr(instanceID), failure.reason, failure.message, containers)
+	if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
+		log.Printf("reconciler: stop workload %s after failure: %v", workloadID, err)
+	}
+	if r.zitiMgmt != nil && workload.GetZitiIdentityId() != "" {
+		if err := r.deleteIdentity(ctx, workload.GetZitiIdentityId()); err != nil {
+			log.Printf("reconciler: delete ziti identity %s after workload %s failure: %v", workload.GetZitiIdentityId(), workloadID, err)
+		}
+	}
+}
+
+func isImagePullFailure(container *runnersv1.Container) bool {
+	_, ok := imagePullReasons[container.GetReason()]
+	return ok
+}
+
+func isConfigInvalidFailure(container *runnersv1.Container) bool {
+	_, ok := configInvalidReasons[container.GetReason()]
+	return ok
+}
+
+func containerFailureMessage(container *runnersv1.Container) string {
+	if container.GetMessage() != "" {
+		return container.GetMessage()
+	}
+	return container.GetReason()
 }

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -215,11 +215,8 @@ func (r *Reconciler) handleMissingRunnerWorkload(ctx context.Context, workload *
 	switch workload.GetStatus() {
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
 		runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING:
-		failureReason := runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED
+		failureReason := runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST
 		failureMessage := "workload missing on runner"
-		if workload.GetStatus() == runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
-			failureReason = runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST
-		}
 		r.markWorkloadFailed(ctx, workloadID, stringPtr(workload.GetInstanceId()), failureReason, failureMessage, nil)
 		if r.zitiMgmt != nil && workload.GetZitiIdentityId() != "" {
 			if err := r.deleteIdentity(ctx, workload.GetZitiIdentityId()); err != nil {
@@ -289,7 +286,11 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 		}
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING:
 		if containers != nil {
-			if failure := classifyRunningContainers(containers); failure != nil {
+			failure, err := classifyRunningContainers(containers)
+			if err != nil {
+				return err
+			}
+			if failure != nil {
 				r.failWorkloadOnRunner(ctx, runnerClient, workload, instanceID, failure, containers)
 				return nil
 			}
@@ -334,6 +335,9 @@ func classifyStartingContainers(containers []*runnersv1.Container, workload *run
 				if isImagePullFailure(container) && startAge > startGracePeriod {
 					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_IMAGE_PULL_FAILED, message: containerFailureMessage(container)}, nil
 				}
+				if isConfigInvalidFailure(container) && startAge > startGracePeriod {
+					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CONFIG_INVALID, message: containerFailureMessage(container)}, nil
+				}
 				initComplete = false
 			case runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED:
 				if container.GetExitCode() != 0 && container.GetRestartCount() >= initRetryThreshold {
@@ -370,19 +374,19 @@ func classifyStartingContainers(containers []*runnersv1.Container, workload *run
 	return false, nil, nil
 }
 
-func classifyRunningContainers(containers []*runnersv1.Container) *workloadFailure {
+func classifyRunningContainers(containers []*runnersv1.Container) (*workloadFailure, error) {
 	for _, container := range containers {
 		if container == nil {
-			continue
+			return nil, fmt.Errorf("container is nil")
 		}
 		if container.GetRole() != runnersv1.ContainerRole_CONTAINER_ROLE_MAIN {
 			continue
 		}
 		if container.GetStatus() == runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING && container.GetReason() == crashLoopBackoffFlag && container.GetRestartCount() >= crashloopThreshold {
-			return &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CRASHLOOP, message: containerFailureMessage(container)}
+			return &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CRASHLOOP, message: containerFailureMessage(container)}, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (r *Reconciler) failWorkloadOnRunner(ctx context.Context, runnerClient runnerv1.RunnerServiceClient, workload *runnersv1.Workload, instanceID string, failure *workloadFailure, containers []*runnersv1.Container) {

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -355,6 +355,9 @@ func classifyStartingContainers(containers []*runnersv1.Container, workload *run
 				mainRunning = false
 			}
 			if container.GetStatus() == runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING {
+				if container.GetReason() == crashLoopBackoffFlag && container.GetRestartCount() >= crashloopThreshold {
+					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CRASHLOOP, message: containerFailureMessage(container)}, nil
+				}
 				if isImagePullFailure(container) && startAge > startGracePeriod {
 					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_IMAGE_PULL_FAILED, message: containerFailureMessage(container)}, nil
 				}
@@ -399,7 +402,7 @@ func (r *Reconciler) failWorkloadOnRunner(ctx context.Context, runnerClient runn
 	}
 	r.markWorkloadFailed(ctx, workloadID, stringPtr(instanceID), failure.reason, failure.message, containers)
 	if err := r.stopRunnerWorkload(ctx, runnerClient, instanceID); err != nil {
-		log.Printf("reconciler: stop workload %s after failure: %v", workloadID, err)
+		log.Printf("reconciler: stop workload %s (instance %s) after failure: %v", workloadID, instanceID, err)
 	}
 	if r.zitiMgmt != nil && workload.GetZitiIdentityId() != "" {
 		if err := r.deleteIdentity(ctx, workload.GetZitiIdentityId()); err != nil {

--- a/internal/reconciler/workload_reconcile_classify_test.go
+++ b/internal/reconciler/workload_reconcile_classify_test.go
@@ -79,6 +79,28 @@ func TestClassifyStartingContainersMainConfigInvalid(t *testing.T) {
 	}
 }
 
+func TestClassifyStartingContainersMainCrashloop(t *testing.T) {
+	now := time.Now().UTC()
+	workload := &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(now.Add(-startGracePeriod - time.Second))}}
+	containers := []*runnersv1.Container{
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING, crashLoopBackoffFlag, "crashloop", crashloopThreshold, nil),
+	}
+
+	ready, failure, err := classifyStartingContainers(containers, workload, now)
+	if err != nil {
+		t.Fatalf("classify starting containers: %v", err)
+	}
+	if ready {
+		t.Fatal("expected workload to be not ready")
+	}
+	if failure == nil {
+		t.Fatal("expected failure")
+	}
+	if failure.reason != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CRASHLOOP {
+		t.Fatalf("unexpected failure reason: %v", failure.reason)
+	}
+}
+
 func TestClassifyStartingContainersInitRestartFailure(t *testing.T) {
 	now := time.Now().UTC()
 	exitCode := int32(1)

--- a/internal/reconciler/workload_reconcile_classify_test.go
+++ b/internal/reconciler/workload_reconcile_classify_test.go
@@ -1,0 +1,146 @@
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestClassifyStartingContainersInitImagePullFailure(t *testing.T) {
+	now := time.Now().UTC()
+	workload := &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(now.Add(-startGracePeriod - time.Second))}}
+	containers := []*runnersv1.Container{
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_INIT, runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING, "ImagePullBackOff", "", 0, nil),
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING, "", "", 0, nil),
+	}
+
+	ready, failure, err := classifyStartingContainers(containers, workload, now)
+	if err != nil {
+		t.Fatalf("classify starting containers: %v", err)
+	}
+	if ready {
+		t.Fatal("expected workload to be not ready")
+	}
+	if failure == nil {
+		t.Fatal("expected failure")
+	}
+	if failure.reason != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_IMAGE_PULL_FAILED {
+		t.Fatalf("unexpected failure reason: %v", failure.reason)
+	}
+}
+
+func TestClassifyStartingContainersInitConfigInvalid(t *testing.T) {
+	now := time.Now().UTC()
+	workload := &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(now.Add(-startGracePeriod - time.Second))}}
+	containers := []*runnersv1.Container{
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_INIT, runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING, "CreateContainerConfigError", "bad init", 0, nil),
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING, "", "", 0, nil),
+	}
+
+	ready, failure, err := classifyStartingContainers(containers, workload, now)
+	if err != nil {
+		t.Fatalf("classify starting containers: %v", err)
+	}
+	if ready {
+		t.Fatal("expected workload to be not ready")
+	}
+	if failure == nil {
+		t.Fatal("expected failure")
+	}
+	if failure.reason != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CONFIG_INVALID {
+		t.Fatalf("unexpected failure reason: %v", failure.reason)
+	}
+	if failure.message != "bad init" {
+		t.Fatalf("unexpected failure message: %s", failure.message)
+	}
+}
+
+func TestClassifyStartingContainersMainConfigInvalid(t *testing.T) {
+	now := time.Now().UTC()
+	workload := &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(now.Add(-startGracePeriod - time.Second))}}
+	containers := []*runnersv1.Container{
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING, "CreateContainerError", "bad main", 0, nil),
+	}
+
+	ready, failure, err := classifyStartingContainers(containers, workload, now)
+	if err != nil {
+		t.Fatalf("classify starting containers: %v", err)
+	}
+	if ready {
+		t.Fatal("expected workload to be not ready")
+	}
+	if failure == nil {
+		t.Fatal("expected failure")
+	}
+	if failure.reason != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CONFIG_INVALID {
+		t.Fatalf("unexpected failure reason: %v", failure.reason)
+	}
+}
+
+func TestClassifyStartingContainersInitRestartFailure(t *testing.T) {
+	now := time.Now().UTC()
+	exitCode := int32(1)
+	workload := &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(now.Add(-startGracePeriod - time.Second))}}
+	containers := []*runnersv1.Container{
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_INIT, runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED, "init failed", "", initRetryThreshold, &exitCode),
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING, "", "", 0, nil),
+	}
+
+	ready, failure, err := classifyStartingContainers(containers, workload, now)
+	if err != nil {
+		t.Fatalf("classify starting containers: %v", err)
+	}
+	if ready {
+		t.Fatal("expected workload to be not ready")
+	}
+	if failure == nil {
+		t.Fatal("expected failure")
+	}
+	if failure.reason != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED {
+		t.Fatalf("unexpected failure reason: %v", failure.reason)
+	}
+}
+
+func TestClassifyStartingContainersReady(t *testing.T) {
+	now := time.Now().UTC()
+	exitCode := int32(0)
+	workload := &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(now.Add(-startGracePeriod - time.Second))}}
+	containers := []*runnersv1.Container{
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_INIT, runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED, "", "", 0, &exitCode),
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING, "", "", 0, nil),
+	}
+
+	ready, failure, err := classifyStartingContainers(containers, workload, now)
+	if err != nil {
+		t.Fatalf("classify starting containers: %v", err)
+	}
+	if !ready {
+		t.Fatal("expected workload to be ready")
+	}
+	if failure != nil {
+		t.Fatalf("unexpected failure: %+v", failure)
+	}
+}
+
+func TestClassifyRunningContainersErrorsOnNil(t *testing.T) {
+	failure, err := classifyRunningContainers([]*runnersv1.Container{nil})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if failure != nil {
+		t.Fatalf("unexpected failure: %+v", failure)
+	}
+}
+
+func makeContainer(role runnersv1.ContainerRole, status runnersv1.ContainerStatus, reason, message string, restartCount int32, exitCode *int32) *runnersv1.Container {
+	return &runnersv1.Container{
+		Role:         role,
+		Status:       status,
+		Reason:       stringPtr(reason),
+		Message:      stringPtr(message),
+		RestartCount: restartCount,
+		ExitCode:     exitCode,
+	}
+}

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -10,7 +10,10 @@ import (
 	notificationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/notifications/v1"
 )
 
-const messageCreatedEvent = "message.created"
+const (
+	messageCreatedEvent = "message.created"
+	agentUpdatedEvent   = "agent.updated"
+)
 
 type Subscriber struct {
 	client notificationsv1.NotificationsServiceClient
@@ -59,7 +62,8 @@ func (s *Subscriber) Run(ctx context.Context) error {
 			if envelope == nil {
 				continue
 			}
-			if envelope.GetEvent() == messageCreatedEvent {
+			switch envelope.GetEvent() {
+			case messageCreatedEvent, agentUpdatedEvent:
 				select {
 				case s.wake <- struct{}{}:
 				default:


### PR DESCRIPTION
## Summary
- add start decision/backoff using workload history and agent.updated_at
- classify workload failures during reconcile with cleanup + ziti delete
- update start flow and agent.updated subscription handling

## Testing
- go test ./...
- go vet ./...

#161