### PR TITLE
Egress v1: distribute CA to workloads

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,8 +42,11 @@ jobs:
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
+        env:
+          E2E_SUITES: go-core playwright-chat-app
         with:
           service: agents_orchestrator
+          include_smoke: "false"
 
       - name: Restore k8s-runner ArgoCD sync
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Checkout service
         uses: actions/checkout@v4
@@ -26,6 +26,17 @@ jobs:
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
+      - name: Checkout k8s-runner
+        uses: actions/checkout@v4
+        with:
+          repository: agynio/k8s-runner
+          ref: main
+          path: .e2e-deps/k8s-runner
+
+      - name: Deploy k8s-runner from source
+        working-directory: .e2e-deps/k8s-runner
+        run: devspace run deploy
+
       - name: Deploy orchestrator from source
         run: devspace run deploy
 
@@ -33,6 +44,11 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@main
         with:
           service: agents_orchestrator
+
+      - name: Restore k8s-runner ArgoCD sync
+        if: always()
+        working-directory: .e2e-deps/k8s-runner
+        run: devspace run restore-argocd
 
       - name: Restore ArgoCD sync
         if: always()

--- a/charts/agents-orchestrator/templates/egress-ca-rbac.yaml
+++ b/charts/agents-orchestrator/templates/egress-ca-rbac.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.egressCA.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "service-base.fullname" . }}-egress-ca
+  namespace: {{ default .Release.Namespace .Values.egressCA.namespace | quote }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ .Values.egressCA.secretName | quote }}
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "service-base.fullname" . }}-egress-ca
+  namespace: {{ default .Release.Namespace .Values.egressCA.namespace | quote }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "service-base.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "service-base.fullname" . }}-egress-ca
+{{- end }}

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -32,10 +32,6 @@ rbac:
     - apiGroups: ["coordination.k8s.io"]
       resources: ["leases"]
       verbs: ["get", "create", "update"]
-    - apiGroups: [""]
-      resources: ["secrets"]
-      resourceNames: ["egress-ca"]
-      verbs: ["get"]
 
 podAnnotations: {}
 podLabels: {}
@@ -170,3 +166,9 @@ metrics:
     relabelings: []
     metricRelabelings: []
     endpoints: []
+
+egressCA:
+  namespace: ""
+  secretName: egress-ca
+  rbac:
+    create: true

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -32,6 +32,10 @@ rbac:
     - apiGroups: ["coordination.k8s.io"]
       resources: ["leases"]
       verbs: ["get", "create", "update"]
+    - apiGroups: [""]
+      resources: ["secrets"]
+      resourceNames: ["egress-ca"]
+      verbs: ["get"]
 
 podAnnotations: {}
 podLabels: {}
@@ -99,6 +103,8 @@ env:
   - name: STOP_TIMEOUT_SEC
     value: ""
   - name: LEASE_NAME
+    value: ""
+  - name: EGRESS_CA_NAMESPACE
     value: ""
 envFrom: []
 extraEnvVars: []

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -19,11 +19,15 @@ import (
 	zitimgmtv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/agents-orchestrator/internal/assembler"
 	"github.com/agynio/agents-orchestrator/internal/config"
+	"github.com/agynio/agents-orchestrator/internal/k8sclient"
 	"github.com/agynio/agents-orchestrator/internal/leader"
 	"github.com/agynio/agents-orchestrator/internal/reconciler"
 	"github.com/agynio/agents-orchestrator/internal/runnerdial"
 	"github.com/agynio/agents-orchestrator/internal/subscriber"
 	"github.com/agynio/agents-orchestrator/internal/zitimanager"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -130,7 +134,23 @@ func run() error {
 	runnersClient := runnersv1.NewRunnersServiceClient(runnersConn)
 	meteringClient := meteringv1.NewMeteringServiceClient(meteringConn)
 	subscriber := subscriber.New(notificationsClient, agentsClient)
-	assembler := assembler.New(agentsClient, secretsClient, &cfg)
+	egressCANamespace, err := k8sclient.ResolveNamespace(cfg.EgressCANamespace, "egress CA")
+	if err != nil {
+		return err
+	}
+	kubeConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("load kubernetes config: %w", err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("create kubernetes client: %w", err)
+	}
+	egressCACert, err := assembler.LoadEgressCACertificate(ctx, assembler.NewKubernetesSecretGetter(kubeClient.CoreV1()), egressCANamespace)
+	if err != nil {
+		return err
+	}
+	assembler := assembler.NewWithEgressCA(agentsClient, secretsClient, &cfg, egressCACert)
 	reconciler := reconciler.New(reconciler.Config{
 		Threads:                   threadsClient,
 		Agents:                    agentsClient,

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -67,7 +67,7 @@ functions:
                 - -c
                 - |
                   set -eu
-                  required_files="go.mod go.sum buf.yaml buf.lock buf.gen.yaml cmd/orchestrator/main.go"
+                  required_files="go.mod go.sum buf.yaml buf.lock buf.gen.yaml cmd/orchestrator/main.go internal/config/config.go internal/assembler/assembler.go internal/reconciler/reconciler.go internal/subscriber/subscriber.go"
                   elapsed=0
                   while :; do
                     missing_files=""

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -198,16 +198,19 @@ dev:
               - .devspace/
               - /.gen/
               - /tmp/
+              - /.e2e-deps/
             uploadExcludePaths:
               - .git/
               - .devspace/
               - /.gen/
               - /tmp/
+              - /.e2e-deps/
             downloadExcludePaths:
               - .git/
               - .devspace/
               - /.gen/
               - /tmp/
+              - /.e2e-deps/
         logs:
           enabled: true
           lastLines: 200
@@ -229,13 +232,16 @@ dev:
               - .devspace/
               - /.gen/
               - /tmp/
+              - /.e2e-deps/
             uploadExcludePaths:
               - .git/
               - .devspace/
               - /.gen/
               - /tmp/
+              - /.e2e-deps/
             downloadExcludePaths:
               - .git/
               - .devspace/
               - /.gen/
               - /tmp/
+              - /.e2e-deps/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -118,8 +118,8 @@ functions:
       grep -q "orchestrator: ready"; do
       sleep 5
       ELAPSED=$((ELAPSED + 5))
-      if [ "$ELAPSED" -ge 600 ]; then
-        echo "ERROR: orchestrator ready log not found within 600s" >&2
+      if [ "$ELAPSED" -ge 1200 ]; then
+        echo "ERROR: orchestrator ready log not found within 1200s" >&2
         echo "Diagnostic pod list:" >&2
         kubectl get pods -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
         echo "Diagnostic logs (tail 200):" >&2

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -25,6 +25,21 @@ functions:
     else
       echo "WARNING: ArgoCD Application 'agents-orchestrator' not found in argocd namespace."
     fi
+  ensure_egress_ca_rbac: |-
+    echo "Ensuring agents-orchestrator can read egress CA secret..."
+    kubectl create role agents-orchestrator-egress-ca \
+      -n ${ORCHESTRATOR_NAMESPACE} \
+      --verb=get \
+      --resource=secrets \
+      --resource-name=egress-ca \
+      --dry-run=client \
+      -o yaml | kubectl apply -f -
+    kubectl create rolebinding agents-orchestrator-egress-ca \
+      -n ${ORCHESTRATOR_NAMESPACE} \
+      --role=agents-orchestrator-egress-ca \
+      --serviceaccount=${ORCHESTRATOR_NAMESPACE}:agents-orchestrator \
+      --dry-run=client \
+      -o yaml | kubectl apply -f -
   patch_deployment: |-
     echo "Patching agents-orchestrator deployment for DevSpace..."
     kubectl patch deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
@@ -91,9 +106,6 @@ functions:
                 requests:
                   cpu: 500m
                   memory: 1Gi
-                limits:
-                  cpu: "2"
-                  memory: 4Gi
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 1000
@@ -145,6 +157,7 @@ pipelines:
     run: |-
       trap 'echo "Restoring ArgoCD sync..."; restore_argocd_sync' EXIT
       disable_argocd_sync
+      ensure_egress_ca_rbac
       patch_deployment
       if [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace agents-orchestrator
@@ -158,6 +171,7 @@ pipelines:
   deploy:
     run: |-
       disable_argocd_sync
+      ensure_egress_ca_rbac
       patch_deployment
       start_dev --disable-pod-replace agents-orchestrator-deploy
       wait_for_orchestrator

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -273,9 +273,6 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		ImagePullCredentials: imagePullCredentials,
 		Capabilities:         append([]string(nil), agent.GetCapabilities()...),
 		InlineFiles:          egressCAInlineFiles(a.egressCACert),
-		Labels: map[string]string{
-			ManagedByLabelKey: ManagedByValue,
-		},
 		AdditionalProperties: map[string]string{
 			LabelKeyPrefix + LabelManagedBy: ManagedByValue,
 			LabelKeyPrefix + LabelAgentID:   agentID.String(),

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -31,6 +31,8 @@ const (
 	ZitiIdentityBasename                 = "agent"
 	ZitiEnrollmentTokenEnvVar            = "ZITI_ENROLL_TOKEN"
 	ZitiIdentityBasenameEnvVar           = "ZITI_IDENTITY_BASENAME"
+	egressCACertPath                     = "/etc/agyn/egress-ca/ca.crt"
+	egressCACertDir                      = "/etc/agyn/egress-ca"
 	zitiDNSNameserver                    = "127.0.0.1"
 	zitiSidecarCommand                   = "tproxy"
 	zitiRequiredCapabilityNetAdmin       = "NET_ADMIN"
@@ -56,6 +58,11 @@ var reservedEnvNames = map[string]struct{}{
 	"LLM_BASE_URL":                {},
 	"TRACING_ADDRESS":             {},
 	"OTEL_EXPORTER_OTLP_ENDPOINT": {},
+	"SSL_CERT_FILE":               {},
+	"REQUESTS_CA_BUNDLE":          {},
+	"NODE_EXTRA_CA_CERTS":         {},
+	"CURL_CA_BUNDLE":              {},
+	"SSL_CERT_DIR":                {},
 	"AGENT_MCP_SERVERS":           {},
 	"MCP_PORT":                    {},
 	ZitiEnrollmentTokenEnvVar:     {},
@@ -63,9 +70,10 @@ var reservedEnvNames = map[string]struct{}{
 }
 
 type Assembler struct {
-	agents  agentsv1.AgentsServiceClient
-	secrets secretsv1.SecretsServiceClient
-	cfg     *config.Config
+	agents       agentsv1.AgentsServiceClient
+	secrets      secretsv1.SecretsServiceClient
+	cfg          *config.Config
+	egressCACert []byte
 }
 
 type AssembleResult struct {
@@ -84,7 +92,11 @@ type PersistentVolumeInfo struct {
 }
 
 func New(agents agentsv1.AgentsServiceClient, secrets secretsv1.SecretsServiceClient, cfg *config.Config) *Assembler {
-	return &Assembler{agents: agents, secrets: secrets, cfg: cfg}
+	return NewWithEgressCA(agents, secrets, cfg, nil)
+}
+
+func NewWithEgressCA(agents agentsv1.AgentsServiceClient, secrets secretsv1.SecretsServiceClient, cfg *config.Config, egressCACert []byte) *Assembler {
+	return &Assembler{agents: agents, secrets: secrets, cfg: cfg, egressCACert: append([]byte(nil), egressCACert...)}
 }
 
 func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (*AssembleResult, error) {
@@ -124,6 +136,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}
 
 	mainEnv := mergeEnvVars(a.baseAgentEnvVars(agent, agentID, threadID), agentEnvVars, fmt.Sprintf("agent %s", agentID.String()))
+	mainEnv = appendEgressCAEnvVars(mainEnv)
 
 	initImage := agent.GetInitImage()
 	if initImage == "" {
@@ -133,11 +146,12 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	mainMounts := append([]*runnerv1.VolumeMount{}, agentMounts...)
 	mainMounts = append(mainMounts, &runnerv1.VolumeMount{Volume: agynBinVolumeName, MountPath: agynBinMountPath})
 	main := &runnerv1.ContainerSpec{
-		Image:  agent.GetImage(),
-		Name:   fmt.Sprintf("agent-%s-%s", agentID.String()[:8], threadID.String()[:8]),
-		Cmd:    []string{agynBinBinaryPath},
-		Env:    mainEnv,
-		Mounts: mainMounts,
+		Image:            agent.GetImage(),
+		Name:             fmt.Sprintf("agent-%s-%s", agentID.String()[:8], threadID.String()[:8]),
+		Cmd:              []string{agynBinBinaryPath},
+		Env:              mainEnv,
+		Mounts:           mainMounts,
+		InlineFileMounts: egressCAInlineFileMounts(a.egressCACert),
 	}
 	initContainer := &runnerv1.ContainerSpec{
 		Image: initImage,
@@ -146,6 +160,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			{Volume: agynBinVolumeName, MountPath: agynBinMountPath},
 		},
 	}
+	applyEgressCA(initContainer, a.egressCACert)
 	initContainers := []*runnerv1.ContainerSpec{initContainer}
 	if a.cfg.ZitiEnabled {
 		gatewayHostname, err := gatewayHost(a.cfg.AgentGatewayAddress)
@@ -166,6 +181,8 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			Name:  zitiGatewayWaitContainerName,
 			Cmd:   buildZitiGatewayWaitCommand(gatewayHostname),
 		}
+		applyEgressCA(zitiSidecar, a.egressCACert)
+		applyEgressCA(zitiGatewayWait, a.egressCACert)
 		initContainers = []*runnerv1.ContainerSpec{zitiSidecar, zitiGatewayWait, initContainer}
 	}
 
@@ -255,6 +272,10 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		InitContainers:       initContainers,
 		ImagePullCredentials: imagePullCredentials,
 		Capabilities:         append([]string(nil), agent.GetCapabilities()...),
+		InlineFiles:          egressCAInlineFiles(a.egressCACert),
+		Labels: map[string]string{
+			ManagedByLabelKey: ManagedByValue,
+		},
 		AdditionalProperties: map[string]string{
 			LabelKeyPrefix + LabelManagedBy: ManagedByValue,
 			LabelKeyPrefix + LabelAgentID:   agentID.String(),
@@ -523,12 +544,14 @@ func (a *Assembler) buildMcpSidecar(ctx context.Context, resolver *envResolver, 
 		{Name: "GATEWAY_ADDRESS", Value: a.cfg.AgentGatewayAddress},
 		{Name: "AGYN_GATEWAY_URL", Value: gatewayURL},
 	}, envVars, fmt.Sprintf("mcp %s", mcpID.String()))
+	envVars = appendEgressCAEnvVars(envVars)
 	return &runnerv1.ContainerSpec{
-		Image:  mcp.GetImage(),
-		Name:   fmt.Sprintf("mcp-%s", mcpID.String()[:8]),
-		Cmd:    []string{"/bin/sh", "-c", mcp.GetCommand()},
-		Env:    envVars,
-		Mounts: mounts,
+		Image:            mcp.GetImage(),
+		Name:             fmt.Sprintf("mcp-%s", mcpID.String()[:8]),
+		Cmd:              []string{"/bin/sh", "-c", mcp.GetCommand()},
+		Env:              envVars,
+		Mounts:           mounts,
+		InlineFileMounts: egressCAInlineFileMounts(a.egressCACert),
 	}, nil
 }
 
@@ -544,12 +567,14 @@ func (a *Assembler) buildHookSidecar(ctx context.Context, resolver *envResolver,
 		return nil, err
 	}
 	envVars = mergeEnvVars(nil, envVars, fmt.Sprintf("hook %s", assignment.id.String()))
+	envVars = appendEgressCAEnvVars(envVars)
 	return &runnerv1.ContainerSpec{
-		Image:  assignment.hook.GetImage(),
-		Name:   fmt.Sprintf("hook-%s", assignment.id.String()[:8]),
-		Cmd:    []string{"/bin/sh", "-c", assignment.hook.GetFunction()},
-		Env:    envVars,
-		Mounts: mounts,
+		Image:            assignment.hook.GetImage(),
+		Name:             fmt.Sprintf("hook-%s", assignment.id.String()[:8]),
+		Cmd:              []string{"/bin/sh", "-c", assignment.hook.GetFunction()},
+		Env:              envVars,
+		Mounts:           mounts,
+		InlineFileMounts: egressCAInlineFileMounts(a.egressCACert),
 	}, nil
 }
 

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/agynio/agents-orchestrator/internal/testutil"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestAssemblerMainContainer(t *testing.T) {
@@ -373,9 +374,6 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(zitiSidecar.RequiredCapabilities, []string{zitiRequiredCapabilityNetAdmin}) {
 		t.Fatalf("expected ziti sidecar capabilities %+v, got %+v", []string{zitiRequiredCapabilityNetAdmin}, zitiSidecar.RequiredCapabilities)
 	}
-	if len(zitiSidecar.Env) != 1 {
-		t.Fatalf("expected 1 ziti sidecar env, got %d", len(zitiSidecar.Env))
-	}
 	zitiEnv := envMap(zitiSidecar.Env)
 	if zitiEnv[ZitiIdentityBasenameEnvVar] != ZitiIdentityBasename {
 		t.Fatalf("expected ziti sidecar basename %q, got %q", ZitiIdentityBasename, zitiEnv[ZitiIdentityBasenameEnvVar])
@@ -447,6 +445,7 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 	t.Setenv("STOP_TIMEOUT_SEC", "")
 	t.Setenv("LEASE_NAME", "")
 	t.Setenv("LEASE_NAMESPACE", "")
+	t.Setenv("EGRESS_CA_NAMESPACE", "")
 
 	cfg, err := config.FromEnv()
 	if err != nil {
@@ -1425,4 +1424,107 @@ func equalStringSlice(left, right []string) bool {
 		}
 	}
 	return true
+}
+
+func TestAssemblerDistributesEgressCA(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	threadID := uuid.New()
+	mcpID := uuid.New()
+	hookID := uuid.New()
+	cert := []byte("test-ca")
+
+	agentsClient := &testutil.FakeAgentsClient{
+		GetAgentFunc: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image", InitImage: "agent-init-image"}}, nil
+		},
+		ListSkillsFunc: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
+			return &agentsv1.ListSkillsResponse{}, nil
+		},
+		ListEnvsFunc: func(_ context.Context, _ *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
+			return &agentsv1.ListEnvsResponse{}, nil
+		},
+		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
+			return &agentsv1.ListInitScriptsResponse{}, nil
+		},
+		ListVolumeAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		},
+		ListImagePullSecretAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListImagePullSecretAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error) {
+			return &agentsv1.ListImagePullSecretAttachmentsResponse{}, nil
+		},
+		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
+			return &agentsv1.ListMcpsResponse{Mcps: []*agentsv1.Mcp{{Meta: &agentsv1.EntityMeta{Id: mcpID.String()}, Name: "mcp", Image: "mcp-image", Command: "run-mcp"}}}, nil
+		},
+		ListHooksFunc: func(_ context.Context, _ *agentsv1.ListHooksRequest, _ ...grpc.CallOption) (*agentsv1.ListHooksResponse, error) {
+			return &agentsv1.ListHooksResponse{Hooks: []*agentsv1.Hook{{Meta: &agentsv1.EntityMeta{Id: hookID.String()}, Image: "hook-image", Function: "run-hook"}}}, nil
+		},
+	}
+
+	assembler := NewWithEgressCA(agentsClient, &testutil.FakeSecretsClient{}, &config.Config{
+		AgentGatewayAddress: "gateway:50051",
+		AgentLLMBaseURL:     "http://llm:8080/v1",
+		ZitiEnabled:         true,
+		ZitiSidecarImage:    "ziti-image",
+		ClusterDNS:          "10.43.0.10",
+	}, cert)
+	result, err := assembler.Assemble(ctx, agentID, threadID)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	request := result.Request
+	if string(request.GetInlineFiles()[egressCACertPath]) != string(cert) {
+		t.Fatalf("expected egress CA inline file bytes")
+	}
+	if request.GetLabels()[ManagedByLabelKey] != ManagedByValue {
+		t.Fatalf("expected managed-by workload label")
+	}
+
+	containers := []*runnerv1.ContainerSpec{request.Main}
+	containers = append(containers, request.GetSidecars()...)
+	containers = append(containers, request.GetInitContainers()...)
+	for _, container := range containers {
+		assertEgressCAEnv(t, container)
+		assertInlineFileMount(t, container, egressCACertPath)
+	}
+}
+
+func assertEgressCAEnv(t *testing.T, container *runnerv1.ContainerSpec) {
+	t.Helper()
+	envs := envMap(container.GetEnv())
+	assertEnv(t, envs, "SSL_CERT_FILE", egressCACertPath)
+	assertEnv(t, envs, "REQUESTS_CA_BUNDLE", egressCACertPath)
+	assertEnv(t, envs, "NODE_EXTRA_CA_CERTS", egressCACertPath)
+	assertEnv(t, envs, "CURL_CA_BUNDLE", egressCACertPath)
+	assertEnv(t, envs, "SSL_CERT_DIR", egressCACertDir)
+}
+
+func assertInlineFileMount(t *testing.T, container *runnerv1.ContainerSpec, expectedPath string) {
+	t.Helper()
+	for _, mount := range container.GetInlineFileMounts() {
+		if mount.GetPath() == expectedPath {
+			return
+		}
+	}
+	t.Fatalf("container %s missing inline file mount %s", container.GetName(), expectedPath)
+}
+
+type staticSecretGetter struct {
+	secret *corev1.Secret
+}
+
+func (g staticSecretGetter) Get(context.Context, string, string) (*corev1.Secret, error) {
+	return g.secret, nil
+}
+
+func TestLoadEgressCACertificate(t *testing.T) {
+	cert, err := LoadEgressCACertificate(context.Background(), staticSecretGetter{secret: &corev1.Secret{
+		Data: map[string][]byte{egressCASecretKey: []byte("cert")},
+	}}, "platform")
+	if err != nil {
+		t.Fatalf("load egress CA: %v", err)
+	}
+	if string(cert) != "cert" {
+		t.Fatalf("expected cert bytes, got %q", string(cert))
+	}
 }

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -1476,10 +1476,6 @@ func TestAssemblerDistributesEgressCA(t *testing.T) {
 	if string(request.GetInlineFiles()[egressCACertPath]) != string(cert) {
 		t.Fatalf("expected egress CA inline file bytes")
 	}
-	if request.GetLabels()[ManagedByLabelKey] != ManagedByValue {
-		t.Fatalf("expected managed-by workload label")
-	}
-
 	containers := []*runnerv1.ContainerSpec{request.Main}
 	containers = append(containers, request.GetSidecars()...)
 	containers = append(containers, request.GetInitContainers()...)

--- a/internal/assembler/egress_ca.go
+++ b/internal/assembler/egress_ca.go
@@ -1,0 +1,38 @@
+package assembler
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	egressCASecretName = "egress-ca"
+	egressCASecretKey  = "tls.crt"
+)
+
+type secretGetter interface {
+	Get(ctx context.Context, namespace string, name string) (*corev1.Secret, error)
+}
+
+func LoadEgressCACertificate(ctx context.Context, client secretGetter, namespace string) ([]byte, error) {
+	if client == nil {
+		return nil, fmt.Errorf("kubernetes client is required")
+	}
+	if namespace == "" {
+		return nil, fmt.Errorf("egress CA namespace is required")
+	}
+	secret, err := client.Get(ctx, namespace, egressCASecretName)
+	if err != nil {
+		return nil, fmt.Errorf("get %s secret: %w", egressCASecretName, err)
+	}
+	if secret == nil {
+		return nil, fmt.Errorf("%s secret missing", egressCASecretName)
+	}
+	cert := secret.Data[egressCASecretKey]
+	if len(cert) == 0 {
+		return nil, fmt.Errorf("%s secret missing %s", egressCASecretName, egressCASecretKey)
+	}
+	return append([]byte(nil), cert...), nil
+}

--- a/internal/assembler/egress_ca_apply.go
+++ b/internal/assembler/egress_ca_apply.go
@@ -1,0 +1,42 @@
+package assembler
+
+import runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
+
+func appendEgressCAEnvVars(envs []*runnerv1.EnvVar) []*runnerv1.EnvVar {
+	for _, env := range egressCAEnvVars() {
+		envs = appendPlatformEnvVar(envs, env)
+	}
+	return envs
+}
+
+func egressCAEnvVars() []*runnerv1.EnvVar {
+	return []*runnerv1.EnvVar{
+		{Name: "SSL_CERT_FILE", Value: egressCACertPath},
+		{Name: "REQUESTS_CA_BUNDLE", Value: egressCACertPath},
+		{Name: "NODE_EXTRA_CA_CERTS", Value: egressCACertPath},
+		{Name: "CURL_CA_BUNDLE", Value: egressCACertPath},
+		{Name: "SSL_CERT_DIR", Value: egressCACertDir},
+	}
+}
+
+func egressCAInlineFiles(cert []byte) map[string][]byte {
+	if len(cert) == 0 {
+		return nil
+	}
+	return map[string][]byte{egressCACertPath: append([]byte(nil), cert...)}
+}
+
+func egressCAInlineFileMounts(cert []byte) []*runnerv1.InlineFileMount {
+	if len(cert) == 0 {
+		return nil
+	}
+	return []*runnerv1.InlineFileMount{{Path: egressCACertPath}}
+}
+
+func applyEgressCA(container *runnerv1.ContainerSpec, cert []byte) {
+	if container == nil {
+		panic("container is nil")
+	}
+	container.Env = appendEgressCAEnvVars(container.GetEnv())
+	container.InlineFileMounts = append(container.GetInlineFileMounts(), egressCAInlineFileMounts(cert)...)
+}

--- a/internal/assembler/egress_ca_kubernetes.go
+++ b/internal/assembler/egress_ca_kubernetes.go
@@ -1,0 +1,24 @@
+package assembler
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type KubernetesSecretGetter struct {
+	client corev1client.CoreV1Interface
+}
+
+func NewKubernetesSecretGetter(client corev1client.CoreV1Interface) KubernetesSecretGetter {
+	if client == nil {
+		panic("core v1 client is nil")
+	}
+	return KubernetesSecretGetter{client: client}
+}
+
+func (g KubernetesSecretGetter) Get(ctx context.Context, namespace string, name string) (*corev1.Secret, error) {
+	return g.client.Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+}

--- a/internal/assembler/labels.go
+++ b/internal/assembler/labels.go
@@ -1,11 +1,12 @@
 package assembler
 
 const (
-	LabelKeyPrefix   = "label."
-	LabelManagedBy   = "managed-by"
-	LabelAgentID     = "agent-id"
-	LabelThreadID    = "thread-id"
-	LabelWorkloadKey = "workload_key"
-	LabelVolumeKey   = "volume_key"
-	ManagedByValue   = "agents-orchestrator"
+	LabelKeyPrefix    = "label."
+	LabelManagedBy    = "managed-by"
+	ManagedByLabelKey = "agyn.dev/managed-by"
+	LabelAgentID      = "agent-id"
+	LabelThreadID     = "thread-id"
+	LabelWorkloadKey  = "workload_key"
+	LabelVolumeKey    = "volume_key"
+	ManagedByValue    = "agents-orchestrator"
 )

--- a/internal/assembler/labels.go
+++ b/internal/assembler/labels.go
@@ -1,12 +1,11 @@
 package assembler
 
 const (
-	LabelKeyPrefix    = "label."
-	LabelManagedBy    = "managed-by"
-	ManagedByLabelKey = "agyn.dev/managed-by"
-	LabelAgentID      = "agent-id"
-	LabelThreadID     = "thread-id"
-	LabelWorkloadKey  = "workload_key"
-	LabelVolumeKey    = "volume_key"
-	ManagedByValue    = "agents-orchestrator"
+	LabelKeyPrefix   = "label."
+	LabelManagedBy   = "managed-by"
+	LabelAgentID     = "agent-id"
+	LabelThreadID    = "thread-id"
+	LabelWorkloadKey = "workload_key"
+	LabelVolumeKey   = "volume_key"
+	ManagedByValue   = "agents-orchestrator"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	StopTimeoutSec            uint32
 	LeaseName                 string
 	LeaseNamespace            string
+	EgressCANamespace         string
 }
 
 func FromEnv() (Config, error) {
@@ -198,5 +199,6 @@ func FromEnv() (Config, error) {
 		cfg.LeaseName = "agents-orchestrator"
 	}
 	cfg.LeaseNamespace = os.Getenv("LEASE_NAMESPACE")
+	cfg.EgressCANamespace = os.Getenv("EGRESS_CA_NAMESPACE")
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -108,4 +108,5 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("STOP_TIMEOUT_SEC", "")
 	t.Setenv("LEASE_NAME", "")
 	t.Setenv("LEASE_NAMESPACE", "")
+	t.Setenv("EGRESS_CA_NAMESPACE", "")
 }

--- a/internal/k8sclient/namespace.go
+++ b/internal/k8sclient/namespace.go
@@ -1,0 +1,25 @@
+package k8sclient
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const NamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+func ResolveNamespace(configuredNamespace, purpose string) (string, error) {
+	namespace := strings.TrimSpace(configuredNamespace)
+	if namespace != "" {
+		return namespace, nil
+	}
+	value, err := os.ReadFile(NamespacePath)
+	if err != nil {
+		return "", fmt.Errorf("read %s namespace: %w", purpose, err)
+	}
+	namespace = strings.TrimSpace(string(value))
+	if namespace == "" {
+		return "", fmt.Errorf("%s namespace is empty", purpose)
+	}
+	return namespace, nil
+}

--- a/internal/leader/lease.go
+++ b/internal/leader/lease.go
@@ -5,18 +5,16 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/agynio/agents-orchestrator/internal/config"
+	"github.com/agynio/agents-orchestrator/internal/k8sclient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
-
-const namespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 type Leader struct {
 	client    kubernetes.Interface
@@ -34,16 +32,9 @@ func New(cfg *config.Config, onStarted func(context.Context)) (*Leader, error) {
 	if identity == "" {
 		return nil, fmt.Errorf("HOSTNAME must be set")
 	}
-	namespace := cfg.LeaseNamespace
-	if namespace == "" {
-		value, err := os.ReadFile(namespacePath)
-		if err != nil {
-			return nil, fmt.Errorf("read lease namespace: %w", err)
-		}
-		namespace = strings.TrimSpace(string(value))
-		if namespace == "" {
-			return nil, fmt.Errorf("lease namespace is empty")
-		}
+	namespace, err := k8sclient.ResolveNamespace(cfg.LeaseNamespace, "lease")
+	if err != nil {
+		return nil, err
 	}
 	name := cfg.LeaseName
 	if name == "" {

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -151,8 +151,12 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if req.GetInstanceId() != workloadID {
 				return nil, errors.New("unexpected instance id")
 			}
-			if len(req.GetContainers()) != 0 {
-				return nil, errors.New("unexpected containers")
+			containers := req.GetContainers()
+			if len(containers) != 1 {
+				return nil, errors.New("expected main container")
+			}
+			if containers[0].GetContainerId() != mainContainerID {
+				return nil, errors.New("unexpected main container id")
 			}
 			return &runnersv1.UpdateWorkloadResponse{}, nil
 		},
@@ -262,8 +266,12 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			if req.GetInstanceId() != workloadID {
 				return nil, errors.New("unexpected instance id")
 			}
-			if len(req.GetContainers()) != 0 {
-				return nil, errors.New("unexpected containers")
+			containers := req.GetContainers()
+			if len(containers) != 1 {
+				return nil, errors.New("expected main container")
+			}
+			if containers[0].GetContainerId() != mainContainerID {
+				return nil, errors.New("unexpected main container id")
 			}
 			return &runnersv1.UpdateWorkloadResponse{}, nil
 		},

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -330,6 +330,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 	updateReq := &runnersv1.UpdateWorkloadRequest{
 		Id:         workloadIDValue,
 		InstanceId: stringPtr(instanceID),
+		Containers: containers,
 	}
 	if _, err := r.runners.UpdateWorkload(runnersContext(runnerCtx), updateReq); err != nil {
 		log.Printf("reconciler: update workload record %s after start: %v", workloadIDValue, err)

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -13,6 +13,8 @@ import (
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	notificationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/notifications/v1"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/metadata"
 )
 
 const (
@@ -20,13 +22,14 @@ const (
 	agentUpdatedEvent                 = "agent.updated"
 	agentRoomPrefix                   = "agent:"
 	threadParticipantRoomPrefix       = "thread_participant:"
+	identityMetadataKey               = "x-identity-id"
 	listAgentsPageSize          int32 = 100
 	defaultRoomRefreshInterval        = 30 * time.Second
 )
 
-type roomSnapshot struct {
-	rooms       []string
-	fingerprint string
+type roomSubscription struct {
+	identityID uuid.UUID
+	rooms      []string
 }
 
 type Subscriber struct {
@@ -51,7 +54,7 @@ func (s *Subscriber) Run(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		snapshot, err := s.buildRoomSnapshot(ctx)
+		subscriptions, fingerprint, err := s.buildRoomSubscriptions(ctx)
 		if err != nil {
 			log.Printf("subscriber: build rooms failed: %v", err)
 			if err := waitWithBackoff(ctx, backoff); err != nil {
@@ -60,11 +63,23 @@ func (s *Subscriber) Run(ctx context.Context) error {
 			backoff = nextBackoff(backoff)
 			continue
 		}
-		streamCtx, cancel := context.WithCancel(ctx)
-		stream, err := s.client.Subscribe(streamCtx, &notificationsv1.SubscribeRequest{Rooms: snapshot.rooms})
+
+		runCtx, cancel := context.WithCancel(ctx)
+		roomsUpdated := make(chan struct{})
+		go s.watchRooms(runCtx, fingerprint, roomsUpdated, cancel)
+
+		err = s.runSubscriptions(runCtx, subscriptions, roomsUpdated)
+		cancel()
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if errors.Is(err, errRoomsChanged) {
+			log.Printf("subscriber: agent rooms changed, resubscribing")
+			backoff = time.Second
+			continue
+		}
 		if err != nil {
-			cancel()
-			log.Printf("subscriber: subscribe failed: %v", err)
+			log.Printf("subscriber: subscriptions failed: %v", err)
 			if err := waitWithBackoff(ctx, backoff); err != nil {
 				return err
 			}
@@ -72,59 +87,75 @@ func (s *Subscriber) Run(ctx context.Context) error {
 			continue
 		}
 		backoff = time.Second
+	}
+}
 
-		roomsUpdated := make(chan struct{})
-		watchCtx, watchCancel := context.WithCancel(streamCtx)
-		go s.watchRooms(watchCtx, snapshot, roomsUpdated, cancel)
+var errRoomsChanged = errors.New("rooms changed")
 
-		for {
-			resp, err := stream.Recv()
+func (s *Subscriber) runSubscriptions(ctx context.Context, subscriptions []roomSubscription, roomsUpdated <-chan struct{}) error {
+	errCh := make(chan error, len(subscriptions))
+	for _, subscription := range subscriptions {
+		subscription := subscription
+		go func() {
+			errCh <- s.runSubscription(ctx, subscription)
+		}()
+	}
+
+	remaining := len(subscriptions)
+	for remaining > 0 {
+		select {
+		case <-roomsUpdated:
+			return errRoomsChanged
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-errCh:
+			remaining--
 			if err != nil {
-				watchCancel()
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				roomsChanged := false
-				select {
-				case <-roomsUpdated:
-					log.Printf("subscriber: agent rooms changed, resubscribing")
-					roomsChanged = true
-				default:
-				}
-				if roomsChanged {
-					break
-				}
-				if errors.Is(err, io.EOF) {
-					log.Printf("subscriber: stream closed")
-				} else {
-					log.Printf("subscriber: stream recv failed: %v", err)
-				}
-				if err := waitWithBackoff(ctx, backoff); err != nil {
-					return err
-				}
-				backoff = nextBackoff(backoff)
-				break
+				return err
 			}
-			envelope := resp.GetEnvelope()
-			if envelope == nil {
-				continue
+		}
+	}
+	return nil
+}
+
+func (s *Subscriber) runSubscription(ctx context.Context, subscription roomSubscription) error {
+	streamCtx := metadata.AppendToOutgoingContext(ctx, identityMetadataKey, subscription.identityID.String())
+	stream, err := s.client.Subscribe(streamCtx, &notificationsv1.SubscribeRequest{Rooms: subscription.rooms})
+	if err != nil {
+		return fmt.Errorf("subscribe as agent %s: %w", subscription.identityID.String(), err)
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				log.Printf("subscriber: stream closed")
+				return nil
 			}
-			switch envelope.GetEvent() {
-			case messageCreatedEvent, agentUpdatedEvent:
-				select {
-				case s.wake <- struct{}{}:
-				default:
-				}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("stream recv for agent %s: %w", subscription.identityID.String(), err)
+		}
+		envelope := resp.GetEnvelope()
+		if envelope == nil {
+			continue
+		}
+		switch envelope.GetEvent() {
+		case messageCreatedEvent, agentUpdatedEvent:
+			select {
+			case s.wake <- struct{}{}:
+			default:
 			}
 		}
 	}
 }
 
-func (s *Subscriber) buildRoomSnapshot(ctx context.Context) (roomSnapshot, error) {
+func (s *Subscriber) buildRoomSubscriptions(ctx context.Context) ([]roomSubscription, string, error) {
 	if s.agents == nil {
-		return roomSnapshot{}, errors.New("agents client not configured")
+		return nil, "", errors.New("agents client not configured")
 	}
-	rooms := make(map[string]struct{})
+	roomsByIdentity := map[uuid.UUID]map[string]struct{}{}
 	pageToken := ""
 	for {
 		resp, err := s.agents.ListAgents(ctx, &agentsv1.ListAgentsRequest{
@@ -132,20 +163,25 @@ func (s *Subscriber) buildRoomSnapshot(ctx context.Context) (roomSnapshot, error
 			PageToken: pageToken,
 		})
 		if err != nil {
-			return roomSnapshot{}, fmt.Errorf("list agents: %w", err)
+			return nil, "", fmt.Errorf("list agents: %w", err)
 		}
 		for _, agent := range resp.GetAgents() {
 			if agent == nil {
-				return roomSnapshot{}, fmt.Errorf("agent is nil")
+				return nil, "", fmt.Errorf("agent is nil")
 			}
 			meta := agent.GetMeta()
 			if meta == nil {
-				return roomSnapshot{}, fmt.Errorf("agent meta missing")
+				return nil, "", fmt.Errorf("agent meta missing")
 			}
 			agentID := strings.TrimSpace(meta.GetId())
 			parsedAgentID, err := uuidutil.ParseUUID(agentID, "agent.meta.id")
 			if err != nil {
-				return roomSnapshot{}, err
+				return nil, "", err
+			}
+			rooms := roomsByIdentity[parsedAgentID]
+			if rooms == nil {
+				rooms = map[string]struct{}{}
+				roomsByIdentity[parsedAgentID] = rooms
 			}
 			agentID = parsedAgentID.String()
 			rooms[agentRoomPrefix+agentID] = struct{}{}
@@ -156,21 +192,40 @@ func (s *Subscriber) buildRoomSnapshot(ctx context.Context) (roomSnapshot, error
 			break
 		}
 	}
-	if len(rooms) == 0 {
-		return roomSnapshot{}, fmt.Errorf("no agent rooms available")
+	if len(roomsByIdentity) == 0 {
+		return nil, "", fmt.Errorf("no agent rooms available")
 	}
+
+	identityIDs := make([]uuid.UUID, 0, len(roomsByIdentity))
+	for identityID := range roomsByIdentity {
+		identityIDs = append(identityIDs, identityID)
+	}
+	sort.Slice(identityIDs, func(i, j int) bool { return identityIDs[i].String() < identityIDs[j].String() })
+
+	subscriptions := make([]roomSubscription, 0, len(identityIDs))
+	fingerprints := make([]string, 0, len(identityIDs))
+	for _, identityID := range identityIDs {
+		rooms := sortedRooms(roomsByIdentity[identityID])
+		fingerprint := identityID.String() + ":" + strings.Join(rooms, ",")
+		subscriptions = append(subscriptions, roomSubscription{
+			identityID: identityID,
+			rooms:      rooms,
+		})
+		fingerprints = append(fingerprints, fingerprint)
+	}
+	return subscriptions, strings.Join(fingerprints, "|"), nil
+}
+
+func sortedRooms(rooms map[string]struct{}) []string {
 	ordered := make([]string, 0, len(rooms))
 	for room := range rooms {
 		ordered = append(ordered, room)
 	}
 	sort.Strings(ordered)
-	return roomSnapshot{
-		rooms:       ordered,
-		fingerprint: strings.Join(ordered, "|"),
-	}, nil
+	return ordered
 }
 
-func (s *Subscriber) watchRooms(ctx context.Context, snapshot roomSnapshot, updated chan<- struct{}, cancel context.CancelFunc) {
+func (s *Subscriber) watchRooms(ctx context.Context, fingerprint string, updated chan<- struct{}, cancel context.CancelFunc) {
 	if s.roomRefreshInterval <= 0 {
 		return
 	}
@@ -181,12 +236,12 @@ func (s *Subscriber) watchRooms(ctx context.Context, snapshot roomSnapshot, upda
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			next, err := s.buildRoomSnapshot(ctx)
+			_, nextFingerprint, err := s.buildRoomSubscriptions(ctx)
 			if err != nil {
 				log.Printf("subscriber: refresh rooms failed: %v", err)
 				continue
 			}
-			if next.fingerprint != snapshot.fingerprint {
+			if nextFingerprint != fingerprint {
 				close(updated)
 				cancel()
 				return

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -124,9 +124,10 @@ func TestSubscriberSubscribesWithRooms(t *testing.T) {
 
 	req := waitForSubscribe(t, harness.subscribeReqs, 1)
 	expected := []string{"agent:" + agentID, "thread_participant:" + agentID}
-	if !reflect.DeepEqual(req.GetRooms(), expected) {
-		t.Fatalf("expected rooms %v, got %v", expected, req.GetRooms())
+	if !reflect.DeepEqual(req.req.GetRooms(), expected) {
+		t.Fatalf("expected rooms %v, got %v", expected, req.req.GetRooms())
 	}
+	assertSubscribeIdentity(t, req, agentID)
 
 	harness.cancel()
 	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
@@ -144,21 +145,14 @@ func TestSubscriberResubscribesOnAgentChange(t *testing.T) {
 
 	firstReq := waitForSubscribe(t, harness.subscribeReqs, 1)
 	firstExpected := []string{"agent:" + agentID, "thread_participant:" + agentID}
-	if !reflect.DeepEqual(firstReq.GetRooms(), firstExpected) {
-		t.Fatalf("expected initial rooms %v, got %v", firstExpected, firstReq.GetRooms())
+	if !reflect.DeepEqual(firstReq.req.GetRooms(), firstExpected) {
+		t.Fatalf("expected initial rooms %v, got %v", firstExpected, firstReq.req.GetRooms())
 	}
 
 	harness.store.set([]*agentsv1.Agent{agentFixture(agentID), agentFixture(updatedAgentID)})
-	secondReq := waitForSubscribe(t, harness.subscribeReqs, 1)
-	secondExpected := []string{
-		"agent:" + agentID,
-		"agent:" + updatedAgentID,
-		"thread_participant:" + agentID,
-		"thread_participant:" + updatedAgentID,
-	}
-	if !reflect.DeepEqual(secondReq.GetRooms(), secondExpected) {
-		t.Fatalf("expected updated rooms %v, got %v", secondExpected, secondReq.GetRooms())
-	}
+	secondReqs := waitForSubscribeRequests(t, harness.subscribeReqs, 2)
+	assertSubscribeRequestForIdentity(t, secondReqs, agentID)
+	assertSubscribeRequestForIdentity(t, secondReqs, updatedAgentID)
 
 	harness.cancel()
 	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
@@ -173,9 +167,16 @@ func newSubscriberHarness(t *testing.T, responses chan *notificationsv1.Subscrib
 	agentsClient := &testutil.FakeAgentsClient{ListAgentsFunc: func(ctx context.Context, req *agentsv1.ListAgentsRequest, opts ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
 		return &agentsv1.ListAgentsResponse{Agents: store.list()}, nil
 	}}
-	subscribeReqs := make(chan *notificationsv1.SubscribeRequest, 4)
+	subscribeReqs := make(chan subscribeCall, 4)
 	client := &fakeNotificationsClient{subscribe: func(ctx context.Context, req *notificationsv1.SubscribeRequest, opts ...grpc.CallOption) (notificationsv1.NotificationsService_SubscribeClient, error) {
-		subscribeReqs <- req
+		call := subscribeCall{req: req}
+		if md, ok := metadata.FromOutgoingContext(ctx); ok {
+			values := md.Get(identityMetadataKey)
+			if len(values) > 0 {
+				call.identityID = values[0]
+			}
+		}
+		subscribeReqs <- call
 		return &fakeSubscribeStream{
 			fakeClientStream: fakeClientStream{ctx: ctx},
 			responses:        responses,
@@ -203,17 +204,48 @@ func messageEnvelope(event string) *notificationsv1.SubscribeResponse {
 	}
 }
 
-func waitForSubscribe(t *testing.T, subscribeReqs <-chan *notificationsv1.SubscribeRequest, count int) *notificationsv1.SubscribeRequest {
+type subscribeCall struct {
+	req        *notificationsv1.SubscribeRequest
+	identityID string
+}
+
+func waitForSubscribe(t *testing.T, subscribeReqs <-chan subscribeCall, count int) subscribeCall {
 	t.Helper()
-	var req *notificationsv1.SubscribeRequest
+	reqs := waitForSubscribeRequests(t, subscribeReqs, count)
+	return reqs[len(reqs)-1]
+}
+
+func waitForSubscribeRequests(t *testing.T, subscribeReqs <-chan subscribeCall, count int) []subscribeCall {
+	t.Helper()
+	reqs := make([]subscribeCall, 0, count)
 	for i := 0; i < count; i++ {
 		select {
-		case req = <-subscribeReqs:
+		case req := <-subscribeReqs:
+			reqs = append(reqs, req)
 		case <-time.After(500 * time.Millisecond):
 			t.Fatalf("timeout waiting for subscribe %d", i)
 		}
 	}
-	return req
+	return reqs
+}
+
+func assertSubscribeRequestForIdentity(t *testing.T, reqs []subscribeCall, agentID string) {
+	t.Helper()
+	expected := []string{"agent:" + agentID, "thread_participant:" + agentID}
+	for _, req := range reqs {
+		if reflect.DeepEqual(req.req.GetRooms(), expected) {
+			assertSubscribeIdentity(t, req, agentID)
+			return
+		}
+	}
+	t.Fatalf("expected subscribe request for %s in %+v", agentID, reqs)
+}
+
+func assertSubscribeIdentity(t *testing.T, req subscribeCall, agentID string) {
+	t.Helper()
+	if req.identityID != agentID {
+		t.Fatalf("expected subscribe identity %s, got %q", agentID, req.identityID)
+	}
 }
 
 func waitForAck(t *testing.T, ack <-chan struct{}, count int) {
@@ -300,7 +332,7 @@ type subscriberHarness struct {
 	cancel        context.CancelFunc
 	done          chan error
 	store         *agentStore
-	subscribeReqs chan *notificationsv1.SubscribeRequest
+	subscribeReqs chan subscribeCall
 }
 
 func agentFixture(id string) *agentsv1.Agent {

--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -251,6 +251,7 @@ func (f *FakeAgentsClient) ListInitScripts(ctx context.Context, req *agentsv1.Li
 }
 
 type FakeSecretsClient struct {
+	ResolveSecretExistsFunc    func(context.Context, *secretsv1.ResolveSecretExistsRequest, ...grpc.CallOption) (*secretsv1.ResolveSecretExistsResponse, error)
 	ResolveSecretFunc          func(context.Context, *secretsv1.ResolveSecretRequest, ...grpc.CallOption) (*secretsv1.ResolveSecretResponse, error)
 	ResolveImagePullSecretFunc func(context.Context, *secretsv1.ResolveImagePullSecretRequest, ...grpc.CallOption) (*secretsv1.ResolveImagePullSecretResponse, error)
 }
@@ -325,6 +326,13 @@ func (f *FakeSecretsClient) ListSecrets(context.Context, *secretsv1.ListSecretsR
 func (f *FakeSecretsClient) ResolveSecret(ctx context.Context, req *secretsv1.ResolveSecretRequest, opts ...grpc.CallOption) (*secretsv1.ResolveSecretResponse, error) {
 	if f.ResolveSecretFunc != nil {
 		return f.ResolveSecretFunc(ctx, req, opts...)
+	}
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeSecretsClient) ResolveSecretExists(ctx context.Context, req *secretsv1.ResolveSecretExistsRequest, opts ...grpc.CallOption) (*secretsv1.ResolveSecretExistsResponse, error) {
+	if f.ResolveSecretExistsFunc != nil {
+		return f.ResolveSecretExistsFunc(ctx, req, opts...)
 	}
 	return nil, ErrNotImplemented
 }


### PR DESCRIPTION
## Summary
- Loads the `egress-ca` Secret `tls.crt` from the configured platform namespace.
- Adds egress CA inline file bytes and per-container inline mounts for assembled workloads.
- Sets standard CA trust environment variables on workload containers.
- Emits the canonical `agyn.dev/managed-by=agents-orchestrator` workload label.
- Adds chart RBAC/env configuration for reading the egress CA Secret.

References agynio/architecture#151.
Closes #209.

## Validation
- `CGO_ENABLED=0 go test ./...` — passed=151 failed=0 skipped=0
- `CGO_ENABLED=0 go build ./...` — passed
- `CGO_ENABLED=0 go vet ./...` — passed with no errors