### PR TITLE
fix(reconciler): handle start failures

### DIFF
--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -501,7 +501,7 @@ func runnerContainerRole(role runnerv1.ContainerRole) (runnersv1.ContainerRole, 
 func runnerContainerStatus(status runnerv1.ContainerStatus) (runnersv1.ContainerStatus, error) {
 	switch status {
 	case runnerv1.ContainerStatus_CONTAINER_STATUS_UNSPECIFIED:
-		return runnersv1.ContainerStatus_CONTAINER_STATUS_UNSPECIFIED, fmt.Errorf("runner returned unspecified container status")
+		return runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING, nil
 	case runnerv1.ContainerStatus_CONTAINER_STATUS_RUNNING:
 		return runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING, nil
 	case runnerv1.ContainerStatus_CONTAINER_STATUS_TERMINATED:

--- a/internal/reconciler/reconciler_unit_test.go
+++ b/internal/reconciler/reconciler_unit_test.go
@@ -256,3 +256,24 @@ func TestMapRunnerContainers(t *testing.T) {
 		t.Fatalf("unexpected sidecar container status: %v", sidecarContainer.GetStatus())
 	}
 }
+
+func TestMapRunnerContainersUnspecifiedStatus(t *testing.T) {
+	containers, err := mapRunnerContainers([]*runnerv1.WorkloadContainer{
+		{
+			ContainerId: "main-id",
+			Name:        "main",
+			Role:        runnerv1.ContainerRole_CONTAINER_ROLE_MAIN,
+			Image:       "main-image",
+			Status:      runnerv1.ContainerStatus_CONTAINER_STATUS_UNSPECIFIED,
+		},
+	})
+	if err != nil {
+		t.Fatalf("map containers: %v", err)
+	}
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(containers))
+	}
+	if containers[0].GetStatus() != runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING {
+		t.Fatalf("unexpected container status: %v", containers[0].GetStatus())
+	}
+}

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -351,10 +351,21 @@ func classifyStartingContainers(containers []*runnersv1.Container, workload *run
 			}
 		case runnersv1.ContainerRole_CONTAINER_ROLE_MAIN:
 			foundMain = true
-			if container.GetStatus() != runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING {
+			status := container.GetStatus()
+			if status != runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING {
 				mainRunning = false
 			}
-			if container.GetStatus() == runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING {
+			if status == runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED {
+				message := containerFailureMessage(container)
+				exitCode := container.GetExitCode()
+				if message == "" {
+					message = fmt.Sprintf("main container terminated with exit code %d", exitCode)
+				} else if exitCode != 0 {
+					message = fmt.Sprintf("%s (exit code %d)", message, exitCode)
+				}
+				return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, message: message}, nil
+			}
+			if status == runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING {
 				if container.GetReason() == crashLoopBackoffFlag && container.GetRestartCount() >= crashloopThreshold {
 					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CRASHLOOP, message: containerFailureMessage(container)}, nil
 				}

--- a/internal/reconciler/workload_reconcile_classify_test.go
+++ b/internal/reconciler/workload_reconcile_classify_test.go
@@ -101,6 +101,29 @@ func TestClassifyStartingContainersMainCrashloop(t *testing.T) {
 	}
 }
 
+func TestClassifyStartingContainersMainTerminated(t *testing.T) {
+	now := time.Now().UTC()
+	exitCode := int32(1)
+	workload := &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(now.Add(-startGracePeriod - time.Second))}}
+	containers := []*runnersv1.Container{
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED, "Error", "", 0, &exitCode),
+	}
+
+	ready, failure, err := classifyStartingContainers(containers, workload, now)
+	if err != nil {
+		t.Fatalf("classify starting containers: %v", err)
+	}
+	if ready {
+		t.Fatal("expected workload to be not ready")
+	}
+	if failure == nil {
+		t.Fatal("expected failure")
+	}
+	if failure.reason != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED {
+		t.Fatalf("unexpected failure reason: %v", failure.reason)
+	}
+}
+
 func TestClassifyStartingContainersInitRestartFailure(t *testing.T) {
 	now := time.Now().UTC()
 	exitCode := int32(1)


### PR DESCRIPTION
## Summary
- treat main container termination during start as a start failure
- map runner container status UNSPECIFIED to WAITING to avoid reconcile aborts
- add tests covering main termination and unspecified status mapping

## Testing
- go test ./...
- go vet -p 1 ./...

Closes #170