### PR TITLE
Fix STARTING promotion with restartable init sidecars

### DIFF
--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -330,16 +330,17 @@ func classifyStartingContainers(containers []*runnersv1.Container, workload *run
 		return false, nil, err
 	}
 	startAge := now.Sub(createdAt)
-	initComplete := true
 	mainRunning := true
 	foundMain := false
+	initBlocked := false
 	for _, container := range containers {
 		if container == nil {
 			return false, nil, fmt.Errorf("workload %s has nil container", workload.GetMeta().GetId())
 		}
 		switch container.GetRole() {
 		case runnersv1.ContainerRole_CONTAINER_ROLE_INIT:
-			switch container.GetStatus() {
+			status := container.GetStatus()
+			switch status {
 			case runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING:
 				if isImagePullFailure(container) && startAge > startGracePeriod {
 					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_IMAGE_PULL_FAILED, message: containerFailureMessage(container)}, nil
@@ -347,16 +348,17 @@ func classifyStartingContainers(containers []*runnersv1.Container, workload *run
 				if isConfigInvalidFailure(container) && startAge > startGracePeriod {
 					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CONFIG_INVALID, message: containerFailureMessage(container)}, nil
 				}
-				initComplete = false
+				initBlocked = true
 			case runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED:
 				if container.GetExitCode() != 0 && container.GetRestartCount() >= initRetryThreshold {
 					return false, &workloadFailure{reason: runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, message: containerFailureMessage(container)}, nil
 				}
 				if container.GetExitCode() != 0 {
-					initComplete = false
+					initBlocked = true
 				}
+			case runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING:
 			default:
-				initComplete = false
+				initBlocked = true
 			}
 		case runnersv1.ContainerRole_CONTAINER_ROLE_MAIN:
 			foundMain = true
@@ -391,7 +393,7 @@ func classifyStartingContainers(containers []*runnersv1.Container, workload *run
 	if !foundMain {
 		return false, nil, fmt.Errorf("workload %s missing main container", workload.GetMeta().GetId())
 	}
-	if initComplete && mainRunning {
+	if !initBlocked && mainRunning {
 		return true, nil, nil
 	}
 	return false, nil, nil

--- a/internal/reconciler/workload_reconcile_classify_test.go
+++ b/internal/reconciler/workload_reconcile_classify_test.go
@@ -124,6 +124,70 @@ func TestClassifyStartingContainersMainTerminated(t *testing.T) {
 	}
 }
 
+func TestClassifyStartingContainersReadyWithRunningInitSidecar(t *testing.T) {
+	now := time.Now().UTC()
+	workload := &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(now.Add(-startGracePeriod - time.Second))}}
+	containers := []*runnersv1.Container{
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_INIT, runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING, "", "", 0, nil),
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING, "", "", 0, nil),
+	}
+
+	ready, failure, err := classifyStartingContainers(containers, workload, now)
+	if err != nil {
+		t.Fatalf("classify starting containers: %v", err)
+	}
+	if !ready {
+		t.Fatal("expected workload to be ready")
+	}
+	if failure != nil {
+		t.Fatalf("unexpected failure: %+v", failure)
+	}
+}
+
+func TestClassifyStartingContainersMainWaitingWithRunningInitSidecar(t *testing.T) {
+	now := time.Now().UTC()
+	workload := &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(now.Add(-startGracePeriod - time.Second))}}
+	containers := []*runnersv1.Container{
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_INIT, runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING, "", "", 0, nil),
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, runnersv1.ContainerStatus_CONTAINER_STATUS_WAITING, "ContainerCreating", "", 0, nil),
+	}
+
+	ready, failure, err := classifyStartingContainers(containers, workload, now)
+	if err != nil {
+		t.Fatalf("classify starting containers: %v", err)
+	}
+	if ready {
+		t.Fatal("expected workload to be not ready")
+	}
+	if failure != nil {
+		t.Fatalf("unexpected failure: %+v", failure)
+	}
+}
+
+func TestClassifyStartingContainersMainTerminatedWithRunningInitSidecar(t *testing.T) {
+	now := time.Now().UTC()
+	exitCode := int32(1)
+	workload := &runnersv1.Workload{Meta: &runnersv1.EntityMeta{Id: "workload-1", CreatedAt: timestamppb.New(now.Add(-startGracePeriod - time.Second))}}
+	containers := []*runnersv1.Container{
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_INIT, runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING, "", "", 0, nil),
+		makeContainer(runnersv1.ContainerRole_CONTAINER_ROLE_MAIN, runnersv1.ContainerStatus_CONTAINER_STATUS_TERMINATED, "Error", "main failed", 0, &exitCode),
+	}
+
+	ready, failure, err := classifyStartingContainers(containers, workload, now)
+	if err != nil {
+		t.Fatalf("classify starting containers: %v", err)
+	}
+	if ready {
+		t.Fatal("expected workload to be not ready")
+	}
+	if failure == nil {
+		t.Fatal("expected failure")
+	}
+	if failure.reason != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED {
+		t.Fatalf("unexpected failure reason: %v", failure.reason)
+	}
+}
+
 func TestClassifyStartingContainersInitRestartFailure(t *testing.T) {
 	now := time.Now().UTC()
 	exitCode := int32(1)


### PR DESCRIPTION
## Summary
- Allow `classifyStartingContainers` to treat RUNNING init containers as non-blocking restartable init sidecars.
- Keep init waiting, init retry failure, main waiting, main crashloop, image pull/config invalid, and main termination handling intact.
- Add unit coverage for issue scenarios: ready with running init sidecar, not ready while main waits, and main termination failure.

Closes #181

## Tests
- `git diff --check`: passed with no errors.
- `go vet ./...`: passed with no errors.
- `go test ./...`: 149 passed, 0 failed, 0 skipped.
- `go build ./...`: passed with no errors.