### PR TITLE
test: update secrets fake client

### DIFF
--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -252,6 +252,7 @@ func (f *FakeAgentsClient) ListInitScripts(ctx context.Context, req *agentsv1.Li
 
 type FakeSecretsClient struct {
 	ResolveSecretFunc          func(context.Context, *secretsv1.ResolveSecretRequest, ...grpc.CallOption) (*secretsv1.ResolveSecretResponse, error)
+	ResolveSecretExistsFunc    func(context.Context, *secretsv1.ResolveSecretExistsRequest, ...grpc.CallOption) (*secretsv1.ResolveSecretExistsResponse, error)
 	ResolveImagePullSecretFunc func(context.Context, *secretsv1.ResolveImagePullSecretRequest, ...grpc.CallOption) (*secretsv1.ResolveImagePullSecretResponse, error)
 }
 
@@ -325,6 +326,13 @@ func (f *FakeSecretsClient) ListSecrets(context.Context, *secretsv1.ListSecretsR
 func (f *FakeSecretsClient) ResolveSecret(ctx context.Context, req *secretsv1.ResolveSecretRequest, opts ...grpc.CallOption) (*secretsv1.ResolveSecretResponse, error) {
 	if f.ResolveSecretFunc != nil {
 		return f.ResolveSecretFunc(ctx, req, opts...)
+	}
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeSecretsClient) ResolveSecretExists(ctx context.Context, req *secretsv1.ResolveSecretExistsRequest, opts ...grpc.CallOption) (*secretsv1.ResolveSecretExistsResponse, error) {
+	if f.ResolveSecretExistsFunc != nil {
+		return f.ResolveSecretExistsFunc(ctx, req, opts...)
 	}
 	return nil, ErrNotImplemented
 }


### PR DESCRIPTION
## Summary
- Added the generated `ResolveSecretExists` method to `internal/testutil.FakeSecretsClient`.
- Keeps local test/lint runs compatible with the current generated secrets API while the E2E root-cause remains owned by Expose/Tracing release coordination.

Refs #207

## E2E investigation
- Latest agents-orchestrator main E2E run `26861157089` fails with the same non-orchestrator signatures seen by Emerson:
  - Go core `TestAgentExposeLifecycle_ListAddRemove`: exposure is `active` but missing `openziti_service_id`, `openziti_bind_policy_id`, and `openziti_dial_policy_id`.
  - Playwright tracing app: Claude `ListSpans(messageId)` returns no trace ID; Codex resolves to infrastructure/transport spans or only `initialize`, with zero message/LLM/tool counts.
- Latest PR E2E run `26889882104` shows the same signatures.
- These map to owning repo fixes already merged but not released/pinned into bootstrap images/charts:
  - agynio/expose#30 / agynio/expose#29
  - agynio/tracing#20 / agynio/tracing#19
- Minimal coordination path: release/pin Expose and Tracing fixes in bootstrap, then rerun agents-orchestrator E2E for #207.

## Test & Lint Summary
- `GOTOOLCHAIN=go1.25.7 go test -json ./... | tee /tmp/agents-orchestrator-test.json >/dev/null`: 149 passed / 0 failed / 0 skipped.
- `GOTOOLCHAIN=go1.25.7 go build ./...`: passed.
- `GOTOOLCHAIN=go1.25.7 go vet ./...`: passed with no errors.
- `git diff --check`: passed with no errors.