### PR TITLE
Subscribe to agent notification rooms

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -129,7 +129,7 @@ func run() error {
 	secretsClient := secretsv1.NewSecretsServiceClient(secretsConn)
 	runnersClient := runnersv1.NewRunnersServiceClient(runnersConn)
 	meteringClient := meteringv1.NewMeteringServiceClient(meteringConn)
-	subscriber := subscriber.New(notificationsClient)
+	subscriber := subscriber.New(notificationsClient, agentsClient)
 	assembler := assembler.New(agentsClient, secretsClient, &cfg)
 	reconciler := reconciler.New(reconciler.Config{
 		Threads:                   threadsClient,

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -3,25 +3,46 @@ package subscriber
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log"
+	"sort"
+	"strings"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	notificationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/notifications/v1"
+	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 )
 
 const (
-	messageCreatedEvent = "message.created"
-	agentUpdatedEvent   = "agent.updated"
+	messageCreatedEvent               = "message.created"
+	agentUpdatedEvent                 = "agent.updated"
+	agentRoomPrefix                   = "agent:"
+	threadParticipantRoomPrefix       = "thread_participant:"
+	listAgentsPageSize          int32 = 100
+	defaultRoomRefreshInterval        = 30 * time.Second
 )
 
-type Subscriber struct {
-	client notificationsv1.NotificationsServiceClient
-	wake   chan struct{}
+type roomSnapshot struct {
+	rooms       []string
+	fingerprint string
 }
 
-func New(client notificationsv1.NotificationsServiceClient) *Subscriber {
-	return &Subscriber{client: client, wake: make(chan struct{}, 1)}
+type Subscriber struct {
+	client              notificationsv1.NotificationsServiceClient
+	agents              agentsv1.AgentsServiceClient
+	wake                chan struct{}
+	roomRefreshInterval time.Duration
+}
+
+func New(client notificationsv1.NotificationsServiceClient, agents agentsv1.AgentsServiceClient) *Subscriber {
+	return &Subscriber{
+		client:              client,
+		agents:              agents,
+		wake:                make(chan struct{}, 1),
+		roomRefreshInterval: defaultRoomRefreshInterval,
+	}
 }
 
 func (s *Subscriber) Run(ctx context.Context) error {
@@ -30,8 +51,19 @@ func (s *Subscriber) Run(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		stream, err := s.client.Subscribe(ctx, &notificationsv1.SubscribeRequest{})
+		snapshot, err := s.buildRoomSnapshot(ctx)
 		if err != nil {
+			log.Printf("subscriber: build rooms failed: %v", err)
+			if err := waitWithBackoff(ctx, backoff); err != nil {
+				return err
+			}
+			backoff = nextBackoff(backoff)
+			continue
+		}
+		streamCtx, cancel := context.WithCancel(ctx)
+		stream, err := s.client.Subscribe(streamCtx, &notificationsv1.SubscribeRequest{Rooms: snapshot.rooms})
+		if err != nil {
+			cancel()
 			log.Printf("subscriber: subscribe failed: %v", err)
 			if err := waitWithBackoff(ctx, backoff); err != nil {
 				return err
@@ -41,11 +73,26 @@ func (s *Subscriber) Run(ctx context.Context) error {
 		}
 		backoff = time.Second
 
+		roomsUpdated := make(chan struct{})
+		watchCtx, watchCancel := context.WithCancel(streamCtx)
+		go s.watchRooms(watchCtx, snapshot, roomsUpdated, cancel)
+
 		for {
 			resp, err := stream.Recv()
 			if err != nil {
+				watchCancel()
 				if ctx.Err() != nil {
 					return ctx.Err()
+				}
+				roomsChanged := false
+				select {
+				case <-roomsUpdated:
+					log.Printf("subscriber: agent rooms changed, resubscribing")
+					roomsChanged = true
+				default:
+				}
+				if roomsChanged {
+					break
 				}
 				if errors.Is(err, io.EOF) {
 					log.Printf("subscriber: stream closed")
@@ -68,6 +115,81 @@ func (s *Subscriber) Run(ctx context.Context) error {
 				case s.wake <- struct{}{}:
 				default:
 				}
+			}
+		}
+	}
+}
+
+func (s *Subscriber) buildRoomSnapshot(ctx context.Context) (roomSnapshot, error) {
+	if s.agents == nil {
+		return roomSnapshot{}, errors.New("agents client not configured")
+	}
+	rooms := make(map[string]struct{})
+	pageToken := ""
+	for {
+		resp, err := s.agents.ListAgents(ctx, &agentsv1.ListAgentsRequest{
+			PageSize:  listAgentsPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return roomSnapshot{}, fmt.Errorf("list agents: %w", err)
+		}
+		for _, agent := range resp.GetAgents() {
+			if agent == nil {
+				return roomSnapshot{}, fmt.Errorf("agent is nil")
+			}
+			meta := agent.GetMeta()
+			if meta == nil {
+				return roomSnapshot{}, fmt.Errorf("agent meta missing")
+			}
+			agentID := strings.TrimSpace(meta.GetId())
+			parsedAgentID, err := uuidutil.ParseUUID(agentID, "agent.meta.id")
+			if err != nil {
+				return roomSnapshot{}, err
+			}
+			agentID = parsedAgentID.String()
+			rooms[agentRoomPrefix+agentID] = struct{}{}
+			rooms[threadParticipantRoomPrefix+agentID] = struct{}{}
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	if len(rooms) == 0 {
+		return roomSnapshot{}, fmt.Errorf("no agent rooms available")
+	}
+	ordered := make([]string, 0, len(rooms))
+	for room := range rooms {
+		ordered = append(ordered, room)
+	}
+	sort.Strings(ordered)
+	return roomSnapshot{
+		rooms:       ordered,
+		fingerprint: strings.Join(ordered, "|"),
+	}, nil
+}
+
+func (s *Subscriber) watchRooms(ctx context.Context, snapshot roomSnapshot, updated chan<- struct{}, cancel context.CancelFunc) {
+	if s.roomRefreshInterval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(s.roomRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			next, err := s.buildRoomSnapshot(ctx)
+			if err != nil {
+				log.Printf("subscriber: refresh rooms failed: %v", err)
+				continue
+			}
+			if next.fingerprint != snapshot.fingerprint {
+				close(updated)
+				cancel()
+				return
 			}
 		}
 	}

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"errors"
 	"io"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	notificationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/notifications/v1"
+	"github.com/agynio/agents-orchestrator/internal/testutil"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -15,20 +19,45 @@ import (
 func TestSubscriberWakeOnMessageCreated(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse, 1)
 	ack := make(chan struct{}, 1)
-	subscriber, cancel, done := newSubscriber(t, responses, ack)
-	defer cancel()
+	agentID := "11111111-1111-1111-1111-111111111111"
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour)
+	defer harness.cancel()
+	waitForSubscribe(t, harness.subscribeReqs, 1)
 
 	responses <- messageEnvelope("message.created")
 	waitForAck(t, ack, 1)
 
 	select {
-	case <-subscriber.Wake():
+	case <-harness.subscriber.Wake():
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("expected wake signal")
 	}
 
-	cancel()
-	if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
+	harness.cancel()
+	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected run error: %v", err)
+	}
+}
+
+func TestSubscriberWakeOnAgentUpdated(t *testing.T) {
+	responses := make(chan *notificationsv1.SubscribeResponse, 1)
+	ack := make(chan struct{}, 1)
+	agentID := "22222222-2222-2222-2222-222222222222"
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour)
+	defer harness.cancel()
+	waitForSubscribe(t, harness.subscribeReqs, 1)
+
+	responses <- messageEnvelope("agent.updated")
+	waitForAck(t, ack, 1)
+
+	select {
+	case <-harness.subscriber.Wake():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected wake signal")
+	}
+
+	harness.cancel()
+	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("unexpected run error: %v", err)
 	}
 }
@@ -36,20 +65,22 @@ func TestSubscriberWakeOnMessageCreated(t *testing.T) {
 func TestSubscriberIgnoresOtherEvents(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse, 1)
 	ack := make(chan struct{}, 1)
-	subscriber, cancel, done := newSubscriber(t, responses, ack)
-	defer cancel()
+	agentID := "33333333-3333-3333-3333-333333333333"
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour)
+	defer harness.cancel()
+	waitForSubscribe(t, harness.subscribeReqs, 1)
 
 	responses <- messageEnvelope("thread.updated")
 	waitForAck(t, ack, 1)
 
 	select {
-	case <-subscriber.Wake():
+	case <-harness.subscriber.Wake():
 		t.Fatal("unexpected wake signal")
 	case <-time.After(200 * time.Millisecond):
 	}
 
-	cancel()
-	if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
+	harness.cancel()
+	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("unexpected run error: %v", err)
 	}
 }
@@ -57,53 +88,132 @@ func TestSubscriberIgnoresOtherEvents(t *testing.T) {
 func TestSubscriberCoalescesWake(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse, 2)
 	ack := make(chan struct{}, 2)
-	subscriber, cancel, done := newSubscriber(t, responses, ack)
-	defer cancel()
+	agentID := "44444444-4444-4444-4444-444444444444"
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour)
+	defer harness.cancel()
+	waitForSubscribe(t, harness.subscribeReqs, 1)
 
 	responses <- messageEnvelope("message.created")
 	responses <- messageEnvelope("message.created")
 	waitForAck(t, ack, 2)
 
 	select {
-	case <-subscriber.Wake():
+	case <-harness.subscriber.Wake():
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("expected wake signal")
 	}
 
 	select {
-	case <-subscriber.Wake():
+	case <-harness.subscriber.Wake():
 		t.Fatal("expected wake to be coalesced")
 	case <-time.After(200 * time.Millisecond):
 	}
 
-	cancel()
-	if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
+	harness.cancel()
+	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("unexpected run error: %v", err)
 	}
 }
 
-func newSubscriber(t *testing.T, responses chan *notificationsv1.SubscribeResponse, ack chan struct{}) (*Subscriber, context.CancelFunc, chan error) {
+func TestSubscriberSubscribesWithRooms(t *testing.T) {
+	responses := make(chan *notificationsv1.SubscribeResponse, 1)
+	ack := make(chan struct{}, 1)
+	agentID := "55555555-5555-5555-5555-555555555555"
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour)
+	defer harness.cancel()
+
+	req := waitForSubscribe(t, harness.subscribeReqs, 1)
+	expected := []string{"agent:" + agentID, "thread_participant:" + agentID}
+	if !reflect.DeepEqual(req.GetRooms(), expected) {
+		t.Fatalf("expected rooms %v, got %v", expected, req.GetRooms())
+	}
+
+	harness.cancel()
+	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected run error: %v", err)
+	}
+}
+
+func TestSubscriberResubscribesOnAgentChange(t *testing.T) {
+	responses := make(chan *notificationsv1.SubscribeResponse)
+	ack := make(chan struct{}, 1)
+	agentID := "66666666-6666-6666-6666-666666666666"
+	updatedAgentID := "77777777-7777-7777-7777-777777777777"
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, 10*time.Millisecond)
+	defer harness.cancel()
+
+	firstReq := waitForSubscribe(t, harness.subscribeReqs, 1)
+	firstExpected := []string{"agent:" + agentID, "thread_participant:" + agentID}
+	if !reflect.DeepEqual(firstReq.GetRooms(), firstExpected) {
+		t.Fatalf("expected initial rooms %v, got %v", firstExpected, firstReq.GetRooms())
+	}
+
+	harness.store.set([]*agentsv1.Agent{agentFixture(agentID), agentFixture(updatedAgentID)})
+	secondReq := waitForSubscribe(t, harness.subscribeReqs, 1)
+	secondExpected := []string{
+		"agent:" + agentID,
+		"agent:" + updatedAgentID,
+		"thread_participant:" + agentID,
+		"thread_participant:" + updatedAgentID,
+	}
+	if !reflect.DeepEqual(secondReq.GetRooms(), secondExpected) {
+		t.Fatalf("expected updated rooms %v, got %v", secondExpected, secondReq.GetRooms())
+	}
+
+	harness.cancel()
+	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected run error: %v", err)
+	}
+}
+
+func newSubscriberHarness(t *testing.T, responses chan *notificationsv1.SubscribeResponse, ack chan struct{}, initialAgents []*agentsv1.Agent, refreshInterval time.Duration) *subscriberHarness {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
+	store := &agentStore{agents: initialAgents}
+	agentsClient := &testutil.FakeAgentsClient{ListAgentsFunc: func(ctx context.Context, req *agentsv1.ListAgentsRequest, opts ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+		return &agentsv1.ListAgentsResponse{Agents: store.list()}, nil
+	}}
+	subscribeReqs := make(chan *notificationsv1.SubscribeRequest, 4)
 	client := &fakeNotificationsClient{subscribe: func(ctx context.Context, req *notificationsv1.SubscribeRequest, opts ...grpc.CallOption) (notificationsv1.NotificationsService_SubscribeClient, error) {
+		subscribeReqs <- req
 		return &fakeSubscribeStream{
 			fakeClientStream: fakeClientStream{ctx: ctx},
 			responses:        responses,
 			ack:              ack,
 		}, nil
 	}}
-	subscriber := New(client)
+	subscriber := New(client, agentsClient)
+	subscriber.roomRefreshInterval = refreshInterval
 	done := make(chan error, 1)
 	go func() {
 		done <- subscriber.Run(ctx)
 	}()
-	return subscriber, cancel, done
+	return &subscriberHarness{
+		subscriber:    subscriber,
+		cancel:        cancel,
+		done:          done,
+		store:         store,
+		subscribeReqs: subscribeReqs,
+	}
 }
 
 func messageEnvelope(event string) *notificationsv1.SubscribeResponse {
 	return &notificationsv1.SubscribeResponse{
 		Envelope: &notificationsv1.NotificationEnvelope{Event: event},
 	}
+}
+
+func waitForSubscribe(t *testing.T, subscribeReqs <-chan *notificationsv1.SubscribeRequest, count int) *notificationsv1.SubscribeRequest {
+	t.Helper()
+	var req *notificationsv1.SubscribeRequest
+	for i := 0; i < count; i++ {
+		select {
+		case req = <-subscribeReqs:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("timeout waiting for subscribe %d", i)
+		}
+	}
+	return req
 }
 
 func waitForAck(t *testing.T, ack <-chan struct{}, count int) {
@@ -165,3 +275,34 @@ func (f fakeClientStream) Context() context.Context { return f.ctx }
 func (f fakeClientStream) SendMsg(any) error { return nil }
 
 func (f fakeClientStream) RecvMsg(any) error { return nil }
+
+type agentStore struct {
+	mu     sync.RWMutex
+	agents []*agentsv1.Agent
+}
+
+func (s *agentStore) list() []*agentsv1.Agent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	agents := make([]*agentsv1.Agent, len(s.agents))
+	copy(agents, s.agents)
+	return agents
+}
+
+func (s *agentStore) set(agents []*agentsv1.Agent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.agents = agents
+}
+
+type subscriberHarness struct {
+	subscriber    *Subscriber
+	cancel        context.CancelFunc
+	done          chan error
+	store         *agentStore
+	subscribeReqs chan *notificationsv1.SubscribeRequest
+}
+
+func agentFixture(id string) *agentsv1.Agent {
+	return &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: id}}
+}


### PR DESCRIPTION
## Summary
- build room-scoped Subscribe requests from the current agent list and wake on agent.updated
- resubscribe when the agent set changes to keep room coverage updated
- expand subscriber tests to validate room lists and resubscribe behavior

## Room list derivation
Rooms are derived by listing Agents and using each agent's `meta.id` as both `agent:{id}` and
`thread_participant:{id}` (sorted, de-duplicated). The stream is restarted when the computed
room list changes.

## Testing
- buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1
- go vet ./...
- go test ./...
- go build ./...

Refs https://github.com/agynio/architecture/issues/142