### PR TITLE
Configure agent OTel exporter endpoint

### DIFF
--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -44,21 +44,22 @@ const (
 )
 
 var reservedEnvNames = map[string]struct{}{
-	"AGENT_ID":                 {},
-	"AGENT_NAME":               {},
-	"AGENT_ROLE":               {},
-	"AGENT_MODEL":              {},
-	"AGENT_CONFIG":             {},
-	"THREAD_ID":                {},
-	"WORKLOAD_ID":              {},
-	"GATEWAY_ADDRESS":          {},
-	"AGYN_GATEWAY_URL":         {},
-	"LLM_BASE_URL":             {},
-	"TRACING_ADDRESS":          {},
-	"AGENT_MCP_SERVERS":        {},
-	"MCP_PORT":                 {},
-	ZitiEnrollmentTokenEnvVar:  {},
-	ZitiIdentityBasenameEnvVar: {},
+	"AGENT_ID":                    {},
+	"AGENT_NAME":                  {},
+	"AGENT_ROLE":                  {},
+	"AGENT_MODEL":                 {},
+	"AGENT_CONFIG":                {},
+	"THREAD_ID":                   {},
+	"WORKLOAD_ID":                 {},
+	"GATEWAY_ADDRESS":             {},
+	"AGYN_GATEWAY_URL":            {},
+	"LLM_BASE_URL":                {},
+	"TRACING_ADDRESS":             {},
+	"OTEL_EXPORTER_OTLP_ENDPOINT": {},
+	"AGENT_MCP_SERVERS":           {},
+	"MCP_PORT":                    {},
+	ZitiEnrollmentTokenEnvVar:     {},
+	ZitiIdentityBasenameEnvVar:    {},
 }
 
 type Assembler struct {
@@ -634,6 +635,7 @@ func (a *Assembler) baseAgentEnvVars(agent *agentsv1.Agent, agentID, threadID uu
 	}
 	if a.cfg.AgentTracingAddress != "" {
 		vars = append(vars, &runnerv1.EnvVar{Name: "TRACING_ADDRESS", Value: a.cfg.AgentTracingAddress})
+		vars = append(vars, &runnerv1.EnvVar{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://localhost:4317"})
 	}
 	return vars
 }

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -167,6 +167,7 @@ func TestAssemblerMainContainer(t *testing.T) {
 	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://"+cfg.AgentGatewayAddress)
 	assertEnv(t, envs, "LLM_BASE_URL", cfg.AgentLLMBaseURL)
 	assertEnv(t, envs, "TRACING_ADDRESS", cfg.AgentTracingAddress)
+	assertEnv(t, envs, "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 	assertEnv(t, envs, "WORKSPACE_DIR", "/override")
 	assertEnv(t, envs, "HOME", "/override-home")
 	assertEnv(t, envs, "CUSTOM_ENV", "custom")
@@ -466,6 +467,8 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 	assertEnv(t, envs, "GATEWAY_ADDRESS", "gateway.ziti:443")
 	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://gateway.ziti:443")
 	assertEnv(t, envs, "LLM_BASE_URL", "http://llm-proxy.ziti/v1")
+	assertEnv(t, envs, "TRACING_ADDRESS", "tracing.ziti:443")
+	assertEnv(t, envs, "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 }
 
 func TestAssemblerInitImageOverride(t *testing.T) {


### PR DESCRIPTION
## Summary

- Inject `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` into agent containers whenever tracing is configured.
- Reserve the exporter env var so user env resources cannot override the platform-managed tracing proxy target.
- Add assembler coverage for explicit and Ziti-default tracing configuration.

This is the minimal architecture-aligned tracing fix for #203: `agynd` owns the local tracing proxy and injects `agyn.thread.message.id`, while the orchestrator only provides the standard OTel endpoint needed by Codex, Claude, and agn CLIs to export spans to that proxy.

Fixes #203.

## Test & Lint Summary

- `go test ./...` — passed: 12 packages; failed: 0; skipped: 0.
- `go build ./...` — passed.
- Lint/format: `gofmt -w internal/assembler/assembler.go internal/assembler/assembler_test.go`; `git diff --check` — no errors.