### PR TITLE
Add workload DNS upstream for Ziti workloads

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -88,6 +88,12 @@ env:
     value: "2m"
   - name: ZITI_MANAGEMENT_ADDRESS
     value: ""
+  # Upstream DNS resolver used for Ziti-enabled workload pods.
+  - name: WORKLOAD_DNS_UPSTREAM
+    value: ""
+  # Deprecated: use WORKLOAD_DNS_UPSTREAM instead.
+  - name: CLUSTER_DNS
+    value: ""
   - name: AGENT_GATEWAY_ADDRESS
     value: ""
   - name: AGENT_TRACING_ADDRESS

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -155,7 +155,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		zitiSidecar := &runnerv1.ContainerSpec{
 			Image:                a.cfg.ZitiSidecarImage,
 			Name:                 ZitiSidecarContainerName,
-			Cmd:                  []string{zitiSidecarCommand, "--dnsUpstream", fmt.Sprintf("udp://%s:53", a.cfg.ClusterDNS)},
+			Cmd:                  []string{zitiSidecarCommand, "--dnsUpstream", fmt.Sprintf("udp://%s:53", a.cfg.WorkloadDNSUpstream)},
 			Env:                  []*runnerv1.EnvVar{{Name: ZitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename}},
 			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
@@ -263,7 +263,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}
 	if a.cfg.ZitiEnabled {
 		request.DnsConfig = &runnerv1.DnsConfig{
-			Nameservers: []string{zitiDNSNameserver, a.cfg.ClusterDNS},
+			Nameservers: []string{zitiDNSNameserver, a.cfg.WorkloadDNSUpstream},
 			Searches:    []string{zitiDNSSearchService, zitiDNSSearchCluster},
 		}
 	}

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -314,7 +314,7 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 		AgentLLMBaseURL:     "http://llm:8080/v1",
 		ZitiEnabled:         true,
 		ZitiSidecarImage:    "ziti-image",
-		ClusterDNS:          "10.43.0.10",
+		WorkloadDNSUpstream: "10.43.0.10",
 	}
 
 	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, &cfg)
@@ -332,7 +332,7 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if request.DnsConfig == nil {
 		t.Fatal("expected dns config")
 	}
-	expectedNameservers := []string{zitiDNSNameserver, cfg.ClusterDNS}
+	expectedNameservers := []string{zitiDNSNameserver, cfg.WorkloadDNSUpstream}
 	if !equalStringSlice(request.DnsConfig.Nameservers, expectedNameservers) {
 		t.Fatalf("expected dns nameservers %+v, got %+v", expectedNameservers, request.DnsConfig.Nameservers)
 	}
@@ -366,7 +366,7 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if zitiSidecar.Image != cfg.ZitiSidecarImage {
 		t.Fatalf("expected ziti sidecar image %q, got %q", cfg.ZitiSidecarImage, zitiSidecar.Image)
 	}
-	expectedCmd := []string{zitiSidecarCommand, "--dnsUpstream", fmt.Sprintf("udp://%s:53", cfg.ClusterDNS)}
+	expectedCmd := []string{zitiSidecarCommand, "--dnsUpstream", fmt.Sprintf("udp://%s:53", cfg.WorkloadDNSUpstream)}
 	if !equalStringSlice(zitiSidecar.Cmd, expectedCmd) {
 		t.Fatalf("expected ziti sidecar cmd %+v, got %+v", expectedCmd, zitiSidecar.Cmd)
 	}
@@ -439,6 +439,7 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 	t.Setenv("ZITI_MANAGEMENT_ADDRESS", "")
 	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "")
 	t.Setenv("ZITI_SIDECAR_IMAGE", "")
+	t.Setenv("WORKLOAD_DNS_UPSTREAM", "")
 	t.Setenv("CLUSTER_DNS", "")
 	t.Setenv("AGENT_GATEWAY_ADDRESS", "")
 	t.Setenv("AGENT_LLM_BASE_URL", "")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	ZitiLeaseRenewalInterval  time.Duration
 	ZitiEnrollmentTimeout     time.Duration
 	ZitiSidecarImage          string
-	ClusterDNS                string
+	WorkloadDNSUpstream       string
 	AgentGatewayAddress       string
 	AgentTracingAddress       string
 	AgentLLMBaseURL           string
@@ -142,9 +142,12 @@ func FromEnv() (Config, error) {
 	if cfg.ZitiSidecarImage == "" {
 		cfg.ZitiSidecarImage = "openziti/ziti-tunnel:2.0.0-pre8"
 	}
-	cfg.ClusterDNS = os.Getenv("CLUSTER_DNS")
-	if cfg.ClusterDNS == "" {
-		cfg.ClusterDNS = "10.43.0.10"
+	cfg.WorkloadDNSUpstream = os.Getenv("WORKLOAD_DNS_UPSTREAM")
+	if cfg.WorkloadDNSUpstream == "" {
+		cfg.WorkloadDNSUpstream = os.Getenv("CLUSTER_DNS")
+	}
+	if cfg.WorkloadDNSUpstream == "" {
+		cfg.WorkloadDNSUpstream = "10.43.0.10"
 	}
 	pollInterval := os.Getenv("POLL_INTERVAL")
 	if pollInterval == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,6 +68,50 @@ func TestFromEnvDefaultsZiti(t *testing.T) {
 	if cfg.ZitiEnrollmentTimeout != 2*time.Minute {
 		t.Fatalf("expected ziti enrollment timeout %q, got %q", 2*time.Minute, cfg.ZitiEnrollmentTimeout)
 	}
+	if cfg.WorkloadDNSUpstream != "10.43.0.10" {
+		t.Fatalf("expected workload DNS upstream %q, got %q", "10.43.0.10", cfg.WorkloadDNSUpstream)
+	}
+}
+
+func TestFromEnvWorkloadDNSUpstream(t *testing.T) {
+	tests := []struct {
+		name        string
+		workloadDNS string
+		clusterDNS  string
+		expected    string
+	}{
+		{
+			name:     "default",
+			expected: "10.43.0.10",
+		},
+		{
+			name:       "deprecated cluster dns fallback",
+			clusterDNS: "10.43.0.20",
+			expected:   "10.43.0.20",
+		},
+		{
+			name:        "workload dns upstream takes precedence",
+			workloadDNS: "10.43.0.30",
+			clusterDNS:  "10.43.0.20",
+			expected:    "10.43.0.30",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setBaseEnv(t)
+			t.Setenv("WORKLOAD_DNS_UPSTREAM", tt.workloadDNS)
+			t.Setenv("CLUSTER_DNS", tt.clusterDNS)
+
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if cfg.WorkloadDNSUpstream != tt.expected {
+				t.Fatalf("expected workload DNS upstream %q, got %q", tt.expected, cfg.WorkloadDNSUpstream)
+			}
+		})
+	}
 }
 
 func TestFromEnvAgentTracingAddress(t *testing.T) {
@@ -98,6 +142,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "")
 	t.Setenv("ZITI_ENROLLMENT_TIMEOUT", "")
 	t.Setenv("ZITI_SIDECAR_IMAGE", "")
+	t.Setenv("WORKLOAD_DNS_UPSTREAM", "")
 	t.Setenv("CLUSTER_DNS", "")
 	t.Setenv("AGENT_GATEWAY_ADDRESS", "")
 	t.Setenv("AGENT_TRACING_ADDRESS", "")

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -1356,7 +1356,7 @@ func newTestAssembler(agentID uuid.UUID, zitiEnabled bool) *assembler.Assembler 
 		AgentLLMBaseURL:     "http://llm:8080/v1",
 		ZitiEnabled:         zitiEnabled,
 		ZitiSidecarImage:    "ziti-sidecar-image",
-		ClusterDNS:          "10.43.0.10",
+		WorkloadDNSUpstream: "10.43.0.10",
 	}
 	return assembler.New(agentsClient, &testutil.FakeSecretsClient{}, cfg)
 }


### PR DESCRIPTION
## Summary
- Add `WORKLOAD_DNS_UPSTREAM` config with `CLUSTER_DNS` as a deprecated fallback and `10.43.0.10` as the default.
- Use the selected workload DNS upstream for Ziti sidecar `--dnsUpstream` and workload `DnsConfig.Nameservers`.
- Document the new Helm env var and add config precedence/default tests.

Closes #211

## Test & Lint Summary
- `go test -json ./...`: 153 passed, 0 failed, 0 skipped.
- `helm dependency build charts/agents-orchestrator && helm lint charts/agents-orchestrator`: 1 chart linted, 0 failed; lint passed with no errors.
- `go build ./...`: passed.