### PR TITLE
test: run Claude full pipeline e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,8 @@ jobs:
           AGN_EXPOSE_INIT_IMAGE: ${{ env.AGN_EXPOSE_INIT_IMAGE }}
           AGYN_AGENT_INIT_IMAGE: ${{ env.AGYN_AGENT_INIT_IMAGE }}
           E2E_SUITES: go-core
-          E2E_GO_TEST_RUN: ^TestFullPipelineClaudeMessageResponsen        with:
+          E2E_GO_TEST_RUN: ^TestFullPipelineClaudeMessageResponse$
+        with:
           service: agents_orchestrator
 
       - name: Restore ArgoCD sync

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ concurrency:
 env:
   AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
   CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:latest
-  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.23
+  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.25
   AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
   AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,7 @@ jobs:
           CLAUDE_INIT_IMAGE: ${{ env.CLAUDE_INIT_IMAGE }}
           AGN_EXPOSE_INIT_IMAGE: ${{ env.AGN_EXPOSE_INIT_IMAGE }}
           AGYN_AGENT_INIT_IMAGE: ${{ env.AGYN_AGENT_INIT_IMAGE }}
+          E2E_SUITES: go-core
         with:
           service: agents_orchestrator
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
           AGN_EXPOSE_INIT_IMAGE: ${{ env.AGN_EXPOSE_INIT_IMAGE }}
           AGYN_AGENT_INIT_IMAGE: ${{ env.AGYN_AGENT_INIT_IMAGE }}
           E2E_SUITES: go-core
-        with:
+          E2E_GO_TEST_RUN: ^TestFullPipelineClaudeMessageResponsen        with:
           service: agents_orchestrator
 
       - name: Restore ArgoCD sync


### PR DESCRIPTION
Updates the agents-orchestrator E2E workflow to use the e2e suite containing the Claude full pipeline test and the fixed Claude init image.\n\nNew coverage exercises:\n\nmessage -> thread -> orchestrator -> workload -> agynd -> claude -> agent response\n\nUses ghcr.io/agynio/agent-init-claude:0.1.25.