### PR TITLE
Fix DevSpace buf config sync guard

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,11 +52,22 @@ functions:
                 - -c
                 - |
                   set -eu
+                  required_files="go.mod go.sum buf.yaml buf.lock buf.gen.yaml cmd/orchestrator/main.go"
                   elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ]; do
+                  while :; do
+                    missing_files=""
+                    for required_file in $required_files; do
+                      if [ ! -f "/opt/app/data/${required_file}" ]; then
+                        missing_files="${missing_files} ${required_file}"
+                      fi
+                    done
+                    if [ -z "$missing_files" ]; then
+                      break
+                    fi
                     sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 240 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                    [ "$elapsed" -ge 240 ] && { echo "ERROR: sync timeout waiting for:${missing_files}" >&2; exit 1; }
                   done
+                  [ -s /opt/app/data/buf.gen.yaml ] || { echo "ERROR: buf.gen.yaml is empty" >&2; exit 1; }
                   buf generate buf.build/agynio/api \
                     --include-imports \
                     --path agynio/api/runner/v1 \


### PR DESCRIPTION
## Summary
- Update the DevSpace patched orchestrator command to wait for all required repository files before running `buf generate`.
- Include `buf.gen.yaml` in the guard and assert it is non-empty before invoking Buf.
- Preserve the existing 240s sync timeout while reporting which files are still missing.

Closes #200

## Test & Lint Summary
- `buf generate buf.build/agynio/api --include-imports --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/secrets/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/tracing/v1` — passed.
- `go test ./...` — 7 passed, 0 failed, 0 skipped; 4 packages had no test files.
- `go build ./...` — passed.
- `git diff --check` — passed with no whitespace/lint errors.