### PR TITLE
fix(orchestrator): avoid empty container overwrite

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -44,52 +44,50 @@ func run() error {
 		return err
 	}
 
-	closeConn := func(conn *grpc.ClientConn) {
+	closeConn := func(name string, conn *grpc.ClientConn) {
 		if conn == nil {
 			return
 		}
-		_ = conn.Close()
+		if err := conn.Close(); err != nil {
+			log.Printf("close %s connection: %v", name, err)
+		}
 	}
 
-	threadsConn, err := grpc.DialContext(ctx, cfg.ThreadsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	threadsConn, err := grpc.NewClient(cfg.ThreadsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial threads: %w", err)
 	}
-	defer closeConn(threadsConn)
+	defer closeConn("threads", threadsConn)
 
-	notificationsConn, err := grpc.DialContext(ctx, cfg.NotificationsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	notificationsConn, err := grpc.NewClient(cfg.NotificationsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial notifications: %w", err)
 	}
-	defer closeConn(notificationsConn)
+	defer closeConn("notifications", notificationsConn)
 
-	agentsConn, err := grpc.DialContext(
-		ctx,
-		cfg.AgentsAddress,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	agentsConn, err := grpc.NewClient(cfg.AgentsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial agents: %w", err)
 	}
-	defer closeConn(agentsConn)
+	defer closeConn("agents", agentsConn)
 
-	secretsConn, err := grpc.DialContext(ctx, cfg.SecretsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	secretsConn, err := grpc.NewClient(cfg.SecretsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial secrets: %w", err)
 	}
-	defer closeConn(secretsConn)
+	defer closeConn("secrets", secretsConn)
 
 	runnersConn, err := grpc.NewClient(cfg.RunnersAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial runners: %w", err)
 	}
-	defer closeConn(runnersConn)
+	defer closeConn("runners", runnersConn)
 
 	meteringConn, err := grpc.NewClient(cfg.MeteringServiceAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial metering: %w", err)
 	}
-	defer closeConn(meteringConn)
+	defer closeConn("metering", meteringConn)
 
 	var (
 		runnerDialer   runnerdial.RunnerDialer
@@ -116,12 +114,12 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("dial runner: %w", err)
 		}
-		defer closeConn(runnerConn)
+		defer closeConn("runner", runnerConn)
 		runnerClient := runnerv1.NewRunnerServiceClient(runnerConn)
 		runnerDialer = runnerdial.NewFallbackDialer(runnerClient)
 	}
 	defer runnerDialer.Close()
-	defer closeConn(zitiMgmtConn)
+	defer closeConn("ziti management", zitiMgmtConn)
 
 	threadsClient := threadsv1.NewThreadsServiceClient(threadsConn)
 	notificationsClient := notificationsv1.NewNotificationsServiceClient(notificationsConn)
@@ -129,7 +127,7 @@ func run() error {
 	secretsClient := secretsv1.NewSecretsServiceClient(secretsConn)
 	runnersClient := runnersv1.NewRunnersServiceClient(runnersConn)
 	meteringClient := meteringv1.NewMeteringServiceClient(meteringConn)
-	subscriber := subscriber.New(notificationsClient, agentsClient)
+	subscriber := subscriber.New(notificationsClient, agentsClient, subscriber.WithServiceToken(cfg.InternalSubscribeToken))
 	assembler := assembler.New(agentsClient, secretsClient, &cfg)
 	reconciler := reconciler.New(reconciler.Config{
 		Threads:                   threadsClient,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -31,6 +32,7 @@ type Config struct {
 	StopTimeoutSec            uint32
 	LeaseName                 string
 	LeaseNamespace            string
+	InternalSubscribeToken    string
 }
 
 func FromEnv() (Config, error) {
@@ -198,5 +200,6 @@ func FromEnv() (Config, error) {
 		cfg.LeaseName = "agents-orchestrator"
 	}
 	cfg.LeaseNamespace = os.Getenv("LEASE_NAMESPACE")
+	cfg.InternalSubscribeToken = strings.TrimSpace(os.Getenv("INTERNAL_SUBSCRIBE_TOKEN"))
 	return cfg, nil
 }

--- a/internal/reconciler/lifecycle_helpers.go
+++ b/internal/reconciler/lifecycle_helpers.go
@@ -9,14 +9,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func workloadStatusPtr(status runnersv1.WorkloadStatus) *runnersv1.WorkloadStatus {
-	return &status
-}
-
-func volumeStatusPtr(status runnersv1.VolumeStatus) *runnersv1.VolumeStatus {
-	return &status
-}
-
 func stringPtr(value string) *string {
 	if value == "" {
 		return nil

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -261,7 +261,7 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 		mapped, mapErr := mapRunnerContainers(inspectResp.GetContainers())
 		if mapErr != nil {
 			log.Printf("reconciler: warn: map workload %s containers: %v", workloadID, mapErr)
-		} else {
+		} else if mapped != nil {
 			containers = mapped
 			updateReq.Containers = containers
 			shouldUpdate = true
@@ -283,6 +283,10 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 				updateReq.Status = &status
 				shouldUpdate = true
 			}
+		} else if inspectResp != nil && inspectResp.GetStateRunning() {
+			status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING
+			updateReq.Status = &status
+			shouldUpdate = true
 		}
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING:
 		if containers != nil {

--- a/internal/runnerdial/dialer_test.go
+++ b/internal/runnerdial/dialer_test.go
@@ -31,7 +31,9 @@ func TestDialerCachesConnections(t *testing.T) {
 	}()
 	t.Cleanup(func() {
 		server.Stop()
-		listener.Close()
+		if err := listener.Close(); err != nil {
+			t.Fatalf("close listener: %v", err)
+		}
 	})
 
 	var conns []*grpc.ClientConn
@@ -86,7 +88,9 @@ func TestDialerEvictsBadConnections(t *testing.T) {
 	}()
 	t.Cleanup(func() {
 		server.Stop()
-		listener.Close()
+		if err := listener.Close(); err != nil {
+			t.Fatalf("close listener: %v", err)
+		}
 	})
 
 	var conns []*grpc.ClientConn

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -13,6 +13,7 @@ import (
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	notificationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/notifications/v1"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
+	"google.golang.org/grpc/metadata"
 )
 
 const (
@@ -20,6 +21,7 @@ const (
 	agentUpdatedEvent                 = "agent.updated"
 	agentRoomPrefix                   = "agent:"
 	threadParticipantRoomPrefix       = "thread_participant:"
+	serviceTokenMetadataKey           = "x-service-token"
 	listAgentsPageSize          int32 = 100
 	defaultRoomRefreshInterval        = 30 * time.Second
 )
@@ -34,15 +36,28 @@ type Subscriber struct {
 	agents              agentsv1.AgentsServiceClient
 	wake                chan struct{}
 	roomRefreshInterval time.Duration
+	serviceToken        string
 }
 
-func New(client notificationsv1.NotificationsServiceClient, agents agentsv1.AgentsServiceClient) *Subscriber {
-	return &Subscriber{
+type Option func(*Subscriber)
+
+func WithServiceToken(token string) Option {
+	return func(s *Subscriber) {
+		s.serviceToken = strings.TrimSpace(token)
+	}
+}
+
+func New(client notificationsv1.NotificationsServiceClient, agents agentsv1.AgentsServiceClient, opts ...Option) *Subscriber {
+	subscriber := &Subscriber{
 		client:              client,
 		agents:              agents,
 		wake:                make(chan struct{}, 1),
 		roomRefreshInterval: defaultRoomRefreshInterval,
 	}
+	for _, opt := range opts {
+		opt(subscriber)
+	}
+	return subscriber
 }
 
 func (s *Subscriber) Run(ctx context.Context) error {
@@ -61,6 +76,9 @@ func (s *Subscriber) Run(ctx context.Context) error {
 			continue
 		}
 		streamCtx, cancel := context.WithCancel(ctx)
+		if s.serviceToken != "" {
+			streamCtx = metadata.AppendToOutgoingContext(streamCtx, serviceTokenMetadataKey, s.serviceToken)
+		}
 		stream, err := s.client.Subscribe(streamCtx, &notificationsv1.SubscribeRequest{Rooms: snapshot.rooms})
 		if err != nil {
 			cancel()

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -20,7 +20,7 @@ func TestSubscriberWakeOnMessageCreated(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse, 1)
 	ack := make(chan struct{}, 1)
 	agentID := "11111111-1111-1111-1111-111111111111"
-	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour)
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour, "")
 	defer harness.cancel()
 	waitForSubscribe(t, harness.subscribeReqs, 1)
 
@@ -43,7 +43,7 @@ func TestSubscriberWakeOnAgentUpdated(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse, 1)
 	ack := make(chan struct{}, 1)
 	agentID := "22222222-2222-2222-2222-222222222222"
-	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour)
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour, "")
 	defer harness.cancel()
 	waitForSubscribe(t, harness.subscribeReqs, 1)
 
@@ -66,7 +66,7 @@ func TestSubscriberIgnoresOtherEvents(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse, 1)
 	ack := make(chan struct{}, 1)
 	agentID := "33333333-3333-3333-3333-333333333333"
-	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour)
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour, "")
 	defer harness.cancel()
 	waitForSubscribe(t, harness.subscribeReqs, 1)
 
@@ -89,7 +89,7 @@ func TestSubscriberCoalescesWake(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse, 2)
 	ack := make(chan struct{}, 2)
 	agentID := "44444444-4444-4444-4444-444444444444"
-	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour)
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour, "")
 	defer harness.cancel()
 	waitForSubscribe(t, harness.subscribeReqs, 1)
 
@@ -119,7 +119,7 @@ func TestSubscriberSubscribesWithRooms(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse, 1)
 	ack := make(chan struct{}, 1)
 	agentID := "55555555-5555-5555-5555-555555555555"
-	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour)
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour, "")
 	defer harness.cancel()
 
 	req := waitForSubscribe(t, harness.subscribeReqs, 1)
@@ -134,12 +134,32 @@ func TestSubscriberSubscribesWithRooms(t *testing.T) {
 	}
 }
 
+func TestSubscriberAddsServiceTokenMetadata(t *testing.T) {
+	responses := make(chan *notificationsv1.SubscribeResponse, 1)
+	ack := make(chan struct{}, 1)
+	agentID := "88888888-8888-8888-8888-888888888888"
+	token := "service-token"
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour, token)
+	defer harness.cancel()
+
+	waitForSubscribe(t, harness.subscribeReqs, 1)
+	gotToken := waitForSubscribeToken(t, harness.subscribeTokens, 1)
+	if gotToken != token {
+		t.Fatalf("expected service token %q, got %q", token, gotToken)
+	}
+
+	harness.cancel()
+	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected run error: %v", err)
+	}
+}
+
 func TestSubscriberResubscribesOnAgentChange(t *testing.T) {
 	responses := make(chan *notificationsv1.SubscribeResponse)
 	ack := make(chan struct{}, 1)
 	agentID := "66666666-6666-6666-6666-666666666666"
 	updatedAgentID := "77777777-7777-7777-7777-777777777777"
-	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, 10*time.Millisecond)
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, 10*time.Millisecond, "")
 	defer harness.cancel()
 
 	firstReq := waitForSubscribe(t, harness.subscribeReqs, 1)
@@ -166,7 +186,7 @@ func TestSubscriberResubscribesOnAgentChange(t *testing.T) {
 	}
 }
 
-func newSubscriberHarness(t *testing.T, responses chan *notificationsv1.SubscribeResponse, ack chan struct{}, initialAgents []*agentsv1.Agent, refreshInterval time.Duration) *subscriberHarness {
+func newSubscriberHarness(t *testing.T, responses chan *notificationsv1.SubscribeResponse, ack chan struct{}, initialAgents []*agentsv1.Agent, refreshInterval time.Duration, serviceToken string) *subscriberHarness {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	store := &agentStore{agents: initialAgents}
@@ -174,7 +194,16 @@ func newSubscriberHarness(t *testing.T, responses chan *notificationsv1.Subscrib
 		return &agentsv1.ListAgentsResponse{Agents: store.list()}, nil
 	}}
 	subscribeReqs := make(chan *notificationsv1.SubscribeRequest, 4)
+	subscribeTokens := make(chan string, 4)
 	client := &fakeNotificationsClient{subscribe: func(ctx context.Context, req *notificationsv1.SubscribeRequest, opts ...grpc.CallOption) (notificationsv1.NotificationsService_SubscribeClient, error) {
+		token := ""
+		if md, ok := metadata.FromOutgoingContext(ctx); ok {
+			values := md.Get(serviceTokenMetadataKey)
+			if len(values) > 0 {
+				token = values[0]
+			}
+		}
+		subscribeTokens <- token
 		subscribeReqs <- req
 		return &fakeSubscribeStream{
 			fakeClientStream: fakeClientStream{ctx: ctx},
@@ -182,18 +211,19 @@ func newSubscriberHarness(t *testing.T, responses chan *notificationsv1.Subscrib
 			ack:              ack,
 		}, nil
 	}}
-	subscriber := New(client, agentsClient)
+	subscriber := New(client, agentsClient, WithServiceToken(serviceToken))
 	subscriber.roomRefreshInterval = refreshInterval
 	done := make(chan error, 1)
 	go func() {
 		done <- subscriber.Run(ctx)
 	}()
 	return &subscriberHarness{
-		subscriber:    subscriber,
-		cancel:        cancel,
-		done:          done,
-		store:         store,
-		subscribeReqs: subscribeReqs,
+		subscriber:      subscriber,
+		cancel:          cancel,
+		done:            done,
+		store:           store,
+		subscribeReqs:   subscribeReqs,
+		subscribeTokens: subscribeTokens,
 	}
 }
 
@@ -214,6 +244,19 @@ func waitForSubscribe(t *testing.T, subscribeReqs <-chan *notificationsv1.Subscr
 		}
 	}
 	return req
+}
+
+func waitForSubscribeToken(t *testing.T, tokens <-chan string, count int) string {
+	t.Helper()
+	var token string
+	for i := 0; i < count; i++ {
+		select {
+		case token = <-tokens:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("timeout waiting for subscribe token %d", i)
+		}
+	}
+	return token
 }
 
 func waitForAck(t *testing.T, ack <-chan struct{}, count int) {
@@ -296,11 +339,12 @@ func (s *agentStore) set(agents []*agentsv1.Agent) {
 }
 
 type subscriberHarness struct {
-	subscriber    *Subscriber
-	cancel        context.CancelFunc
-	done          chan error
-	store         *agentStore
-	subscribeReqs chan *notificationsv1.SubscribeRequest
+	subscriber      *Subscriber
+	cancel          context.CancelFunc
+	done            chan error
+	store           *agentStore
+	subscribeReqs   chan *notificationsv1.SubscribeRequest
+	subscribeTokens chan string
 }
 
 func agentFixture(id string) *agentsv1.Agent {


### PR DESCRIPTION
Reconciliation improvements for workload status/container updates:

- Avoid overwriting `containers` when `mapRunnerContainers(...)` returns nil (prevents empty-container overwrites).
- Add a STARTING→RUNNING fallback: if `InspectWorkload` reports RUNNING even when containers cannot be mapped, still update status to RUNNING.

This addresses workloads stuck in “starting” and missing container state after runner inspections.