### PR TITLE
Use internal runners reads in reconciler

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,9 +30,9 @@ jobs:
           path: service
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@17008dc24ccf6d6019ce47abc8c43be053671a8d
+        uses: agynio/bootstrap/.github/actions/provision@ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
         with:
-          ref: 17008dc24ccf6d6019ce47abc8c43be053671a8d
+          ref: ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@e20c83d821f789d2df96038826aed5aa25b91070

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: agynio/runners
-          ref: 7ae169ea800ea9648adb2202fd70e4ab8ea71771
+          ref: 0648a7fd8fe0ebea560e593809f460d78bb41f3f
           path: runners
 
       - name: Deploy runners from source

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,10 +10,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.16
+  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.15
   CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.20
-  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.11
-  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.16
+  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.23
+  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.15
   AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
   RUNNERS_REF: 0648a7fd8fe0ebea560e593809f460d78bb41f3f
 
@@ -30,9 +30,9 @@ jobs:
           path: service
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
+        uses: agynio/bootstrap/.github/actions/provision@17008dc24ccf6d6019ce47abc8c43be053671a8d
         with:
-          ref: ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
+          ref: 17008dc24ccf6d6019ce47abc8c43be053671a8d
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@e20c83d821f789d2df96038826aed5aa25b91070

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
 
       - name: Setup DevSpace
-        uses: agynio/e2e/.github/actions/setup-devspace@a5e483ad61ebf8133c2b92044e5dc2403c99d840
+        uses: agynio/e2e/.github/actions/setup-devspace@e20c83d821f789d2df96038826aed5aa25b91070
 
       - name: Checkout runners
         uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
         run: devspace run deploy -n platform
 
       - name: Run E2E tests
-        uses: agynio/e2e/.github/actions/run-tests@a5e483ad61ebf8133c2b92044e5dc2403c99d840
+        uses: agynio/e2e/.github/actions/run-tests@e20c83d821f789d2df96038826aed5aa25b91070
         env:
           AGN_INIT_IMAGE: ${{ env.AGN_INIT_IMAGE }}
           CODEX_INIT_IMAGE: ${{ env.CODEX_INIT_IMAGE }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,8 +10,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.16
-  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.16
+  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
+  CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
+  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
+  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
 
 jobs:
   e2e:
@@ -52,6 +54,8 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@a5e483ad61ebf8133c2b92044e5dc2403c99d840
         env:
           AGN_INIT_IMAGE: ${{ env.AGN_INIT_IMAGE }}
+          CODEX_INIT_IMAGE: ${{ env.CODEX_INIT_IMAGE }}
+          CLAUDE_INIT_IMAGE: ${{ env.CLAUDE_INIT_IMAGE }}
           AGN_EXPOSE_INIT_IMAGE: ${{ env.AGN_EXPOSE_INIT_IMAGE }}
         with:
           service: agents_orchestrator

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,9 +30,7 @@ jobs:
           path: service
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
-        with:
-          ref: ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
+        uses: agynio/bootstrap/.github/actions/provision@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@ddf19ce30ef4abc4be8d7981cb7db1a9f479f405

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ env:
   CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
   CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
   AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
+  AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
 
 jobs:
   e2e:
@@ -57,6 +58,7 @@ jobs:
           CODEX_INIT_IMAGE: ${{ env.CODEX_INIT_IMAGE }}
           CLAUDE_INIT_IMAGE: ${{ env.CLAUDE_INIT_IMAGE }}
           AGN_EXPOSE_INIT_IMAGE: ${{ env.AGN_EXPOSE_INIT_IMAGE }}
+          AGYN_AGENT_INIT_IMAGE: ${{ env.AGYN_AGENT_INIT_IMAGE }}
         with:
           service: agents_orchestrator
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,10 +10,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
-  CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
-  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
-  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
+  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.16
+  CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.20
+  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.11
+  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.16
   AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
   RUNNERS_REF: 0648a7fd8fe0ebea560e593809f460d78bb41f3f
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,12 +10,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.15
+  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.16
   CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.20
   CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.23
-  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.15
+  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4.16
   AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
-  RUNNERS_REF: 0648a7fd8fe0ebea560e593809f460d78bb41f3f
+  RUNNERS_REF: fe33df94a8057d381949c9f063f7f23be8217f0a
 
 jobs:
   e2e:
@@ -35,7 +35,7 @@ jobs:
           ref: ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
 
       - name: Setup DevSpace
-        uses: agynio/e2e/.github/actions/setup-devspace@e20c83d821f789d2df96038826aed5aa25b91070
+        uses: agynio/e2e/.github/actions/setup-devspace@ddf19ce30ef4abc4be8d7981cb7db1a9f479f405
 
       - name: Checkout runners
         uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
         run: devspace run deploy -n platform
 
       - name: Run E2E tests
-        uses: agynio/e2e/.github/actions/run-tests@e20c83d821f789d2df96038826aed5aa25b91070
+        uses: agynio/e2e/.github/actions/run-tests@ddf19ce30ef4abc4be8d7981cb7db1a9f479f405
         env:
           AGN_INIT_IMAGE: ${{ env.AGN_INIT_IMAGE }}
           CODEX_INIT_IMAGE: ${{ env.CODEX_INIT_IMAGE }}
@@ -61,6 +61,7 @@ jobs:
           AGN_EXPOSE_INIT_IMAGE: ${{ env.AGN_EXPOSE_INIT_IMAGE }}
           AGYN_AGENT_INIT_IMAGE: ${{ env.AGYN_AGENT_INIT_IMAGE }}
         with:
+          ref: 0a4f88cc9d2392234dd2faa88427d3051e2722d0
           service: agents_orchestrator
 
       - name: Restore ArgoCD sync

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,7 @@ env:
   CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
   AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
   AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
+  RUNNERS_REF: 0648a7fd8fe0ebea560e593809f460d78bb41f3f
 
 jobs:
   e2e:
@@ -40,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: agynio/runners
-          ref: 0648a7fd8fe0ebea560e593809f460d78bb41f3f
+          ref: ${{ env.RUNNERS_REF }}
           path: runners
 
       - name: Deploy runners from source

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -92,8 +92,6 @@ env:
     value: ""
   - name: AGENT_TRACING_ADDRESS
     value: ""
-  - name: CLUSTER_ADMIN_IDENTITY_ID
-    value: ""
   - name: POLL_INTERVAL
     value: ""
   - name: IDLE_TIMEOUT

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -139,7 +139,6 @@ func run() error {
 		Runners:                   runnersClient,
 		Metering:                  meteringClient,
 		Assembler:                 assembler,
-		ClusterAdminIdentityID:    cfg.ClusterAdminIdentityID,
 		Wake:                      subscriber.Wake(),
 		Poll:                      cfg.PollInterval,
 		WorkloadReconcileInterval: cfg.WorkloadReconcileInterval,

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -441,7 +441,6 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 	t.Setenv("CLUSTER_DNS", "")
 	t.Setenv("AGENT_GATEWAY_ADDRESS", "")
 	t.Setenv("AGENT_LLM_BASE_URL", "")
-	t.Setenv("CLUSTER_ADMIN_IDENTITY_ID", "44444444-4444-4444-4444-444444444444")
 	t.Setenv("POLL_INTERVAL", "")
 	t.Setenv("IDLE_TIMEOUT", "")
 	t.Setenv("STOP_TIMEOUT_SEC", "")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,13 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"time"
-
-	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 )
-
-const defaultClusterAdminIdentityID = "a3c1e9d2-7f4b-5e1a-9c3d-2b8f6a4e7d10"
 
 type Config struct {
 	ThreadsAddress            string
@@ -30,7 +25,6 @@ type Config struct {
 	AgentGatewayAddress       string
 	AgentTracingAddress       string
 	AgentLLMBaseURL           string
-	ClusterAdminIdentityID    string
 	PollInterval              time.Duration
 	WorkloadReconcileInterval time.Duration
 	IdleTimeout               time.Duration
@@ -114,15 +108,6 @@ func FromEnv() (Config, error) {
 			cfg.AgentLLMBaseURL = "http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080/v1"
 		}
 	}
-	clusterAdminIdentityID := strings.TrimSpace(os.Getenv("CLUSTER_ADMIN_IDENTITY_ID"))
-	if clusterAdminIdentityID == "" {
-		clusterAdminIdentityID = defaultClusterAdminIdentityID
-	}
-	parsedClusterAdminID, err := uuidutil.ParseUUID(clusterAdminIdentityID, "CLUSTER_ADMIN_IDENTITY_ID")
-	if err != nil {
-		return Config{}, err
-	}
-	cfg.ClusterAdminIdentityID = parsedClusterAdminID.String()
 	cfg.ZitiManagementAddress = os.Getenv("ZITI_MANAGEMENT_ADDRESS")
 	if cfg.ZitiManagementAddress == "" {
 		cfg.ZitiManagementAddress = "ziti-management:50051"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,9 +43,6 @@ func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	if cfg.WorkloadReconcileInterval != time.Minute {
 		t.Fatalf("expected workload reconcile interval %q, got %q", time.Minute, cfg.WorkloadReconcileInterval)
 	}
-	if cfg.ClusterAdminIdentityID != defaultClusterAdminIdentityID {
-		t.Fatalf("expected cluster admin identity id %q, got %q", defaultClusterAdminIdentityID, cfg.ClusterAdminIdentityID)
-	}
 }
 
 func TestFromEnvDefaultsZiti(t *testing.T) {
@@ -86,15 +83,6 @@ func TestFromEnvAgentTracingAddress(t *testing.T) {
 	}
 }
 
-func TestFromEnvRejectsInvalidClusterAdminIdentityID(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("CLUSTER_ADMIN_IDENTITY_ID", "not-a-uuid")
-
-	if _, err := FromEnv(); err == nil {
-		t.Fatal("expected error for invalid CLUSTER_ADMIN_IDENTITY_ID")
-	}
-}
-
 func setBaseEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost:5432/db")
@@ -114,7 +102,6 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("AGENT_GATEWAY_ADDRESS", "")
 	t.Setenv("AGENT_TRACING_ADDRESS", "")
 	t.Setenv("AGENT_LLM_BASE_URL", "")
-	t.Setenv("CLUSTER_ADMIN_IDENTITY_ID", "")
 	t.Setenv("POLL_INTERVAL", "")
 	t.Setenv("WORKLOAD_RECONCILE_INTERVAL", "")
 	t.Setenv("IDLE_TIMEOUT", "")

--- a/internal/reconciler/actual.go
+++ b/internal/reconciler/actual.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 )
 
 const activeWorkloadPageSize int32 = 100
@@ -36,44 +38,50 @@ func (r *Reconciler) listActiveWorkloads(ctx context.Context, orgIdentities map[
 	if len(orgIdentities) == 0 {
 		return active, nil
 	}
-	runnerCtx, err := r.clusterAdminRunnerContext(ctx)
-	if err != nil {
-		return nil, err
+	pageToken := ""
+	statuses := []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING,
 	}
-	for orgID := range orgIdentities {
-		orgIDCopy := orgID
-		pageToken := ""
-		for {
-			resp, err := r.runners.ListWorkloads(runnerCtx, &runnersv1.ListWorkloadsRequest{
-				PageSize:       activeWorkloadPageSize,
-				PageToken:      pageToken,
-				OrganizationId: &orgIDCopy,
-				Statuses: []runnersv1.WorkloadStatus{
-					runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
-					runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
-					runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING,
-				},
-			})
+	for {
+		resp, err := r.runners.ListWorkloads(runnersContext(ctx), &runnersv1.ListWorkloadsRequest{
+			PageSize:  activeWorkloadPageSize,
+			PageToken: pageToken,
+			Filter: &runnersv1.ListWorkloadsFilter{
+				StatusIn: statuses,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list workloads: %w", err)
+		}
+		for _, workload := range resp.GetWorkloads() {
+			if workload == nil {
+				return nil, fmt.Errorf("workload is nil")
+			}
+			meta := workload.GetMeta()
+			if meta == nil {
+				return nil, fmt.Errorf("workload meta missing")
+			}
+			if meta.GetId() == "" {
+				return nil, fmt.Errorf("workload meta id missing")
+			}
+			orgID := strings.TrimSpace(workload.GetOrganizationId())
+			if orgID == "" {
+				return nil, fmt.Errorf("workload %s organization id missing", meta.GetId())
+			}
+			parsedOrgID, err := uuidutil.ParseUUID(orgID, "workload.organization_id")
 			if err != nil {
-				return nil, fmt.Errorf("list workloads: %w", err)
+				return nil, err
 			}
-			for _, workload := range resp.GetWorkloads() {
-				if workload == nil {
-					return nil, fmt.Errorf("workload is nil")
-				}
-				meta := workload.GetMeta()
-				if meta == nil {
-					return nil, fmt.Errorf("workload meta missing")
-				}
-				if meta.GetId() == "" {
-					return nil, fmt.Errorf("workload meta id missing")
-				}
-				active = append(active, workload)
+			if _, ok := orgIdentities[parsedOrgID.String()]; !ok {
+				continue
 			}
-			pageToken = resp.GetNextPageToken()
-			if pageToken == "" {
-				break
-			}
+			active = append(active, workload)
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
 		}
 	}
 	return active, nil

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -28,9 +28,10 @@ func (f *fakeAgentsClient) ListAgents(ctx context.Context, req *agentsv1.ListAge
 }
 
 type fakeThreadsClient struct {
-	getThreads         func(context.Context, *threadsv1.GetThreadsRequest, ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error)
-	getUnackedMessages func(context.Context, *threadsv1.GetUnackedMessagesRequest, ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error)
-	degradeThread      func(context.Context, *threadsv1.DegradeThreadRequest, ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error)
+	getThreads              func(context.Context, *threadsv1.GetThreadsRequest, ...grpc.CallOption) (*threadsv1.GetThreadsResponse, error)
+	getUnackedMessages      func(context.Context, *threadsv1.GetUnackedMessagesRequest, ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error)
+	getUnackedMessageCounts func(context.Context, *threadsv1.GetUnackedMessageCountsRequest, ...grpc.CallOption) (*threadsv1.GetUnackedMessageCountsResponse, error)
+	degradeThread           func(context.Context, *threadsv1.DegradeThreadRequest, ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error)
 }
 
 func (f *fakeThreadsClient) CreateThread(context.Context, *threadsv1.CreateThreadRequest, ...grpc.CallOption) (*threadsv1.CreateThreadResponse, error) {
@@ -78,6 +79,13 @@ func (f *fakeThreadsClient) GetMessages(context.Context, *threadsv1.GetMessagesR
 func (f *fakeThreadsClient) GetUnackedMessages(ctx context.Context, req *threadsv1.GetUnackedMessagesRequest, opts ...grpc.CallOption) (*threadsv1.GetUnackedMessagesResponse, error) {
 	if f.getUnackedMessages != nil {
 		return f.getUnackedMessages(ctx, req, opts...)
+	}
+	return nil, testutil.ErrNotImplemented
+}
+
+func (f *fakeThreadsClient) GetUnackedMessageCounts(ctx context.Context, req *threadsv1.GetUnackedMessageCountsRequest, opts ...grpc.CallOption) (*threadsv1.GetUnackedMessageCountsResponse, error) {
+	if f.getUnackedMessageCounts != nil {
+		return f.getUnackedMessageCounts(ctx, req, opts...)
 	}
 	return nil, testutil.ErrNotImplemented
 }
@@ -135,7 +143,7 @@ func TestFetchDesiredSkipsPassiveThreads(t *testing.T) {
 		},
 	}
 
-	reconciler := New(Config{Agents: agents, Threads: threads, ClusterAdminIdentityID: testClusterAdminIdentityID})
+	reconciler := New(Config{Agents: agents, Threads: threads})
 	result, _, _, err := reconciler.fetchDesired(ctx)
 	if err != nil {
 		t.Fatalf("fetch desired: %v", err)
@@ -200,7 +208,7 @@ func TestFetchDesiredSkipsDegradedThreads(t *testing.T) {
 		},
 	}
 
-	reconciler := New(Config{Agents: agents, Threads: threads, ClusterAdminIdentityID: testClusterAdminIdentityID})
+	reconciler := New(Config{Agents: agents, Threads: threads})
 	result, _, _, err := reconciler.fetchDesired(ctx)
 	if err != nil {
 		t.Fatalf("fetch desired: %v", err)
@@ -242,7 +250,7 @@ func TestFetchDesiredSkipsPassiveLookupWithoutMessages(t *testing.T) {
 		},
 	}
 
-	reconciler := New(Config{Agents: agents, Threads: threads, ClusterAdminIdentityID: testClusterAdminIdentityID})
+	reconciler := New(Config{Agents: agents, Threads: threads})
 	result, _, _, err := reconciler.fetchDesired(ctx)
 	if err != nil {
 		t.Fatalf("fetch desired: %v", err)

--- a/internal/reconciler/identity_metadata.go
+++ b/internal/reconciler/identity_metadata.go
@@ -21,15 +21,21 @@ func runnerIdentityContext(ctx context.Context, identityID string) (context.Cont
 	return metadata.NewOutgoingContext(ctx, metadata.Pairs(identityMetadataKey, identityID)), nil
 }
 
-func (r *Reconciler) clusterAdminRunnerContext(ctx context.Context) (context.Context, error) {
-	if r.clusterAdminIdentityID == "" {
-		return nil, fmt.Errorf("cluster admin identity id missing")
-	}
-	return runnerIdentityContext(ctx, r.clusterAdminIdentityID)
-}
-
 func (r *Reconciler) runnerIdentityContextForAgent(ctx context.Context, agentID uuid.UUID) (context.Context, error) {
 	return runnerIdentityContext(ctx, agentID.String())
+}
+
+func runnersContext(ctx context.Context) context.Context {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return ctx
+	}
+	if len(md.Get(identityMetadataKey)) == 0 {
+		return ctx
+	}
+	cleaned := md.Copy()
+	cleaned.Delete(identityMetadataKey)
+	return metadata.NewOutgoingContext(ctx, cleaned)
 }
 
 func (r *Reconciler) agentIdentityByOrg(ctx context.Context) (map[string]string, error) {

--- a/internal/reconciler/lifecycle_helpers.go
+++ b/internal/reconciler/lifecycle_helpers.go
@@ -46,7 +46,7 @@ func (r *Reconciler) markWorkloadFailed(ctx context.Context, workloadID string, 
 	if len(containers) > 0 {
 		req.Containers = containers
 	}
-	if _, err := r.runners.UpdateWorkload(ctx, req); err != nil {
+	if _, err := r.runners.UpdateWorkload(runnersContext(ctx), req); err != nil {
 		log.Printf("reconciler: update workload %s to failed: %v", workloadID, err)
 	}
 }
@@ -57,7 +57,7 @@ func (r *Reconciler) createWorkloadRecord(ctx context.Context, workloadID, runne
 	if zitiIdentityID != nil {
 		zitiIdentityValue = *zitiIdentityID
 	}
-	_, err := r.runners.CreateWorkload(ctx, &runnersv1.CreateWorkloadRequest{
+	_, err := r.runners.CreateWorkload(runnersContext(ctx), &runnersv1.CreateWorkloadRequest{
 		Id:                     workloadID,
 		RunnerId:               runnerID,
 		ThreadId:               target.ThreadID.String(),
@@ -96,7 +96,7 @@ func (r *Reconciler) createVolumeRecords(ctx context.Context, records []volumeRe
 			SizeGb:         record.sizeGB,
 			Status:         runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
 		}
-		if _, err := r.runners.CreateVolume(ctx, req); err != nil {
+		if _, err := r.runners.CreateVolume(runnersContext(ctx), req); err != nil {
 			return created, err
 		}
 		created = append(created, record)
@@ -115,7 +115,7 @@ func (r *Reconciler) markVolumeRecordsFailed(ctx context.Context, records []volu
 			log.Printf("reconciler: volume record missing id")
 			continue
 		}
-		_, err := r.runners.UpdateVolume(ctx, &runnersv1.UpdateVolumeRequest{
+		_, err := r.runners.UpdateVolume(runnersContext(ctx), &runnersv1.UpdateVolumeRequest{
 			Id:        record.id,
 			Status:    &status,
 			RemovedAt: removedAt,

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -26,7 +26,6 @@ const (
 	testOrganizationID         = "11111111-1111-1111-1111-111111111111"
 	testAgentID                = "22222222-2222-2222-2222-222222222222"
 	testAgentIDAlt             = "33333333-3333-3333-3333-333333333333"
-	testClusterAdminIdentityID = "44444444-4444-4444-4444-444444444444"
 	testAllocatedCPUMillicores = int32(500)
 	testAllocatedRAMBytes      = int64(1 << 30)
 )
@@ -1173,11 +1172,11 @@ func TestReconcileOrphanIdentitiesDeletesOrphans(t *testing.T) {
 
 	runners := &fakeRunnersClient{
 		listWorkloads: func(_ context.Context, req *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
-			if len(req.GetStatuses()) == 0 {
+			if len(req.GetFilter().GetStatusIn()) == 0 {
 				return nil, errors.New("missing statuses")
 			}
 			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
-				{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, ZitiIdentityId: activeID},
+				{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, OrganizationId: testOrganizationID, ZitiIdentityId: activeID},
 			}}, nil
 		},
 	}
@@ -1226,7 +1225,7 @@ func TestFetchActualReturnsTrackedWorkloads(t *testing.T) {
 	runners := &fakeRunnersClient{
 		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
 			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
-				{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID},
+				{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, RunnerId: runnerID, OrganizationId: testOrganizationID},
 			}}, nil
 		},
 	}
@@ -1252,7 +1251,7 @@ func TestFetchActualSkipsMissingRunnerID(t *testing.T) {
 	runners := &fakeRunnersClient{
 		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
 			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
-				{Meta: &runnersv1.EntityMeta{Id: "workload-1"}},
+				{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, OrganizationId: testOrganizationID},
 			}}, nil
 		},
 	}
@@ -1282,9 +1281,6 @@ func newTestReconciler(cfg Config) *Reconciler {
 	}
 	if cfg.MeteringSampleInterval == 0 {
 		cfg.MeteringSampleInterval = time.Minute
-	}
-	if cfg.ClusterAdminIdentityID == "" {
-		cfg.ClusterAdminIdentityID = testClusterAdminIdentityID
 	}
 	if cfg.RunnerDialer == nil {
 		cfg.RunnerDialer = &fakeRunnerDialer{}

--- a/internal/reconciler/metering_sample.go
+++ b/internal/reconciler/metering_sample.go
@@ -77,8 +77,8 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 	}
 
 	records := make([]*meteringv1.UsageRecord, 0, len(workloads)*2+len(volumes))
-	workloadUpdates := make(map[string][]*runnersv1.SampledAtEntry)
-	volumeUpdates := make(map[string][]*runnersv1.SampledAtEntry)
+	workloadUpdates := make([]*runnersv1.SampledAtEntry, 0, len(workloads))
+	volumeUpdates := make([]*runnersv1.SampledAtEntry, 0, len(volumes))
 
 	for _, workload := range workloads {
 		workloadRecords, update, err := sampleWorkloadMetering(workload, now)
@@ -86,23 +86,7 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 			return err
 		}
 		if update != nil {
-			meta := workload.GetMeta()
-			if meta == nil {
-				return fmt.Errorf("workload meta missing")
-			}
-			orgID := strings.TrimSpace(workload.GetOrganizationId())
-			if orgID == "" {
-				return fmt.Errorf("workload %s organization id missing", meta.GetId())
-			}
-			parsedOrgID, err := uuidutil.ParseUUID(orgID, "workload.organization_id")
-			if err != nil {
-				return err
-			}
-			identityID, ok := orgIdentities[parsedOrgID.String()]
-			if !ok {
-				return fmt.Errorf("workload %s missing identity for org %s", meta.GetId(), orgID)
-			}
-			workloadUpdates[identityID] = append(workloadUpdates[identityID], update)
+			workloadUpdates = append(workloadUpdates, update)
 		}
 		records = append(records, workloadRecords...)
 	}
@@ -112,23 +96,7 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 			return err
 		}
 		if update != nil {
-			meta := volume.GetMeta()
-			if meta == nil {
-				return fmt.Errorf("volume meta missing")
-			}
-			orgID := strings.TrimSpace(volume.GetOrganizationId())
-			if orgID == "" {
-				return fmt.Errorf("volume %s organization id missing", meta.GetId())
-			}
-			parsedOrgID, err := uuidutil.ParseUUID(orgID, "volume.organization_id")
-			if err != nil {
-				return err
-			}
-			identityID, ok := orgIdentities[parsedOrgID.String()]
-			if !ok {
-				return fmt.Errorf("volume %s missing identity for org %s", meta.GetId(), orgID)
-			}
-			volumeUpdates[identityID] = append(volumeUpdates[identityID], update)
+			volumeUpdates = append(volumeUpdates, update)
 		}
 		if volumeRecord != nil {
 			records = append(records, volumeRecord)
@@ -140,27 +108,13 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 			return fmt.Errorf("record metering: %w", err)
 		}
 	}
-	for identityID, entries := range workloadUpdates {
-		if len(entries) == 0 {
-			continue
-		}
-		runnerCtx, err := runnerIdentityContext(ctx, identityID)
-		if err != nil {
-			return err
-		}
-		if _, err := r.runners.BatchUpdateWorkloadSampledAt(runnerCtx, &runnersv1.BatchUpdateWorkloadSampledAtRequest{Entries: entries}); err != nil {
+	if len(workloadUpdates) > 0 {
+		if _, err := r.runners.BatchUpdateWorkloadSampledAt(runnersContext(ctx), &runnersv1.BatchUpdateWorkloadSampledAtRequest{Entries: workloadUpdates}); err != nil {
 			return fmt.Errorf("update workloads sampled_at: %w", err)
 		}
 	}
-	for identityID, entries := range volumeUpdates {
-		if len(entries) == 0 {
-			continue
-		}
-		runnerCtx, err := runnerIdentityContext(ctx, identityID)
-		if err != nil {
-			return err
-		}
-		if _, err := r.runners.BatchUpdateVolumeSampledAt(runnerCtx, &runnersv1.BatchUpdateVolumeSampledAtRequest{Entries: entries}); err != nil {
+	if len(volumeUpdates) > 0 {
+		if _, err := r.runners.BatchUpdateVolumeSampledAt(runnersContext(ctx), &runnersv1.BatchUpdateVolumeSampledAtRequest{Entries: volumeUpdates}); err != nil {
 			return fmt.Errorf("update volumes sampled_at: %w", err)
 		}
 	}
@@ -172,40 +126,45 @@ func (r *Reconciler) listPendingSampleWorkloads(ctx context.Context, orgIdentiti
 	if len(orgIdentities) == 0 {
 		return workloads, nil
 	}
-	runnerCtx, err := r.clusterAdminRunnerContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for orgID := range orgIdentities {
-		orgIDCopy := orgID
-		pageToken := ""
-		for {
-			resp, err := r.runners.ListWorkloads(runnerCtx, &runnersv1.ListWorkloadsRequest{
-				PageSize:       meteringSamplePageSize,
-				PageToken:      pageToken,
-				OrganizationId: &orgIDCopy,
-				PendingSample:  boolPtr(true),
-			})
+	pageToken := ""
+	for {
+		resp, err := r.runners.ListWorkloads(runnersContext(ctx), &runnersv1.ListWorkloadsRequest{
+			PageSize:  meteringSamplePageSize,
+			PageToken: pageToken,
+			Filter: &runnersv1.ListWorkloadsFilter{
+				PendingSample: boolPtr(true),
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list workloads for metering: %w", err)
+		}
+		for _, workload := range resp.GetWorkloads() {
+			if workload == nil {
+				return nil, fmt.Errorf("workload is nil")
+			}
+			meta := workload.GetMeta()
+			if meta == nil {
+				return nil, fmt.Errorf("workload meta missing")
+			}
+			if meta.GetId() == "" {
+				return nil, fmt.Errorf("workload meta id missing")
+			}
+			orgID := strings.TrimSpace(workload.GetOrganizationId())
+			if orgID == "" {
+				return nil, fmt.Errorf("workload %s organization id missing", meta.GetId())
+			}
+			parsedOrgID, err := uuidutil.ParseUUID(orgID, "workload.organization_id")
 			if err != nil {
-				return nil, fmt.Errorf("list workloads for metering: %w", err)
+				return nil, err
 			}
-			for _, workload := range resp.GetWorkloads() {
-				if workload == nil {
-					return nil, fmt.Errorf("workload is nil")
-				}
-				meta := workload.GetMeta()
-				if meta == nil {
-					return nil, fmt.Errorf("workload meta missing")
-				}
-				if meta.GetId() == "" {
-					return nil, fmt.Errorf("workload meta id missing")
-				}
-				workloads = append(workloads, workload)
+			if _, ok := orgIdentities[parsedOrgID.String()]; !ok {
+				continue
 			}
-			pageToken = resp.GetNextPageToken()
-			if pageToken == "" {
-				break
-			}
+			workloads = append(workloads, workload)
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
 		}
 	}
 	return workloads, nil
@@ -216,40 +175,45 @@ func (r *Reconciler) listPendingSampleVolumes(ctx context.Context, orgIdentities
 	if len(orgIdentities) == 0 {
 		return volumes, nil
 	}
-	runnerCtx, err := r.clusterAdminRunnerContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for orgID := range orgIdentities {
-		orgIDCopy := orgID
-		pageToken := ""
-		for {
-			resp, err := r.runners.ListVolumes(runnerCtx, &runnersv1.ListVolumesRequest{
-				PageSize:       meteringSamplePageSize,
-				PageToken:      pageToken,
-				OrganizationId: &orgIDCopy,
-				PendingSample:  boolPtr(true),
-			})
+	pageToken := ""
+	for {
+		resp, err := r.runners.ListVolumes(runnersContext(ctx), &runnersv1.ListVolumesRequest{
+			PageSize:  meteringSamplePageSize,
+			PageToken: pageToken,
+			Filter: &runnersv1.ListVolumesFilter{
+				PendingSample: boolPtr(true),
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list volumes for metering: %w", err)
+		}
+		for _, volume := range resp.GetVolumes() {
+			if volume == nil {
+				return nil, fmt.Errorf("volume is nil")
+			}
+			meta := volume.GetMeta()
+			if meta == nil {
+				return nil, fmt.Errorf("volume meta missing")
+			}
+			if meta.GetId() == "" {
+				return nil, fmt.Errorf("volume meta id missing")
+			}
+			orgID := strings.TrimSpace(volume.GetOrganizationId())
+			if orgID == "" {
+				return nil, fmt.Errorf("volume %s organization id missing", meta.GetId())
+			}
+			parsedOrgID, err := uuidutil.ParseUUID(orgID, "volume.organization_id")
 			if err != nil {
-				return nil, fmt.Errorf("list volumes for metering: %w", err)
+				return nil, err
 			}
-			for _, volume := range resp.GetVolumes() {
-				if volume == nil {
-					return nil, fmt.Errorf("volume is nil")
-				}
-				meta := volume.GetMeta()
-				if meta == nil {
-					return nil, fmt.Errorf("volume meta missing")
-				}
-				if meta.GetId() == "" {
-					return nil, fmt.Errorf("volume meta id missing")
-				}
-				volumes = append(volumes, volume)
+			if _, ok := orgIdentities[parsedOrgID.String()]; !ok {
+				continue
 			}
-			pageToken = resp.GetNextPageToken()
-			if pageToken == "" {
-				break
-			}
+			volumes = append(volumes, volume)
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
 		}
 	}
 	return volumes, nil

--- a/internal/reconciler/metering_sample_test.go
+++ b/internal/reconciler/metering_sample_test.go
@@ -86,7 +86,7 @@ func TestSampleMeteringEmitsRecordsAndUpdatesSampledAt(t *testing.T) {
 
 	runners := &fakeRunnersClient{
 		listWorkloads: func(_ context.Context, req *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
-			if !req.GetPendingSample() {
+			if !req.GetFilter().GetPendingSample() {
 				return nil, errors.New("expected pending sample workload request")
 			}
 			if req.GetPageToken() == "" {
@@ -98,7 +98,7 @@ func TestSampleMeteringEmitsRecordsAndUpdatesSampledAt(t *testing.T) {
 			return nil, errors.New("unexpected workload page token")
 		},
 		listVolumes: func(_ context.Context, req *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
-			if !req.GetPendingSample() {
+			if !req.GetFilter().GetPendingSample() {
 				return nil, errors.New("expected pending sample volume request")
 			}
 			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{volume}}, nil
@@ -126,7 +126,6 @@ func TestSampleMeteringEmitsRecordsAndUpdatesSampledAt(t *testing.T) {
 		Metering:               metering,
 		Agents:                 defaultAgentsClient(),
 		MeteringSampleInterval: time.Minute,
-		ClusterAdminIdentityID: testClusterAdminIdentityID,
 	})
 	if err := reconciler.sampleMetering(ctx, now); err != nil {
 		t.Fatalf("sample metering: %v", err)

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -229,7 +229,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 		}
 		selectedRunner = runner
 	} else {
-		selectedRunner, err = r.selectRunner(runnerCtx, target.AgentID.String(), assembled.OrganizationID, assembled.RunnerLabels, assembled.Request.GetCapabilities())
+		selectedRunner, err = r.selectRunner(ctx, assembled.OrganizationID, assembled.RunnerLabels, assembled.Request.GetCapabilities())
 		if err != nil {
 			log.Printf("reconciler: select runner for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
 			return

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -34,7 +34,6 @@ type Reconciler struct {
 	meteringSampleInterval    time.Duration
 	zitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
 	assembler                 *assembler.Assembler
-	clusterAdminIdentityID    string
 	wake                      <-chan struct{}
 	poll                      time.Duration
 	workloadReconcileInterval time.Duration
@@ -50,7 +49,6 @@ type Config struct {
 	Metering                  meteringv1.MeteringServiceClient
 	ZitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
 	Assembler                 *assembler.Assembler
-	ClusterAdminIdentityID    string
 	Wake                      <-chan struct{}
 	Poll                      time.Duration
 	WorkloadReconcileInterval time.Duration
@@ -69,7 +67,6 @@ func New(cfg Config) *Reconciler {
 		meteringSampleInterval:    cfg.MeteringSampleInterval,
 		zitiMgmt:                  cfg.ZitiMgmt,
 		assembler:                 cfg.Assembler,
-		clusterAdminIdentityID:    cfg.ClusterAdminIdentityID,
 		wake:                      cfg.Wake,
 		poll:                      cfg.Poll,
 		workloadReconcileInterval: cfg.WorkloadReconcileInterval,
@@ -334,7 +331,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 		Id:         workloadIDValue,
 		InstanceId: stringPtr(instanceID),
 	}
-	if _, err := r.runners.UpdateWorkload(runnerCtx, updateReq); err != nil {
+	if _, err := r.runners.UpdateWorkload(runnersContext(runnerCtx), updateReq); err != nil {
 		log.Printf("reconciler: update workload record %s after start: %v", workloadIDValue, err)
 	}
 }
@@ -373,7 +370,7 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 		return
 	}
 	stoppingStatus := runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING
-	if _, err := r.runners.UpdateWorkload(runnerCtx, &runnersv1.UpdateWorkloadRequest{
+	if _, err := r.runners.UpdateWorkload(runnersContext(runnerCtx), &runnersv1.UpdateWorkloadRequest{
 		Id:     workloadID,
 		Status: &stoppingStatus,
 	}); err != nil {
@@ -391,7 +388,7 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 		return
 	}
 	stoppedStatus := runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED
-	if _, err := r.runners.UpdateWorkload(runnerCtx, &runnersv1.UpdateWorkloadRequest{
+	if _, err := r.runners.UpdateWorkload(runnersContext(runnerCtx), &runnersv1.UpdateWorkloadRequest{
 		Id:        workloadID,
 		Status:    &stoppedStatus,
 		RemovedAt: timestamppb.New(time.Now().UTC()),

--- a/internal/reconciler/runner_pinning.go
+++ b/internal/reconciler/runner_pinning.go
@@ -18,7 +18,7 @@ func (r *Reconciler) pinnedRunnerForThread(ctx context.Context, threadID string)
 	pageToken := ""
 	runnerID := ""
 	for {
-		resp, err := r.runners.ListVolumesByThread(ctx, &runnersv1.ListVolumesByThreadRequest{
+		resp, err := r.runners.ListVolumesByThread(runnersContext(ctx), &runnersv1.ListVolumesByThreadRequest{
 			ThreadId:  threadID,
 			PageSize:  volumesByThreadPageSize,
 			PageToken: pageToken,
@@ -72,7 +72,7 @@ func (r *Reconciler) getRunnerIfEnrolled(ctx context.Context, runnerID string) (
 	if runnerID == "" {
 		return nil, false, fmt.Errorf("runner id missing")
 	}
-	resp, err := r.runners.GetRunner(ctx, &runnersv1.GetRunnerRequest{Id: runnerID})
+	resp, err := r.runners.GetRunner(runnersContext(ctx), &runnersv1.GetRunnerRequest{Id: runnerID})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
 			return nil, false, nil

--- a/internal/reconciler/runners.go
+++ b/internal/reconciler/runners.go
@@ -30,7 +30,7 @@ func (r *Reconciler) listRunners(ctx context.Context, organizationID string) ([]
 	var runners []*runnersv1.Runner
 	pageToken := ""
 	for {
-		resp, err := r.runners.ListRunners(ctx, &runnersv1.ListRunnersRequest{
+		resp, err := r.runners.ListRunners(runnersContext(ctx), &runnersv1.ListRunnersRequest{
 			PageSize:       runnerPageSize,
 			PageToken:      pageToken,
 			OrganizationId: &orgID,

--- a/internal/reconciler/runners.go
+++ b/internal/reconciler/runners.go
@@ -10,12 +10,8 @@ import (
 
 const runnerPageSize int32 = 100
 
-func (r *Reconciler) selectRunner(ctx context.Context, identityID, organizationID string, runnerLabels map[string]string, requiredCapabilities []string) (*runnersv1.Runner, error) {
-	runnerCtx, err := runnerIdentityContext(ctx, identityID)
-	if err != nil {
-		return nil, err
-	}
-	runners, err := r.listRunners(runnerCtx, organizationID)
+func (r *Reconciler) selectRunner(ctx context.Context, organizationID string, runnerLabels map[string]string, requiredCapabilities []string) (*runnersv1.Runner, error) {
+	runners, err := r.listRunners(ctx, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -52,12 +48,8 @@ func (r *Reconciler) listRunnersByOrg(ctx context.Context, orgIdentities map[str
 		return nil, nil
 	}
 	var runners []*runnersv1.Runner
-	for orgID, identityID := range orgIdentities {
-		runnerCtx, err := runnerIdentityContext(ctx, identityID)
-		if err != nil {
-			return nil, err
-		}
-		orgRunners, err := r.listRunners(runnerCtx, orgID)
+	for orgID := range orgIdentities {
+		orgRunners, err := r.listRunners(ctx, orgID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/reconciler/start_decision.go
+++ b/internal/reconciler/start_decision.go
@@ -148,7 +148,7 @@ func (r *Reconciler) listWorkloadsByThread(ctx context.Context, threadID string,
 		if len(statuses) > 0 {
 			req.Statuses = statuses
 		}
-		resp, err := r.runners.ListWorkloadsByThread(ctx, req)
+		resp, err := r.runners.ListWorkloadsByThread(runnersContext(ctx), req)
 		if err != nil {
 			return nil, fmt.Errorf("list workloads for thread %s: %w", threadID, err)
 		}

--- a/internal/reconciler/start_decision_test.go
+++ b/internal/reconciler/start_decision_test.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestShouldStartWorkloadUsesRunnerIdentityContext(t *testing.T) {
+func TestShouldStartWorkloadStripsRunnerIdentityContext(t *testing.T) {
 	ctx := context.Background()
 	threadID := uuid.New()
 	agentID := uuid.MustParse(testAgentID)
@@ -28,12 +28,9 @@ func TestShouldStartWorkloadUsesRunnerIdentityContext(t *testing.T) {
 			if req.GetThreadId() != threadID.String() {
 				return nil, errors.New("unexpected thread id")
 			}
-			metadataValues, ok := metadata.FromOutgoingContext(ctx)
-			if !ok {
-				return nil, errors.New("missing outgoing metadata")
-			}
+			metadataValues, _ := metadata.FromOutgoingContext(ctx)
 			identityValues := metadataValues.Get(identityMetadataKey)
-			if len(identityValues) != 1 || identityValues[0] != agentID.String() {
+			if len(identityValues) != 0 {
 				return nil, fmt.Errorf("unexpected identity metadata: %v", identityValues)
 			}
 			return &runnersv1.ListWorkloadsByThreadResponse{}, nil

--- a/internal/reconciler/volume_reconcile.go
+++ b/internal/reconciler/volume_reconcile.go
@@ -12,6 +12,7 @@ import (
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	"github.com/agynio/agents-orchestrator/internal/runnerdial"
+	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -216,44 +217,50 @@ func (r *Reconciler) listActiveVolumes(ctx context.Context, orgIdentities map[st
 	if len(orgIdentities) == 0 {
 		return active, nil
 	}
-	runnerCtx, err := r.clusterAdminRunnerContext(ctx)
-	if err != nil {
-		return nil, err
+	pageToken := ""
+	statuses := []runnersv1.VolumeStatus{
+		runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
+		runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE,
+		runnersv1.VolumeStatus_VOLUME_STATUS_DEPROVISIONING,
 	}
-	for orgID := range orgIdentities {
-		orgIDCopy := orgID
-		pageToken := ""
-		for {
-			resp, err := r.runners.ListVolumes(runnerCtx, &runnersv1.ListVolumesRequest{
-				PageSize:       activeVolumePageSize,
-				PageToken:      pageToken,
-				OrganizationId: &orgIDCopy,
-				Statuses: []runnersv1.VolumeStatus{
-					runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
-					runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE,
-					runnersv1.VolumeStatus_VOLUME_STATUS_DEPROVISIONING,
-				},
-			})
+	for {
+		resp, err := r.runners.ListVolumes(runnersContext(ctx), &runnersv1.ListVolumesRequest{
+			PageSize:  activeVolumePageSize,
+			PageToken: pageToken,
+			Filter: &runnersv1.ListVolumesFilter{
+				StatusIn: statuses,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list volumes: %w", err)
+		}
+		for _, volume := range resp.GetVolumes() {
+			if volume == nil {
+				return nil, fmt.Errorf("volume is nil")
+			}
+			meta := volume.GetMeta()
+			if meta == nil {
+				return nil, fmt.Errorf("volume meta missing")
+			}
+			if meta.GetId() == "" {
+				return nil, fmt.Errorf("volume meta id missing")
+			}
+			orgID := strings.TrimSpace(volume.GetOrganizationId())
+			if orgID == "" {
+				return nil, fmt.Errorf("volume %s organization id missing", meta.GetId())
+			}
+			parsedOrgID, err := uuidutil.ParseUUID(orgID, "volume.organization_id")
 			if err != nil {
-				return nil, fmt.Errorf("list volumes: %w", err)
+				return nil, err
 			}
-			for _, volume := range resp.GetVolumes() {
-				if volume == nil {
-					return nil, fmt.Errorf("volume is nil")
-				}
-				meta := volume.GetMeta()
-				if meta == nil {
-					return nil, fmt.Errorf("volume meta missing")
-				}
-				if meta.GetId() == "" {
-					return nil, fmt.Errorf("volume meta id missing")
-				}
-				active = append(active, volume)
+			if _, ok := orgIdentities[parsedOrgID.String()]; !ok {
+				continue
 			}
-			pageToken = resp.GetNextPageToken()
-			if pageToken == "" {
-				break
-			}
+			active = append(active, volume)
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
 		}
 	}
 	return active, nil
@@ -269,14 +276,14 @@ func (r *Reconciler) handleMissingRunnerVolume(ctx context.Context, volume *runn
 		return nil
 	case runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE:
 		status := runnersv1.VolumeStatus_VOLUME_STATUS_FAILED
-		_, err := r.runners.UpdateVolume(ctx, &runnersv1.UpdateVolumeRequest{
+		_, err := r.runners.UpdateVolume(runnersContext(ctx), &runnersv1.UpdateVolumeRequest{
 			Id:     volumeID,
 			Status: &status,
 		})
 		return err
 	case runnersv1.VolumeStatus_VOLUME_STATUS_DEPROVISIONING:
 		status := runnersv1.VolumeStatus_VOLUME_STATUS_DELETED
-		_, err := r.runners.UpdateVolume(ctx, &runnersv1.UpdateVolumeRequest{
+		_, err := r.runners.UpdateVolume(runnersContext(ctx), &runnersv1.UpdateVolumeRequest{
 			Id:        volumeID,
 			Status:    &status,
 			RemovedAt: timestamppb.New(time.Now().UTC()),
@@ -299,7 +306,7 @@ func (r *Reconciler) handlePresentRunnerVolume(ctx context.Context, runnerClient
 	switch volume.GetStatus() {
 	case runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING:
 		status := runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE
-		_, err := r.runners.UpdateVolume(ctx, &runnersv1.UpdateVolumeRequest{
+		_, err := r.runners.UpdateVolume(runnersContext(ctx), &runnersv1.UpdateVolumeRequest{
 			Id:         volumeID,
 			Status:     &status,
 			InstanceId: stringPtr(instanceID),
@@ -307,7 +314,7 @@ func (r *Reconciler) handlePresentRunnerVolume(ctx context.Context, runnerClient
 		return err
 	case runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE:
 		if volume.GetInstanceId() != instanceID {
-			if _, err := r.runners.UpdateVolume(ctx, &runnersv1.UpdateVolumeRequest{
+			if _, err := r.runners.UpdateVolume(runnersContext(ctx), &runnersv1.UpdateVolumeRequest{
 				Id:         volumeID,
 				InstanceId: stringPtr(instanceID),
 			}); err != nil {
@@ -322,7 +329,7 @@ func (r *Reconciler) handlePresentRunnerVolume(ctx context.Context, runnerClient
 			return nil
 		}
 		status := runnersv1.VolumeStatus_VOLUME_STATUS_DEPROVISIONING
-		if _, err := r.runners.UpdateVolume(ctx, &runnersv1.UpdateVolumeRequest{Id: volumeID, Status: &status}); err != nil {
+		if _, err := r.runners.UpdateVolume(runnersContext(ctx), &runnersv1.UpdateVolumeRequest{Id: volumeID, Status: &status}); err != nil {
 			return err
 		}
 		return r.removeRunnerVolume(ctx, runnerClient, instanceID)

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -227,7 +227,7 @@ func (r *Reconciler) handleMissingRunnerWorkload(ctx context.Context, workload *
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING:
 		missingAt := timestamppb.New(time.Now().UTC())
 		status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED
-		_, err := r.runners.UpdateWorkload(ctx, &runnersv1.UpdateWorkloadRequest{
+		_, err := r.runners.UpdateWorkload(runnersContext(ctx), &runnersv1.UpdateWorkloadRequest{
 			Id:        workloadID,
 			Status:    &status,
 			RemovedAt: missingAt,
@@ -300,7 +300,7 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 	default:
 	}
 	if shouldUpdate {
-		if _, err := r.runners.UpdateWorkload(ctx, updateReq); err != nil {
+		if _, err := r.runners.UpdateWorkload(runnersContext(ctx), updateReq); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- remove cluster admin identity configuration and strip x-identity-id from internal Runners calls
- switch metering and reconciliation list calls to internal ListWorkloads/ListVolumes filters
- update tests and thread fakes for new API requirements

## Testing
- buf generate
- go test ./...
- go build ./...
- go vet -p 1 ./...

Refs agynio/architecture#144