### PR TITLE
fix: promote starting workloads

### DIFF
--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -235,6 +235,72 @@ func TestReconcileWorkloadsTransitionsStartingToRunningWithoutContainers(t *test
 	}
 }
 
+func TestReconcileWorkloadsDoesNotPromoteStartingWhenNotRunning(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadKey := "workload-1"
+	rawInstanceID := uuid.New().String()
+	instanceID := "workload-" + rawInstanceID
+	createdAt := timestamppb.New(time.Date(2024, time.January, 1, 1, 2, 3, 0, time.UTC))
+
+	updateCalled := false
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadKey, CreatedAt: createdAt}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING, InstanceId: stringPtr(rawInstanceID)},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateWorkload: func(_ context.Context, _ *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateCalled = true
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	inspectCalled := false
+	runner := &fakeRunnerClient{
+		listWorkloads: func(_ context.Context, _ *runnerv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnerv1.ListWorkloadsResponse, error) {
+			return &runnerv1.ListWorkloadsResponse{Workloads: []*runnerv1.WorkloadListItem{
+				{WorkloadKey: workloadKey, InstanceId: instanceID},
+			}}, nil
+		},
+		inspectWorkload: func(_ context.Context, req *runnerv1.InspectWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+			inspectCalled = true
+			if req.GetWorkloadId() != rawInstanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return &runnerv1.InspectWorkloadResponse{StateRunning: false}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateCalled {
+		t.Fatal("expected no update workload")
+	}
+	if !inspectCalled {
+		t.Fatal("expected inspect workload")
+	}
+}
+
 func TestReconcileWorkloadsRefreshesContainersOnRunning(t *testing.T) {
 	ctx := context.Background()
 	runnerID := "runner-1"

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -160,6 +160,81 @@ func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 	}
 }
 
+func TestReconcileWorkloadsTransitionsStartingToRunningWithoutContainers(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadKey := "workload-1"
+	rawInstanceID := uuid.New().String()
+	instanceID := "workload-" + rawInstanceID
+	createdAt := timestamppb.New(time.Date(2024, time.January, 1, 1, 2, 3, 0, time.UTC))
+
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadKey, CreatedAt: createdAt}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	inspectCalled := false
+	runner := &fakeRunnerClient{
+		listWorkloads: func(_ context.Context, _ *runnerv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnerv1.ListWorkloadsResponse, error) {
+			return &runnerv1.ListWorkloadsResponse{Workloads: []*runnerv1.WorkloadListItem{
+				{WorkloadKey: workloadKey, InstanceId: instanceID},
+			}}, nil
+		},
+		inspectWorkload: func(_ context.Context, req *runnerv1.InspectWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+			inspectCalled = true
+			if req.GetWorkloadId() != rawInstanceID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return &runnerv1.InspectWorkloadResponse{StateRunning: true}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			if id != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected update workload")
+	}
+	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
+	}
+	if updateReq.GetInstanceId() != rawInstanceID {
+		t.Fatalf("unexpected instance id: %v", updateReq.GetInstanceId())
+	}
+	if len(updateReq.GetContainers()) != 0 {
+		t.Fatalf("expected no containers, got %d", len(updateReq.GetContainers()))
+	}
+	if !inspectCalled {
+		t.Fatal("expected inspect workload")
+	}
+}
+
 func TestReconcileWorkloadsRefreshesContainersOnRunning(t *testing.T) {
 	ctx := context.Background()
 	runnerID := "runner-1"

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -254,14 +254,18 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 		shouldUpdate = true
 	}
 	inspectResp, err := r.inspectRunnerWorkload(ctx, runnerClient, instanceID)
+	inspectStateRunning := false
+	inspectContainerCount := 0
 	var containers []*runnersv1.Container
 	if err != nil {
 		log.Printf("reconciler: warn: inspect workload %s: %v", workloadID, err)
 	} else {
+		inspectStateRunning = inspectResp.GetStateRunning()
+		inspectContainerCount = len(inspectResp.GetContainers())
 		mapped, mapErr := mapRunnerContainers(inspectResp.GetContainers())
 		if mapErr != nil {
 			log.Printf("reconciler: warn: map workload %s containers: %v", workloadID, mapErr)
-		} else {
+		} else if mapped != nil {
 			containers = mapped
 			updateReq.Containers = containers
 			shouldUpdate = true
@@ -283,6 +287,10 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 				updateReq.Status = &status
 				shouldUpdate = true
 			}
+		} else if inspectStateRunning && inspectContainerCount == 0 {
+			status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING
+			updateReq.Status = &status
+			shouldUpdate = true
 		}
 	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING:
 		if containers != nil {

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -288,6 +288,7 @@ func (r *Reconciler) handlePresentRunnerWorkload(ctx context.Context, runnerClie
 				shouldUpdate = true
 			}
 		} else if inspectStateRunning && inspectContainerCount == 0 {
+			// Some runner versions report state_running without containers; avoid a stuck STARTING state.
 			status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING
 			updateReq.Status = &status
 			shouldUpdate = true


### PR DESCRIPTION
## Summary
- promote STARTING workloads to RUNNING when runner reports state_running with no containers
- add unit test coverage for the empty-containers running state
- local repro via unit test; full cluster bring-up not attempted in this sandbox

## Testing
- rm -rf .gen && buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1
- go test ./...
- go build ./...
- go vet -p 1 ./...

Closes #172