### PR TITLE
ci: align e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,28 +5,20 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
-
-env:
-  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
-  CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:latest
-  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.25
-  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
-  AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
 
 jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    permissions:
-      contents: read
     steps:
       - name: Checkout service
         uses: actions/checkout@v4
-        with:
-          path: service
 
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@main
@@ -35,23 +27,13 @@ jobs:
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
       - name: Deploy orchestrator from source
-        working-directory: service
-        run: devspace run deploy -n platform
+        run: devspace run deploy
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
-        env:
-          AGN_INIT_IMAGE: ${{ env.AGN_INIT_IMAGE }}
-          CODEX_INIT_IMAGE: ${{ env.CODEX_INIT_IMAGE }}
-          CLAUDE_INIT_IMAGE: ${{ env.CLAUDE_INIT_IMAGE }}
-          AGN_EXPOSE_INIT_IMAGE: ${{ env.AGN_EXPOSE_INIT_IMAGE }}
-          AGYN_AGENT_INIT_IMAGE: ${{ env.AGYN_AGENT_INIT_IMAGE }}
-          E2E_SUITES: go-core
-          E2E_GO_TEST_RUN: ^TestFullPipelineClaudeMessageResponse$
         with:
           service: agents_orchestrator
 
       - name: Restore ArgoCD sync
         if: always()
-        working-directory: service
-        run: devspace run restore-argocd -n platform
+        run: devspace run restore-argocd

--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -77,6 +77,22 @@ func (f *FakeAgentsClient) ListAgents(ctx context.Context, req *agentsv1.ListAge
 	return nil, ErrNotImplemented
 }
 
+func (f *FakeAgentsClient) SetAgentRole(context.Context, *agentsv1.SetAgentRoleRequest, ...grpc.CallOption) (*agentsv1.SetAgentRoleResponse, error) {
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeAgentsClient) RemoveAgentRole(context.Context, *agentsv1.RemoveAgentRoleRequest, ...grpc.CallOption) (*agentsv1.RemoveAgentRoleResponse, error) {
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeAgentsClient) ListAgentRoles(context.Context, *agentsv1.ListAgentRolesRequest, ...grpc.CallOption) (*agentsv1.ListAgentRolesResponse, error) {
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeAgentsClient) ListMyAgentRoles(context.Context, *agentsv1.ListMyAgentRolesRequest, ...grpc.CallOption) (*agentsv1.ListMyAgentRolesResponse, error) {
+	return nil, ErrNotImplemented
+}
+
 func (f *FakeAgentsClient) CreateVolume(context.Context, *agentsv1.CreateVolumeRequest, ...grpc.CallOption) (*agentsv1.CreateVolumeResponse, error) {
 	return nil, ErrNotImplemented
 }


### PR DESCRIPTION
## Summary
- Simplifies E2E workflow to the centralized sequence: checkout, `agynio/bootstrap/.github/actions/provision@main`, DevSpace source deploy, and `agynio/e2e/.github/actions/run-tests@main`.
- Removes service workflow cluster/test environment overrides (`AGYN_*`, `E2E_*`) so those concerns remain in bootstrap/e2e.
- Keeps PR workflows free of image/chart publishing; release publishing remains tag-only.
- Adds read-only workflow permissions.
- Updates the test fake agents client for the current generated Agents API so local tests/build pass after generation.

Closes #183

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `go test ./...` — 149 passed, 0 failed, 0 skipped.
- `go build ./...` — passed.

## Notes
- Initial local `go test ./...` exposed stale fake client methods for the generated Agents API (`ListAgentRoles` and related role methods); the fake client was updated to satisfy the interface without changing runtime behavior.