### PR TITLE
Fix DevSpace source sync readiness race

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -51,12 +51,19 @@ functions:
                 - sh
                 - -c
                 - |
-                  set -eu
-                  elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ]; do
-                    sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 240 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                  set -eux
+                  start=$(date +%s)
+                  while [ ! -f /opt/app/data/go.mod ] \
+                    || [ ! -f /opt/app/data/go.sum ] \
+                    || [ ! -f /opt/app/data/buf.gen.yaml ] \
+                    || [ ! -f /opt/app/data/buf.yaml ] \
+                    || [ ! -f /opt/app/data/cmd/orchestrator/main.go ]; do
+                    sleep 1
+                    elapsed=$(( $(date +%s) - start ))
+                    [ "$elapsed" -ge 300 ] && { echo "ERROR: sync timeout waiting for source files" >&2; exit 1; }
                   done
+                  echo "Files synced, starting buf generate..."
+                  ls -la /opt/app/data/
                   buf generate buf.build/agynio/api \
                     --include-imports \
                     --path agynio/api/runner/v1 \
@@ -72,6 +79,7 @@ functions:
                     --path agynio/api/users/v1 \
                     --path agynio/api/organizations/v1 \
                     --path agynio/api/tracing/v1
+                  echo "buf generate complete, starting go run..."
                   exec go run ./cmd/orchestrator
               volumeMounts:
                 - name: data


### PR DESCRIPTION
## Summary
- Wait for all required source/config files in `/opt/app/data` before running `buf generate`.
- Match the runners DevSpace convention by checking `go.mod`, `go.sum`, `buf.gen.yaml`, `buf.yaml`, and `cmd/orchestrator/main.go`.
- Add explicit sync/generation log messages to make source deploy startup diagnostics clearer.

Fixes #186

## Test & Lint Summary
- `buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1`: passed
- `go test -json ./...`: 149 passed, 0 failed, 0 skipped
- `go build ./...`: passed
- `git diff --check`: passed with no whitespace/lint errors
- `devspace print --skip-info`: passed

Note: I could not execute the full `.github/workflows/e2e.yml` locally because it depends on GitHub Actions provisioning actions and a Kubernetes cluster, but the DevSpace config now renders locally and the workflow should run on this PR.