### PR TITLE
test(e2e): use expose token auth fix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,7 +59,7 @@ jobs:
           AGN_EXPOSE_INIT_IMAGE: ${{ env.AGN_EXPOSE_INIT_IMAGE }}
           AGYN_AGENT_INIT_IMAGE: ${{ env.AGYN_AGENT_INIT_IMAGE }}
         with:
-          ref: 6df1c6725dfedaca351fc83d85d4a12dbd8551a7
+          ref: 036249361bf16cff166f6cf87f591e8fb9ca2281
           service: agents_orchestrator
 
       - name: Restore ArgoCD sync


### PR DESCRIPTION
Updates the agents-orchestrator e2e workflow to consume the merged e2e fix agynio/e2e#92.\n\nThis keeps the original agyn CLI wait coverage and includes the expose CLI token-auth fix needed by the current go-core suite.