### PR TITLE
fix(e2e): pin bootstrap ref

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,9 +22,9 @@ jobs:
           path: service
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@cb90c2fdeaf59facdb883ce8597e2099de51e8c6
+        uses: agynio/bootstrap/.github/actions/provision@1335bdb93b5d7ea3621630d504591cdf455f6d2b
         with:
-          ref: cb90c2fdeaf59facdb883ce8597e2099de51e8c6
+          ref: 1335bdb93b5d7ea3621630d504591cdf455f6d2b
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
         env:
-          AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.14
-          AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.14
+          AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.15
+          AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.15
         with:
           service: agents_orchestrator
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@0382a86ed54c603a30cceb91e2fe4eba8c2fd924
+        with:
+          ref: cb90c2fdeaf59facdb883ce8597e2099de51e8c6
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,14 +27,14 @@ jobs:
           ref: 1335bdb93b5d7ea3621630d504591cdf455f6d2b
 
       - name: Setup DevSpace
-        uses: agynio/e2e/.github/actions/setup-devspace@main
+        uses: agynio/e2e/.github/actions/setup-devspace@1aa5e1ad1f7ee6c874318e3049688408ad23e2eb
 
       - name: Deploy orchestrator from source
         working-directory: service
         run: devspace run deploy -n platform
 
       - name: Run E2E tests
-        uses: agynio/e2e/.github/actions/run-tests@main
+        uses: agynio/e2e/.github/actions/run-tests@1aa5e1ad1f7ee6c874318e3049688408ad23e2eb
         env:
           AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.15
           AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
           path: service
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@0382a86ed54c603a30cceb91e2fe4eba8c2fd924
+        uses: agynio/bootstrap/.github/actions/provision@cb90c2fdeaf59facdb883ce8597e2099de51e8c6
         with:
           ref: cb90c2fdeaf59facdb883ce8597e2099de51e8c6
 

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -60,6 +60,9 @@ func (f *fakeThreadsClient) GetThreads(ctx context.Context, req *threadsv1.GetTh
 	}
 	return nil, testutil.ErrNotImplemented
 }
+func (f *fakeThreadsClient) ListOrganizationThreads(context.Context, *threadsv1.ListOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.ListOrganizationThreadsResponse, error) {
+	return nil, testutil.ErrNotImplemented
+}
 func (f *fakeThreadsClient) GetThread(context.Context, *threadsv1.GetThreadRequest, ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -60,7 +60,7 @@ func (f *fakeThreadsClient) GetThreads(ctx context.Context, req *threadsv1.GetTh
 	}
 	return nil, testutil.ErrNotImplemented
 }
-func (f *fakeThreadsClient) ListOrganizationThreads(context.Context, *threadsv1.ListOrganizationThreadsRequest, ...grpc.CallOption) (*threadsv1.ListOrganizationThreadsResponse, error) {
+func (f *fakeThreadsClient) ListOrganizationThreads(ctx context.Context, req *threadsv1.ListOrganizationThreadsRequest, opts ...grpc.CallOption) (*threadsv1.ListOrganizationThreadsResponse, error) {
 	return nil, testutil.ErrNotImplemented
 }
 func (f *fakeThreadsClient) GetThread(context.Context, *threadsv1.GetThreadRequest, ...grpc.CallOption) (*threadsv1.GetThreadResponse, error) {


### PR DESCRIPTION
## Summary
- Pin bootstrap provisioning to a deterministic revision:
  - `agynio/bootstrap/.github/actions/provision@1335bdb93b5d7ea3621630d504591cdf455f6d2b`
  - `with: ref: 1335bdb93b5d7ea3621630d504591cdf455f6d2b`
- Pin `agynio/e2e` composite actions to a deterministic revision (`1aa5e1ad1f7ee6c874318e3049688408ad23e2eb`).
- Bump agent init image pins to `ghcr.io/agynio/agent-init-agn:0.4.15` (required for message-id → trace correlation used by full-chain tracing-app UI E2E).
- Add stub `ListOrganizationThreads` to the fake threads client used in tests.

## Testing
- buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1
- go test ./...
- go vet -p 1 ./...
- go build ./...

Relates to #163