### PR TITLE
Improve subscriber stream error logging

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -130,6 +130,7 @@ func run() error {
 	runnersClient := runnersv1.NewRunnersServiceClient(runnersConn)
 	meteringClient := meteringv1.NewMeteringServiceClient(meteringConn)
 	subscriber := subscriber.New(notificationsClient, agentsClient)
+	subscriber.SetServiceTargets(cfg.NotificationsAddress, cfg.AgentsAddress)
 	assembler := assembler.New(agentsClient, secretsClient, &cfg)
 	reconciler := reconciler.New(reconciler.Config{
 		Threads:                   threadsClient,

--- a/internal/runnerdial/runnerdial.go
+++ b/internal/runnerdial/runnerdial.go
@@ -168,15 +168,29 @@ func dialZitiWithRetry(ctx context.Context, zitiCtx ZitiDialer, service string) 
 		if IsNoTerminators(err) {
 			return nil, fmt.Errorf("dial ziti service %s: %w", service, err)
 		}
-		log.Printf("dial ziti service %s: attempt %d/%d failed: %v", service, attempt, retryMaxAttempts, err)
 		lastErr = err
 		if isAuthFailure(err) {
+			log.Printf(
+				"runnerdial: dial ziti service failed service=%s attempt=%d/%d auth_failure=true action=re_enroll err=%v",
+				service,
+				attempt,
+				retryMaxAttempts,
+				err,
+			)
 			zitiCtx.NotifyAuthFailure(ctx)
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
 			continue
 		}
+		log.Printf(
+			"runnerdial: dial ziti service failed service=%s attempt=%d/%d auth_failure=false backoff=%s err=%v",
+			service,
+			attempt,
+			retryMaxAttempts,
+			backoff,
+			err,
+		)
 		if attempt == retryMaxAttempts {
 			break
 		}

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -2,17 +2,22 @@ package subscriber
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	notificationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/notifications/v1"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -22,6 +27,10 @@ const (
 	threadParticipantRoomPrefix       = "thread_participant:"
 	listAgentsPageSize          int32 = 100
 	defaultRoomRefreshInterval        = 30 * time.Second
+	streamErrorSummaryInterval        = time.Minute
+	roomSnapshotSampleSize            = 3
+	agentsServiceName                 = "agents"
+	notificationsServiceName          = "notifications"
 )
 
 type roomSnapshot struct {
@@ -34,6 +43,9 @@ type Subscriber struct {
 	agents              agentsv1.AgentsServiceClient
 	wake                chan struct{}
 	roomRefreshInterval time.Duration
+	notificationsTarget string
+	agentsTarget        string
+	streamErrors        *repeatedErrorLimiter
 }
 
 func New(client notificationsv1.NotificationsServiceClient, agents agentsv1.AgentsServiceClient) *Subscriber {
@@ -42,7 +54,17 @@ func New(client notificationsv1.NotificationsServiceClient, agents agentsv1.Agen
 		agents:              agents,
 		wake:                make(chan struct{}, 1),
 		roomRefreshInterval: defaultRoomRefreshInterval,
+		streamErrors:        newRepeatedErrorLimiter(streamErrorSummaryInterval),
 	}
+}
+
+func (s *Subscriber) Wake() <-chan struct{} {
+	return s.wake
+}
+
+func (s *Subscriber) SetServiceTargets(notificationsTarget, agentsTarget string) {
+	s.notificationsTarget = strings.TrimSpace(notificationsTarget)
+	s.agentsTarget = strings.TrimSpace(agentsTarget)
 }
 
 func (s *Subscriber) Run(ctx context.Context) error {
@@ -53,7 +75,12 @@ func (s *Subscriber) Run(ctx context.Context) error {
 		}
 		snapshot, err := s.buildRoomSnapshot(ctx)
 		if err != nil {
-			log.Printf("subscriber: build rooms failed: %v", err)
+			log.Printf(
+				"subscriber: rooms build failed phase=rooms.build %s backoff=%s err=%v",
+				formatServiceTarget(agentsServiceName, s.agentsTarget),
+				backoff,
+				err,
+			)
 			if err := waitWithBackoff(ctx, backoff); err != nil {
 				return err
 			}
@@ -64,7 +91,7 @@ func (s *Subscriber) Run(ctx context.Context) error {
 		stream, err := s.client.Subscribe(streamCtx, &notificationsv1.SubscribeRequest{Rooms: snapshot.rooms})
 		if err != nil {
 			cancel()
-			log.Printf("subscriber: subscribe failed: %v", err)
+			s.logStreamError("Subscribe", snapshot, backoff, err)
 			if err := waitWithBackoff(ctx, backoff); err != nil {
 				return err
 			}
@@ -87,7 +114,11 @@ func (s *Subscriber) Run(ctx context.Context) error {
 				roomsChanged := false
 				select {
 				case <-roomsUpdated:
-					log.Printf("subscriber: agent rooms changed, resubscribing")
+					log.Printf(
+						"subscriber: rooms changed, resubscribing phase=rooms.refresh %s previous_%s",
+						formatServiceTarget(agentsServiceName, s.agentsTarget),
+						formatRoomSnapshot(snapshot),
+					)
 					roomsChanged = true
 				default:
 				}
@@ -95,9 +126,14 @@ func (s *Subscriber) Run(ctx context.Context) error {
 					break
 				}
 				if errors.Is(err, io.EOF) {
-					log.Printf("subscriber: stream closed")
+					log.Printf(
+						"subscriber: stream closed phase=Recv %s %s backoff=%s",
+						formatServiceTarget(notificationsServiceName, s.notificationsTarget),
+						formatRoomSnapshot(snapshot),
+						backoff,
+					)
 				} else {
-					log.Printf("subscriber: stream recv failed: %v", err)
+					s.logStreamError("Recv", snapshot, backoff, err)
 				}
 				if err := waitWithBackoff(ctx, backoff); err != nil {
 					return err
@@ -166,7 +202,7 @@ func (s *Subscriber) buildRoomSnapshot(ctx context.Context) (roomSnapshot, error
 	sort.Strings(ordered)
 	return roomSnapshot{
 		rooms:       ordered,
-		fingerprint: strings.Join(ordered, "|"),
+		fingerprint: fingerprintRooms(ordered),
 	}, nil
 }
 
@@ -183,20 +219,27 @@ func (s *Subscriber) watchRooms(ctx context.Context, snapshot roomSnapshot, upda
 		case <-ticker.C:
 			next, err := s.buildRoomSnapshot(ctx)
 			if err != nil {
-				log.Printf("subscriber: refresh rooms failed: %v", err)
+				log.Printf(
+					"subscriber: rooms refresh failed phase=rooms.refresh %s previous_%s err=%v",
+					formatServiceTarget(agentsServiceName, s.agentsTarget),
+					formatRoomSnapshot(snapshot),
+					err,
+				)
 				continue
 			}
 			if next.fingerprint != snapshot.fingerprint {
+				log.Printf(
+					"subscriber: rooms refresh detected change phase=rooms.refresh %s previous_%s current_%s",
+					formatServiceTarget(agentsServiceName, s.agentsTarget),
+					formatRoomSnapshot(snapshot),
+					formatRoomSnapshot(next),
+				)
 				close(updated)
 				cancel()
 				return
 			}
 		}
 	}
-}
-
-func (s *Subscriber) Wake() <-chan struct{} {
-	return s.wake
 }
 
 func waitWithBackoff(ctx context.Context, delay time.Duration) error {
@@ -222,4 +265,137 @@ func nextBackoff(current time.Duration) time.Duration {
 		return 30 * time.Second
 	}
 	return next
+}
+
+func (s *Subscriber) logStreamError(phase string, snapshot roomSnapshot, backoff time.Duration, err error) {
+	code, desc := grpcErrorDetails(err)
+	key := strings.Join([]string{phase, notificationsServiceName, s.notificationsTarget, snapshot.fingerprint, code, desc}, "\x00")
+	decision := s.streamErrors.Record(key)
+	if decision.First {
+		log.Printf(
+			"subscriber: stream error phase=%s %s %s grpc_code=%s grpc_desc=%q backoff=%s err=%v",
+			phase,
+			formatServiceTarget(notificationsServiceName, s.notificationsTarget),
+			formatRoomSnapshot(snapshot),
+			code,
+			desc,
+			backoff,
+			err,
+		)
+		return
+	}
+	if decision.Summary {
+		log.Printf(
+			"subscriber: stream error repeated phase=%s %s %s grpc_code=%s grpc_desc=%q backoff=%s suppressed=%d",
+			phase,
+			formatServiceTarget(notificationsServiceName, s.notificationsTarget),
+			formatRoomSnapshot(snapshot),
+			code,
+			desc,
+			backoff,
+			decision.Suppressed,
+		)
+	}
+}
+
+func grpcErrorDetails(err error) (string, string) {
+	statusErr, ok := status.FromError(err)
+	if !ok {
+		return "NonGRPC", err.Error()
+	}
+	code := statusErr.Code()
+	if code == codes.OK {
+		return "NonGRPC", err.Error()
+	}
+	return code.String(), statusErr.Message()
+}
+
+func formatServiceTarget(serviceName, target string) string {
+	if target == "" {
+		return fmt.Sprintf("service=%s target=unknown", serviceName)
+	}
+	return fmt.Sprintf("service=%s target=%s", serviceName, target)
+}
+
+func formatRoomSnapshot(snapshot roomSnapshot) string {
+	agentRooms := 0
+	threadParticipantRooms := 0
+	for _, room := range snapshot.rooms {
+		switch {
+		case strings.HasPrefix(room, agentRoomPrefix):
+			agentRooms++
+		case strings.HasPrefix(room, threadParticipantRoomPrefix):
+			threadParticipantRooms++
+		}
+	}
+	otherRooms := len(snapshot.rooms) - agentRooms - threadParticipantRooms
+	sampleLimit := roomSnapshotSampleSize
+	if len(snapshot.rooms) < sampleLimit {
+		sampleLimit = len(snapshot.rooms)
+	}
+	return fmt.Sprintf(
+		"rooms_count=%d agent_rooms=%d thread_participant_rooms=%d other_rooms=%d fingerprint=%s sample=%q",
+		len(snapshot.rooms),
+		agentRooms,
+		threadParticipantRooms,
+		otherRooms,
+		snapshot.fingerprint,
+		snapshot.rooms[:sampleLimit],
+	)
+}
+
+func fingerprintRooms(rooms []string) string {
+	hash := sha256.New()
+	for _, room := range rooms {
+		_, _ = hash.Write([]byte(room))
+		_, _ = hash.Write([]byte{0})
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
+}
+
+type repeatedErrorLimiter struct {
+	mu       sync.Mutex
+	interval time.Duration
+	now      func() time.Time
+	entries  map[string]repeatedErrorEntry
+}
+
+type repeatedErrorEntry struct {
+	lastLogged time.Time
+	suppressed int
+}
+
+type repeatedErrorDecision struct {
+	First      bool
+	Summary    bool
+	Suppressed int
+}
+
+func newRepeatedErrorLimiter(interval time.Duration) *repeatedErrorLimiter {
+	return &repeatedErrorLimiter{
+		interval: interval,
+		now:      time.Now,
+		entries:  make(map[string]repeatedErrorEntry),
+	}
+}
+
+func (l *repeatedErrorLimiter) Record(key string) repeatedErrorDecision {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	entry, ok := l.entries[key]
+	if !ok {
+		l.entries[key] = repeatedErrorEntry{lastLogged: now}
+		return repeatedErrorDecision{First: true}
+	}
+	entry.suppressed++
+	if now.Sub(entry.lastLogged) >= l.interval {
+		decision := repeatedErrorDecision{Summary: true, Suppressed: entry.suppressed}
+		entry.lastLogged = now
+		entry.suppressed = 0
+		l.entries[key] = entry
+		return decision
+	}
+	l.entries[key] = entry
+	return repeatedErrorDecision{}
 }

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -166,6 +167,58 @@ func TestSubscriberResubscribesOnAgentChange(t *testing.T) {
 	}
 }
 
+func TestFormatRoomSnapshotIncludesCountsFingerprintAndSamples(t *testing.T) {
+	snapshot := roomSnapshot{
+		rooms: []string{
+			"agent:11111111-1111-1111-1111-111111111111",
+			"agent:22222222-2222-2222-2222-222222222222",
+			"custom:room",
+			"thread_participant:11111111-1111-1111-1111-111111111111",
+			"thread_participant:22222222-2222-2222-2222-222222222222",
+		},
+	}
+	snapshot.fingerprint = fingerprintRooms(snapshot.rooms)
+
+	formatted := formatRoomSnapshot(snapshot)
+	assertContains(t, formatted, "rooms_count=5")
+	assertContains(t, formatted, "agent_rooms=2")
+	assertContains(t, formatted, "thread_participant_rooms=2")
+	assertContains(t, formatted, "other_rooms=1")
+	assertContains(t, formatted, "fingerprint=sha256:")
+	assertContains(t, formatted, "agent:11111111-1111-1111-1111-111111111111")
+	assertContains(t, formatted, "custom:room")
+	if strings.Contains(formatted, "thread_participant:22222222-2222-2222-2222-222222222222") {
+		t.Fatalf("expected sample to be limited, got %q", formatted)
+	}
+}
+
+func TestRepeatedErrorLimiterSuppressesUntilSummaryInterval(t *testing.T) {
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	limiter := newRepeatedErrorLimiter(time.Minute)
+	limiter.now = func() time.Time { return now }
+
+	first := limiter.Record("Recv\x00Unauthenticated\x00identity not available")
+	if !first.First || first.Summary || first.Suppressed != 0 {
+		t.Fatalf("expected first decision, got %+v", first)
+	}
+
+	second := limiter.Record("Recv\x00Unauthenticated\x00identity not available")
+	if second.First || second.Summary || second.Suppressed != 0 {
+		t.Fatalf("expected suppressed decision, got %+v", second)
+	}
+
+	now = now.Add(time.Minute)
+	third := limiter.Record("Recv\x00Unauthenticated\x00identity not available")
+	if third.First || !third.Summary || third.Suppressed != 2 {
+		t.Fatalf("expected summary for two suppressed errors, got %+v", third)
+	}
+
+	fourth := limiter.Record("Subscribe\x00Unauthenticated\x00identity not available")
+	if !fourth.First || fourth.Summary || fourth.Suppressed != 0 {
+		t.Fatalf("expected independent key to log first occurrence, got %+v", fourth)
+	}
+}
+
 func newSubscriberHarness(t *testing.T, responses chan *notificationsv1.SubscribeResponse, ack chan struct{}, initialAgents []*agentsv1.Agent, refreshInterval time.Duration) *subscriberHarness {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -305,4 +358,11 @@ type subscriberHarness struct {
 
 func agentFixture(id string) *agentsv1.Agent {
 	return &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: id}}
+}
+
+func assertContains(t *testing.T, value, substring string) {
+	t.Helper()
+	if !strings.Contains(value, substring) {
+		t.Fatalf("expected %q to contain %q", value, substring)
+	}
 }

--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -252,6 +252,7 @@ func (f *FakeAgentsClient) ListInitScripts(ctx context.Context, req *agentsv1.Li
 
 type FakeSecretsClient struct {
 	ResolveSecretFunc          func(context.Context, *secretsv1.ResolveSecretRequest, ...grpc.CallOption) (*secretsv1.ResolveSecretResponse, error)
+	ResolveSecretExistsFunc    func(context.Context, *secretsv1.ResolveSecretExistsRequest, ...grpc.CallOption) (*secretsv1.ResolveSecretExistsResponse, error)
 	ResolveImagePullSecretFunc func(context.Context, *secretsv1.ResolveImagePullSecretRequest, ...grpc.CallOption) (*secretsv1.ResolveImagePullSecretResponse, error)
 }
 
@@ -325,6 +326,13 @@ func (f *FakeSecretsClient) ListSecrets(context.Context, *secretsv1.ListSecretsR
 func (f *FakeSecretsClient) ResolveSecret(ctx context.Context, req *secretsv1.ResolveSecretRequest, opts ...grpc.CallOption) (*secretsv1.ResolveSecretResponse, error) {
 	if f.ResolveSecretFunc != nil {
 		return f.ResolveSecretFunc(ctx, req, opts...)
+	}
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeSecretsClient) ResolveSecretExists(ctx context.Context, req *secretsv1.ResolveSecretExistsRequest, opts ...grpc.CallOption) (*secretsv1.ResolveSecretExistsResponse, error) {
+	if f.ResolveSecretExistsFunc != nil {
+		return f.ResolveSecretExistsFunc(ctx, req, opts...)
 	}
 	return nil, ErrNotImplemented
 }

--- a/internal/zitimanager/manager.go
+++ b/internal/zitimanager/manager.go
@@ -84,7 +84,7 @@ func (m *ZitiManager) DialContext(ctx context.Context, service string) (edge.Con
 func (m *ZitiManager) NotifyAuthFailure(ctx context.Context) {
 	waitCtx := m.effectiveContext(ctx)
 	if err := m.triggerReEnroll(waitCtx); err != nil && waitCtx.Err() == nil {
-		log.Printf("ziti re-enroll after auth failure failed: %v", err)
+		log.Printf("zitimanager: re-enroll after auth failure failed identity_id=%s err=%v", m.currentIdentityID(), err)
 	}
 }
 
@@ -105,12 +105,12 @@ func (m *ZitiManager) RunLeaseRenewal(ctx context.Context) {
 			}
 			if isNotFoundGrpcError(err) {
 				if err := m.triggerReEnroll(ctx); err != nil && ctx.Err() == nil {
-					log.Printf("ziti lease renewal re-enroll failed: %v", err)
+					log.Printf("zitimanager: lease renewal re-enroll failed identity_id=%s err=%v", m.currentIdentityID(), err)
 				}
 				continue
 			}
 			if ctx.Err() == nil {
-				log.Printf("failed to extend ziti lease: %v", err)
+				log.Printf("zitimanager: extend ziti lease failed identity_id=%s err=%v", m.currentIdentityID(), err)
 			}
 		}
 	}
@@ -282,7 +282,16 @@ func retryWithBackoff(ctx context.Context, operationName string, fn func(context
 			delay = retryMaxBackoff
 		}
 
-		log.Printf("%s failed (attempt %d), retrying in %s: %v", operationName, attempt, delay, err)
+		statusErr, _ := status.FromError(err)
+		log.Printf(
+			"zitimanager: retryable operation failed operation=%q attempt=%d backoff=%s grpc_code=%s grpc_desc=%q err=%v",
+			operationName,
+			attempt,
+			delay,
+			statusErr.Code().String(),
+			statusErr.Message(),
+			err,
+		)
 
 		timer := time.NewTimer(delay)
 		select {


### PR DESCRIPTION
## Summary
- Adds subscriber stream log context for Subscribe/Recv/rooms refresh phases, service target addresses, room snapshot counts/samples/fingerprints, gRPC code/description, and retry backoff.
- Suppresses repeated identical subscriber stream errors while logging the first full occurrence and periodic summaries with suppressed counts.
- Improves closely related runnerdial and zitimanager retry/error logs with service/identity/backoff/auth context.
- Adds unit coverage for room snapshot formatting and repeated stream error suppression.

Closes #205

## Test & Lint Summary
- `go test -json ./... | tee /tmp/agents-orchestrator-test.json >/dev/null`: 151 passed / 0 failed / 0 skipped.
- `go test ./...`: passed.
- `go build ./...`: passed.
- `go vet ./...`: passed with no errors.