### PR TITLE
fix(devspace): wait for buf config sync

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,10 @@ jobs:
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
-      - name: Deploy orchestrator from source
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Deploy orchestrator from CI image
         run: devspace run deploy
 
       - name: Run E2E tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,10 +26,7 @@ jobs:
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Deploy orchestrator from CI image
+      - name: Deploy orchestrator from source
         run: devspace run deploy
 
       - name: Run E2E tests

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -99,9 +99,7 @@ functions:
     EOF
     )"
   wait_for_orchestrator: |-
-    echo "Waiting for orchestrator deployment to roll out..."
-    kubectl rollout status deployment/agents-orchestrator \
-      -n ${ORCHESTRATOR_NAMESPACE} --timeout=120s
+    rollout_or_recover
 
     echo "Waiting for orchestrator source sync and process start..."
     ELAPSED=0
@@ -160,6 +158,52 @@ functions:
       exit 1
     fi
     echo "Source tree synced."
+  rollout_diagnostics: |-
+    LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
+    echo "Diagnostic deployment:" >&2
+    kubectl get deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} -o wide >&2 || true
+    echo "Diagnostic replica sets:" >&2
+    kubectl get rs -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
+    echo "Diagnostic pods:" >&2
+    kubectl get pods -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
+    echo "Diagnostic pod descriptions:" >&2
+    kubectl describe pods -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" >&2 || true
+    echo "Diagnostic recent events:" >&2
+    kubectl get events -n ${ORCHESTRATOR_NAMESPACE} --sort-by=.lastTimestamp | tail -n 80 >&2 || true
+  force_delete_terminating_orchestrator_pods: |-
+    LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
+    TERMINATING_PODS="$(kubectl get pods -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" \
+      -o jsonpath='{range .items[?(@.metadata.deletionTimestamp)]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)"
+    if [ -z "${TERMINATING_PODS}" ]; then
+      echo "No terminating agents-orchestrator pods found to force delete."
+      return 0
+    fi
+    echo "Force deleting terminating agents-orchestrator pods:"
+    for POD in ${TERMINATING_PODS}; do
+      echo "  ${POD}"
+      kubectl delete pod "${POD}" -n ${ORCHESTRATOR_NAMESPACE} \
+        --grace-period=0 --force --wait=false || true
+    done
+  rollout_or_recover: |-
+    echo "Waiting for orchestrator deployment to roll out..."
+    if kubectl rollout status deployment/agents-orchestrator \
+      -n ${ORCHESTRATOR_NAMESPACE} --timeout=120s; then
+      return 0
+    fi
+
+    echo "WARNING: orchestrator rollout did not finish within 120s; collecting diagnostics." >&2
+    rollout_diagnostics
+    force_delete_terminating_orchestrator_pods
+
+    echo "Retrying orchestrator rollout after cleanup..."
+    if kubectl rollout status deployment/agents-orchestrator \
+      -n ${ORCHESTRATOR_NAMESPACE} --timeout=240s; then
+      return 0
+    fi
+
+    echo "ERROR: orchestrator rollout still did not finish after cleanup." >&2
+    rollout_diagnostics
+    exit 1
 
 commands:
   deploy: |-
@@ -190,8 +234,7 @@ pipelines:
     run: |-
       disable_argocd_sync
       patch_deployment
-      kubectl rollout status deployment/agents-orchestrator \
-        -n ${ORCHESTRATOR_NAMESPACE} --timeout=120s
+      rollout_or_recover
       sync_sources_once
       wait_for_orchestrator
       echo "Deploy complete. Orchestrator is running from source."

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -126,12 +126,13 @@ functions:
     LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
     POD="$(kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" \
       -o jsonpath='{.items[0].metadata.name}')"
-    tar \
-      --exclude='./.git' \
-      --exclude='./.devspace' \
-      --exclude='./.gen' \
-      --exclude='./tmp' \
-      -cf - . | kubectl exec -i -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
+    find . -mindepth 1 -maxdepth 1 \
+      ! -name .git \
+      ! -name .devspace \
+      ! -name .gen \
+      ! -name tmp \
+      -print0 | tar --null -T - -cf - | \
+      kubectl exec -i -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
         -c agents-orchestrator -- tar -xf - -C /opt/app/data
     echo "Source tree synced."
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -202,6 +202,7 @@ dev:
         sync:
           - path: ./:/opt/app/data
             initialSync: mirrorLocal
+            waitInitialSync: true
             noWatch: true
             polling: false
             excludePaths:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -129,13 +129,6 @@ functions:
   sync_sources_once: |-
     echo "Syncing source tree into agents-orchestrator pod..."
     LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
-    POD="$(kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" \
-      -o jsonpath='{.items[0].metadata.name}')"
-    if [ -z "${POD}" ]; then
-      echo "ERROR: agents-orchestrator pod not found for selector ${LABEL_SELECTOR}" >&2
-      kubectl get pods -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
-      exit 1
-    fi
 
     SYNC_ARCHIVE="$(mktemp)"
     trap 'rm -f "${SYNC_ARCHIVE}"' EXIT
@@ -146,25 +139,46 @@ functions:
       ! -name tmp \
       -print0 | tar --null -T - -cf "${SYNC_ARCHIVE}"
     SYNC_SIZE="$(wc -c < "${SYNC_ARCHIVE}")"
-    echo "Uploading source archive (${SYNC_SIZE} bytes) to pod ${POD}..."
-    if ! timeout 120s kubectl cp -n ${ORCHESTRATOR_NAMESPACE} \
-      -c agents-orchestrator "${SYNC_ARCHIVE}" "${POD}:/tmp/agents-orchestrator-source.tar"; then
-      echo "ERROR: source archive upload failed or timed out" >&2
-      kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} "${POD}" -o wide >&2 || true
-      kubectl logs -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
-        -c agents-orchestrator --tail=200 >&2 || true
+    ATTEMPT=1
+    SYNC_COMPLETE=false
+    while [ "${ATTEMPT}" -le 5 ]; do
+      echo "Source sync attempt ${ATTEMPT}/5..."
+      POD="$(kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" \
+        --field-selector=status.phase=Running \
+        --sort-by=.metadata.creationTimestamp \
+        -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | tail -n 1 || true)"
+      if [ -z "${POD}" ]; then
+        echo "No running agents-orchestrator pod found for selector ${LABEL_SELECTOR}." >&2
+      else
+        kubectl wait -n ${ORCHESTRATOR_NAMESPACE} "pod/${POD}" \
+          --for=condition=Ready --timeout=30s >&2 || true
+        echo "Uploading source archive (${SYNC_SIZE} bytes) to pod ${POD}..."
+        if timeout 120s kubectl cp -n ${ORCHESTRATOR_NAMESPACE} \
+          -c agents-orchestrator "${SYNC_ARCHIVE}" "${POD}:/tmp/agents-orchestrator-source.tar" && \
+          timeout 120s kubectl exec -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
+            -c agents-orchestrator -- sh -c \
+            'tar -xf /tmp/agents-orchestrator-source.tar -C /opt/app/data && rm -f /tmp/agents-orchestrator-source.tar'; then
+          echo "Source tree synced to pod ${POD}."
+          SYNC_COMPLETE=true
+          break
+        fi
+        echo "WARNING: source sync attempt ${ATTEMPT} failed for pod ${POD}; retrying with current pod selection." >&2
+      fi
+
+      echo "Diagnostic pod list:" >&2
+      kubectl get pods -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
+      echo "Diagnostic deployment rollout:" >&2
+      kubectl rollout status deployment/agents-orchestrator \
+        -n ${ORCHESTRATOR_NAMESPACE} --timeout=30s >&2 || true
+      ATTEMPT=$((ATTEMPT + 1))
+      sleep 5
+    done
+
+    if [ "${SYNC_COMPLETE}" != "true" ]; then
+      echo "ERROR: source archive upload/extract failed after retries" >&2
+      rollout_diagnostics
       exit 1
     fi
-    if ! timeout 120s kubectl exec -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
-      -c agents-orchestrator -- sh -c \
-      'tar -xf /tmp/agents-orchestrator-source.tar -C /opt/app/data && rm -f /tmp/agents-orchestrator-source.tar'; then
-      echo "ERROR: source archive extraction failed or timed out" >&2
-      kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} "${POD}" -o wide >&2 || true
-      kubectl logs -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
-        -c agents-orchestrator --tail=200 >&2 || true
-      exit 1
-    fi
-    echo "Source tree synced."
   rollout_diagnostics: |-
     LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
     echo "Diagnostic deployment:" >&2

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -201,7 +201,9 @@ dev:
         container: agents-orchestrator
         sync:
           - path: ./:/opt/app/data
+            initialSync: mirrorLocal
             noWatch: true
+            polling: false
             excludePaths:
               - .git/
               - .devspace/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,7 +3,6 @@ version: v2beta1
 vars:
   ORCHESTRATOR_NAMESPACE: platform
   DEV_IMAGE: ghcr.io/agynio/devcontainer-go:1
-  CI_IMAGE: agents-orchestrator:e2e
 
 functions:
   disable_argocd_sync: |-
@@ -99,29 +98,12 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
-  patch_ci_image_deployment: |-
-    echo "Patching agents-orchestrator deployment to use CI image..."
-    kubectl patch deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} --type strategic --patch "$(cat <<EOF
-    spec:
-      template:
-        spec:
-          containers:
-            - name: agents-orchestrator
-              image: ${CI_IMAGE}
-              imagePullPolicy: Never
-              env:
-                - name: POLL_INTERVAL
-                  value: "10s"
-                - name: WORKLOAD_RECONCILE_INTERVAL
-                  value: "10s"
-    EOF
-    )"
   wait_for_orchestrator: |-
     echo "Waiting for orchestrator deployment to roll out..."
     kubectl rollout status deployment/agents-orchestrator \
       -n ${ORCHESTRATOR_NAMESPACE} --timeout=120s
 
-    echo "Waiting for orchestrator process start..."
+    echo "Waiting for orchestrator source sync and process start..."
     ELAPSED=0
     LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
     until kubectl logs -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 2>/dev/null | \
@@ -138,17 +120,21 @@ functions:
       fi
       echo "  still waiting... (${ELAPSED}s)"
     done
-    echo "Orchestrator is running."
-  build_ci_image: |-
-    echo "Building agents-orchestrator CI image..."
-    docker buildx build --load -t ${CI_IMAGE} .
-    if command -v k3d >/dev/null 2>&1 && k3d cluster list agyn-local >/dev/null 2>&1; then
-      echo "Importing agents-orchestrator CI image into k3d cluster..."
-      k3d image import ${CI_IMAGE} -c agyn-local
-    else
-      echo "k3d cluster agyn-local not found; assuming ${CI_IMAGE} is already visible to Kubernetes."
-    fi
-    echo "Agents-orchestrator CI image is ready."
+    echo "Orchestrator is running from source."
+  sync_sources_once: |-
+    echo "Syncing source tree into agents-orchestrator pod..."
+    LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
+    POD="$(kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" \
+      -o jsonpath='{.items[0].metadata.name}')"
+    find . -mindepth 1 -maxdepth 1 \
+      ! -name .git \
+      ! -name .devspace \
+      ! -name .gen \
+      ! -name tmp \
+      -print0 | tar --null -T - -cf - | \
+      kubectl exec -i -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
+        -c agents-orchestrator -- tar -xf - -C /opt/app/data
+    echo "Source tree synced."
 
 commands:
   deploy: |-
@@ -178,12 +164,12 @@ pipelines:
   deploy:
     run: |-
       disable_argocd_sync
-      build_ci_image
-      patch_ci_image_deployment
+      patch_deployment
       kubectl rollout status deployment/agents-orchestrator \
         -n ${ORCHESTRATOR_NAMESPACE} --timeout=120s
+      sync_sources_once
       wait_for_orchestrator
-      echo "Deploy complete. Orchestrator is running from the CI image."
+      echo "Deploy complete. Orchestrator is running from source."
 
   restore-argocd:
     run: |-
@@ -191,7 +177,7 @@ pipelines:
 
 dev:
   # Interactive dev sync uses inotify in the container. CI deploy avoids DevSpace
-  # sync/watch entirely and runs the freshly built CI image.
+  # sync/watch entirely and performs a one-shot source upload in sync_sources_once.
   agents-orchestrator:
     namespace: ${ORCHESTRATOR_NAMESPACE}
     labelSelector:
@@ -222,7 +208,7 @@ dev:
           enabled: true
           lastLines: 200
 
-  # Kept for manual one-shot DevSpace sync experiments. CI deploy uses a built image instead.
+  # One-shot variant of agents-orchestrator for CI deploy pipeline. Keep sync excludePaths in sync.
   agents-orchestrator-deploy:
     namespace: ${ORCHESTRATOR_NAMESPACE}
     labelSelector:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -126,14 +126,39 @@ functions:
     LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
     POD="$(kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" \
       -o jsonpath='{.items[0].metadata.name}')"
+    if [ -z "${POD}" ]; then
+      echo "ERROR: agents-orchestrator pod not found for selector ${LABEL_SELECTOR}" >&2
+      kubectl get pods -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
+      exit 1
+    fi
+
+    SYNC_ARCHIVE="$(mktemp)"
+    trap 'rm -f "${SYNC_ARCHIVE}"' EXIT
     find . -mindepth 1 -maxdepth 1 \
       ! -name .git \
       ! -name .devspace \
       ! -name .gen \
       ! -name tmp \
-      -print0 | tar --null -T - -cf - | \
-      kubectl exec -i -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
-        -c agents-orchestrator -- tar -xf - -C /opt/app/data
+      -print0 | tar --null -T - -cf "${SYNC_ARCHIVE}"
+    SYNC_SIZE="$(wc -c < "${SYNC_ARCHIVE}")"
+    echo "Uploading source archive (${SYNC_SIZE} bytes) to pod ${POD}..."
+    if ! timeout 120s kubectl cp -n ${ORCHESTRATOR_NAMESPACE} \
+      -c agents-orchestrator "${SYNC_ARCHIVE}" "${POD}:/tmp/agents-orchestrator-source.tar"; then
+      echo "ERROR: source archive upload failed or timed out" >&2
+      kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} "${POD}" -o wide >&2 || true
+      kubectl logs -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
+        -c agents-orchestrator --tail=200 >&2 || true
+      exit 1
+    fi
+    if ! timeout 120s kubectl exec -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
+      -c agents-orchestrator -- sh -c \
+      'tar -xf /tmp/agents-orchestrator-source.tar -C /opt/app/data && rm -f /tmp/agents-orchestrator-source.tar'; then
+      echo "ERROR: source archive extraction failed or timed out" >&2
+      kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} "${POD}" -o wide >&2 || true
+      kubectl logs -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
+        -c agents-orchestrator --tail=200 >&2 || true
+      exit 1
+    fi
     echo "Source tree synced."
 
 commands:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -121,6 +121,19 @@ functions:
       echo "  still waiting... (${ELAPSED}s)"
     done
     echo "Orchestrator is running from source."
+  sync_sources_once: |-
+    echo "Syncing source tree into agents-orchestrator pod..."
+    LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
+    POD="$(kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" \
+      -o jsonpath='{.items[0].metadata.name}')"
+    tar \
+      --exclude='./.git' \
+      --exclude='./.devspace' \
+      --exclude='./.gen' \
+      --exclude='./tmp' \
+      -cf - . | kubectl exec -i -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
+        -c agents-orchestrator -- tar -xf - -C /opt/app/data
+    echo "Source tree synced."
 
 commands:
   deploy: |-
@@ -151,7 +164,9 @@ pipelines:
     run: |-
       disable_argocd_sync
       patch_deployment
-      start_dev --disable-pod-replace agents-orchestrator-deploy
+      kubectl rollout status deployment/agents-orchestrator \
+        -n ${ORCHESTRATOR_NAMESPACE} --timeout=120s
+      sync_sources_once
       wait_for_orchestrator
       echo "Deploy complete. Orchestrator is running from source."
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -56,9 +56,16 @@ functions:
                   while [ ! -f /opt/app/data/go.mod ] || \
                     [ ! -f /opt/app/data/go.sum ] || \
                     [ ! -f /opt/app/data/buf.gen.yaml ] || \
-                    [ ! -f /opt/app/data/buf.yaml ]; do
+                    [ ! -f /opt/app/data/buf.yaml ] || \
+                    [ ! -f /opt/app/data/cmd/orchestrator/main.go ]; do
                     sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 240 ] && { echo "ERROR: sync timeout waiting for source and Buf config" >&2; exit 1; }
+                    if [ "$elapsed" -ge 240 ]; then
+                      echo "ERROR: sync timeout waiting for source and Buf config" >&2
+                      ls -la /opt/app/data >&2 || true
+                      ls -la /opt/app/data/cmd >&2 || true
+                      ls -la /opt/app/data/cmd/orchestrator >&2 || true
+                      exit 1
+                    fi
                   done
                   buf generate buf.build/agynio/api \
                     --include-imports \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,6 +3,7 @@ version: v2beta1
 vars:
   ORCHESTRATOR_NAMESPACE: platform
   DEV_IMAGE: ghcr.io/agynio/devcontainer-go:1
+  CI_IMAGE: agents-orchestrator:e2e
 
 functions:
   disable_argocd_sync: |-
@@ -98,12 +99,29 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
+  patch_ci_image_deployment: |-
+    echo "Patching agents-orchestrator deployment to use CI image..."
+    kubectl patch deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} --type strategic --patch "$(cat <<EOF
+    spec:
+      template:
+        spec:
+          containers:
+            - name: agents-orchestrator
+              image: ${CI_IMAGE}
+              imagePullPolicy: Never
+              env:
+                - name: POLL_INTERVAL
+                  value: "10s"
+                - name: WORKLOAD_RECONCILE_INTERVAL
+                  value: "10s"
+    EOF
+    )"
   wait_for_orchestrator: |-
     echo "Waiting for orchestrator deployment to roll out..."
     kubectl rollout status deployment/agents-orchestrator \
       -n ${ORCHESTRATOR_NAMESPACE} --timeout=120s
 
-    echo "Waiting for orchestrator source sync and process start..."
+    echo "Waiting for orchestrator process start..."
     ELAPSED=0
     LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
     until kubectl logs -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 2>/dev/null | \
@@ -120,21 +138,17 @@ functions:
       fi
       echo "  still waiting... (${ELAPSED}s)"
     done
-    echo "Orchestrator is running from source."
-  sync_sources_once: |-
-    echo "Syncing source tree into agents-orchestrator pod..."
-    LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
-    POD="$(kubectl get pod -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" \
-      -o jsonpath='{.items[0].metadata.name}')"
-    find . -mindepth 1 -maxdepth 1 \
-      ! -name .git \
-      ! -name .devspace \
-      ! -name .gen \
-      ! -name tmp \
-      -print0 | tar --null -T - -cf - | \
-      kubectl exec -i -n ${ORCHESTRATOR_NAMESPACE} "${POD}" \
-        -c agents-orchestrator -- tar -xf - -C /opt/app/data
-    echo "Source tree synced."
+    echo "Orchestrator is running."
+  build_ci_image: |-
+    echo "Building agents-orchestrator CI image..."
+    docker buildx build --load -t ${CI_IMAGE} .
+    if command -v k3d >/dev/null 2>&1 && k3d cluster list agyn-local >/dev/null 2>&1; then
+      echo "Importing agents-orchestrator CI image into k3d cluster..."
+      k3d image import ${CI_IMAGE} -c agyn-local
+    else
+      echo "k3d cluster agyn-local not found; assuming ${CI_IMAGE} is already visible to Kubernetes."
+    fi
+    echo "Agents-orchestrator CI image is ready."
 
 commands:
   deploy: |-
@@ -164,12 +178,12 @@ pipelines:
   deploy:
     run: |-
       disable_argocd_sync
-      patch_deployment
+      build_ci_image
+      patch_ci_image_deployment
       kubectl rollout status deployment/agents-orchestrator \
         -n ${ORCHESTRATOR_NAMESPACE} --timeout=120s
-      sync_sources_once
       wait_for_orchestrator
-      echo "Deploy complete. Orchestrator is running from source."
+      echo "Deploy complete. Orchestrator is running from the CI image."
 
   restore-argocd:
     run: |-
@@ -177,7 +191,7 @@ pipelines:
 
 dev:
   # Interactive dev sync uses inotify in the container. CI deploy avoids DevSpace
-  # sync/watch entirely and performs a one-shot source upload in sync_sources_once.
+  # sync/watch entirely and runs the freshly built CI image.
   agents-orchestrator:
     namespace: ${ORCHESTRATOR_NAMESPACE}
     labelSelector:
@@ -208,7 +222,7 @@ dev:
           enabled: true
           lastLines: 200
 
-  # One-shot variant of agents-orchestrator for CI deploy pipeline. Keep sync excludePaths in sync.
+  # Kept for manual one-shot DevSpace sync experiments. CI deploy uses a built image instead.
   agents-orchestrator-deploy:
     namespace: ${ORCHESTRATOR_NAMESPACE}
     labelSelector:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -162,8 +162,10 @@ functions:
     LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
     echo "Diagnostic deployment:" >&2
     kubectl get deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} -o wide >&2 || true
+    kubectl describe deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} >&2 || true
     echo "Diagnostic replica sets:" >&2
     kubectl get rs -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
+    kubectl describe rs -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" >&2 || true
     echo "Diagnostic pods:" >&2
     kubectl get pods -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
     echo "Diagnostic pod descriptions:" >&2
@@ -174,13 +176,24 @@ functions:
     LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
     TERMINATING_PODS="$(kubectl get pods -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" \
       -o jsonpath='{range .items[?(@.metadata.deletionTimestamp)]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)"
-    if [ -z "${TERMINATING_PODS}" ]; then
+    OLD_REPLICA_SET_PODS="$(kubectl get pods -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" \
+      -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].kind=="ReplicaSet")]}{.metadata.name}{"\t"}{.metadata.ownerReferences[0].name}{"\n"}{end}' 2>/dev/null \
+      | while IFS="$(printf '\t')" read -r POD REPLICA_SET; do
+          [ -n "${POD}" ] || continue
+          DESIRED="$(kubectl get rs "${REPLICA_SET}" -n ${ORCHESTRATOR_NAMESPACE} -o jsonpath='{.spec.replicas}' 2>/dev/null || true)"
+          if [ "${DESIRED}" = "0" ]; then
+            printf '%s\n' "${POD}"
+          fi
+        done)"
+    DELETE_PODS="$(printf '%s\n%s\n' "${TERMINATING_PODS}" "${OLD_REPLICA_SET_PODS}" | awk 'NF && !seen[$0]++')"
+    if [ -z "${DELETE_PODS}" ]; then
       echo "No terminating agents-orchestrator pods found to force delete."
       return 0
     fi
-    echo "Force deleting terminating agents-orchestrator pods:"
-    for POD in ${TERMINATING_PODS}; do
+    echo "Force deleting stuck old or terminating agents-orchestrator pods:"
+    for POD in ${DELETE_PODS}; do
       echo "  ${POD}"
+      kubectl describe pod "${POD}" -n ${ORCHESTRATOR_NAMESPACE} >&2 || true
       kubectl delete pod "${POD}" -n ${ORCHESTRATOR_NAMESPACE} \
         --grace-period=0 --force --wait=false || true
     done

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -53,9 +53,12 @@ functions:
                 - |
                   set -eu
                   elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ]; do
+                  while [ ! -f /opt/app/data/go.mod ] || \
+                    [ ! -f /opt/app/data/go.sum ] || \
+                    [ ! -f /opt/app/data/buf.gen.yaml ] || \
+                    [ ! -f /opt/app/data/buf.yaml ]; do
                     sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 240 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                    [ "$elapsed" -ge 240 ] && { echo "ERROR: sync timeout waiting for source and Buf config" >&2; exit 1; }
                   done
                   buf generate buf.build/agynio/api \
                     --include-imports \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -188,35 +188,33 @@ functions:
     DELETE_PODS="$(printf '%s\n%s\n' "${TERMINATING_PODS}" "${OLD_REPLICA_SET_PODS}" | awk 'NF && !seen[$0]++')"
     if [ -z "${DELETE_PODS}" ]; then
       echo "No terminating agents-orchestrator pods found to force delete."
-      return 0
+    else
+      echo "Force deleting stuck old or terminating agents-orchestrator pods:"
+      for POD in ${DELETE_PODS}; do
+        echo "  ${POD}"
+        kubectl describe pod "${POD}" -n ${ORCHESTRATOR_NAMESPACE} >&2 || true
+        kubectl delete pod "${POD}" -n ${ORCHESTRATOR_NAMESPACE} \
+          --grace-period=0 --force --wait=false || true
+      done
     fi
-    echo "Force deleting stuck old or terminating agents-orchestrator pods:"
-    for POD in ${DELETE_PODS}; do
-      echo "  ${POD}"
-      kubectl describe pod "${POD}" -n ${ORCHESTRATOR_NAMESPACE} >&2 || true
-      kubectl delete pod "${POD}" -n ${ORCHESTRATOR_NAMESPACE} \
-        --grace-period=0 --force --wait=false || true
-    done
   rollout_or_recover: |-
     echo "Waiting for orchestrator deployment to roll out..."
     if kubectl rollout status deployment/agents-orchestrator \
       -n ${ORCHESTRATOR_NAMESPACE} --timeout=120s; then
-      return 0
+      echo "Orchestrator deployment successfully rolled out."
+    else
+      echo "WARNING: orchestrator rollout did not finish within 120s; collecting diagnostics." >&2
+      rollout_diagnostics
+      force_delete_terminating_orchestrator_pods
+
+      echo "Retrying orchestrator rollout after cleanup..."
+      if ! kubectl rollout status deployment/agents-orchestrator \
+        -n ${ORCHESTRATOR_NAMESPACE} --timeout=240s; then
+        echo "ERROR: orchestrator rollout still did not finish after cleanup." >&2
+        rollout_diagnostics
+        exit 1
+      fi
     fi
-
-    echo "WARNING: orchestrator rollout did not finish within 120s; collecting diagnostics." >&2
-    rollout_diagnostics
-    force_delete_terminating_orchestrator_pods
-
-    echo "Retrying orchestrator rollout after cleanup..."
-    if kubectl rollout status deployment/agents-orchestrator \
-      -n ${ORCHESTRATOR_NAMESPACE} --timeout=240s; then
-      return 0
-    fi
-
-    echo "ERROR: orchestrator rollout still did not finish after cleanup." >&2
-    rollout_diagnostics
-    exit 1
 
 commands:
   deploy: |-

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -176,7 +176,8 @@ pipelines:
       restore_argocd_sync
 
 dev:
-  # CI counterpart: agents-orchestrator-deploy (one-shot sync)
+  # Interactive dev sync uses inotify in the container. CI deploy avoids DevSpace
+  # sync/watch entirely and performs a one-shot source upload in sync_sources_once.
   agents-orchestrator:
     namespace: ${ORCHESTRATOR_NAMESPACE}
     labelSelector:
@@ -187,6 +188,7 @@ dev:
         container: agents-orchestrator
         sync:
           - path: ./:/opt/app/data
+            polling: false
             excludePaths:
               - .git/
               - .devspace/


### PR DESCRIPTION
## Summary
- Wait for `buf.gen.yaml`, `buf.yaml`, `go.mod`, `go.sum`, and `cmd/orchestrator/main.go` before running source-deploy protobuf generation.
- Add timeout diagnostics that list `/opt/app/data`, `/opt/app/data/cmd`, and `/opt/app/data/cmd/orchestrator` when source sync prerequisites are missing.
- Keep the CI one-shot DevSpace sync config on `initialSync: mirrorLocal`, `waitInitialSync: true`, `noWatch: true`, and `polling: false`.
- Leave the E2E workflow unchanged.

Closes #187
Closes #199

## Test & Lint Summary
- `nix shell nixpkgs#devspace nixpkgs#buf nixpkgs#gcc --command sh -c 'devspace --version && devspace print --skip-info >/tmp/devspace-print.yaml && buf --version && gcc --version | head -1 && buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1 && go test ./... && go vet ./... && go build ./...'`: passed
- `git diff --check`: passed