### PR TITLE
Remove CoreDNS from workload DNS config

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -67,7 +67,7 @@ functions:
                 - -c
                 - |
                   set -eu
-                  required_files="go.mod go.sum buf.yaml buf.lock buf.gen.yaml cmd/orchestrator/main.go internal/config/config.go internal/assembler/assembler.go internal/reconciler/reconciler.go internal/subscriber/subscriber.go"
+                  required_files="go.mod go.sum buf.yaml buf.lock buf.gen.yaml cmd/orchestrator/main.go internal/config/config.go internal/k8sclient/namespace.go internal/assembler/assembler.go internal/reconciler/reconciler.go internal/subscriber/subscriber.go"
                   elapsed=0
                   while :; do
                     missing_files=""

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -70,6 +70,7 @@ if [[ ! -s "${identity_file}" ]]; then
     cat "${hosts_file}.tmp" > "${hosts_file}"
     rm -f "${hosts_file}.tmp"
   fi
+  printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > "${resolv_file}"
 
   ziti edge enroll --jwt "${jwt_file}" --out "${identity_file}"
 fi

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -285,7 +285,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}
 	if a.cfg.ZitiEnabled {
 		request.DnsConfig = &runnerv1.DnsConfig{
-			Nameservers: []string{zitiDNSNameserver, a.cfg.WorkloadDNSUpstream},
+			Nameservers: []string{zitiDNSNameserver},
 			Searches:    []string{zitiDNSSearchService, zitiDNSSearchCluster},
 		}
 	}

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -38,30 +38,38 @@ const (
 	zitiSidecarCommand                = "tproxy"
 	zitiSidecarEntrypointScript       = `workload_dns_upstream="$1"
 shift
-identity_dir="${ZITI_IDENTITY_DIR:-/netfoundry}"
-identity_basename="${ZITI_IDENTITY_BASENAME:-ziti_id}"
-identity_file="${identity_dir}/${identity_basename}.json"
-jwt_file="${identity_dir}/${identity_basename}.jwt"
+resolv_file="${ZITI_RESOLV_CONF:-/etc/resolv.conf}"
+real_ziti_binary="${ZITI_BINARY:-/usr/local/bin/ziti}"
+entrypoint="${ZITI_ENTRYPOINT:-/entrypoint.sh}"
 original_resolv="$(mktemp)"
+wrapper_dir="$(mktemp -d)"
+cp "${resolv_file}" "${original_resolv}"
+cat > "${wrapper_dir}/ziti" <<'ZITI_WRAPPER'
+#!/usr/bin/env bash
+set -o nounset -o pipefail
 restore_resolv() {
-  if [[ -f "${original_resolv}" ]]; then
-    cp "${original_resolv}" /etc/resolv.conf
-    rm -f "${original_resolv}"
+  if [[ -f "${ZITI_ORIGINAL_RESOLV}" ]]; then
+    cp "${ZITI_ORIGINAL_RESOLV}" "${ZITI_RESOLV_CONF}"
   fi
 }
-if [[ ! -s "${identity_file}" && -n "${ZITI_ENROLL_TOKEN:-}" ]]; then
-  mkdir -p "${identity_dir}"
-  printf '%s\n' "${ZITI_ENROLL_TOKEN}" > "${jwt_file}"
-fi
-if [[ ! -s "${identity_file}" && -s "${jwt_file}" ]]; then
-  cp /etc/resolv.conf "${original_resolv}"
-  trap restore_resolv EXIT
-  printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > /etc/resolv.conf
-  ziti edge enroll --jwt "${jwt_file}" --out "${identity_file}"
+if [[ "${1:-}" == "edge" && "${2:-}" == "enroll" ]]; then
+  "${ZITI_BINARY}" "$@"
+  status="$?"
   restore_resolv
-  trap - EXIT
+  exit "${status}"
 fi
-exec /entrypoint.sh "$@"`
+if [[ "${1:-}" == "tunnel" ]]; then
+  restore_resolv
+fi
+exec "${ZITI_BINARY}" "$@"
+ZITI_WRAPPER
+chmod +x "${wrapper_dir}/ziti"
+export ZITI_BINARY="${real_ziti_binary}"
+export ZITI_ORIGINAL_RESOLV="${original_resolv}"
+export ZITI_RESOLV_CONF="${resolv_file}"
+export PATH="${wrapper_dir}:${PATH}"
+printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > "${resolv_file}"
+exec "${entrypoint}" "$@"`
 	zitiRequiredCapabilityNetAdmin = "NET_ADMIN"
 	zitiRestartPolicyKey           = "restart_policy"
 	zitiRestartPolicyAlways        = "Always"

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -208,6 +208,9 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			Env:                  zitiEnvVars(),
 			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
+			// k8s-runner maps restart_policy=Always on init containers to
+			// Kubernetes restartable init containers. This lets the tunnel stay
+			// up while Kubernetes continues to later init containers and main.
 			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},
 		}
 		zitiGatewayWait := &runnerv1.ContainerSpec{

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -39,6 +39,7 @@ const (
 	zitiEnrollEntrypoint             = "/usr/bin/bash"
 	zitiSidecarCommand               = "tproxy"
 	zitiEnrollScript                 = `workload_dns_upstream="$1"
+workload_dns_nameserver="$2"
 identity_dir="${ZITI_IDENTITY_DIR}"
 identity_basename="${ZITI_IDENTITY_BASENAME}"
 identity_file="${identity_dir}/${identity_basename}.json"
@@ -78,7 +79,9 @@ fi
 if [[ ! -s "${identity_file}" ]]; then
   echo "expected identity file ${identity_file}" >&2
   exit 1
-fi`
+fi
+
+printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_nameserver}" > "${resolv_file}"`
 	zitiRequiredCapabilityNetAdmin = "NET_ADMIN"
 	zitiRestartPolicyKey           = "restart_policy"
 	zitiRestartPolicyAlways        = "Always"
@@ -369,6 +372,7 @@ func buildZitiEnrollCommand(workloadDNSUpstream string) []string {
 		zitiEnrollScript,
 		ZitiEnrollContainerName,
 		workloadDNSUpstream,
+		zitiDNSNameserver,
 	}
 }
 

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -43,18 +43,10 @@ identity_dir="${ZITI_IDENTITY_DIR}"
 identity_basename="${ZITI_IDENTITY_BASENAME}"
 identity_file="${identity_dir}/${identity_basename}.json"
 jwt_file="${identity_dir}/${identity_basename}.jwt"
-hosts_file="/etc/hosts"
-ziti_controller_host="ziti.agyn.dev"
+resolv_file="${ZITI_RESOLV_CONF:-/etc/resolv.conf}"
+hosts_file="${ZITI_HOSTS_FILE:-/etc/hosts}"
 
-printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > /etc/resolv.conf
-awk -v host="${ziti_controller_host}" '$0 !~ "(^|[[:space:]])" host "([[:space:]]|$)" { print }' "${hosts_file}" > "${hosts_file}.tmp"
-cat "${hosts_file}.tmp" > "${hosts_file}"
-rm -f "${hosts_file}.tmp"
-ziti_controller_ip="$(getent hosts "${ziti_controller_host}" | awk '{ print $1; exit }')"
-if [[ -z "${ziti_controller_ip}" || "${ziti_controller_ip}" == 127.* || "${ziti_controller_ip}" == ::1 ]]; then
-  echo "failed to resolve ${ziti_controller_host} through workload DNS upstream ${workload_dns_upstream}" >&2
-  exit 1
-fi
+printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > "${resolv_file}"
 mkdir -p "${identity_dir}"
 
 if [[ ! -s "${identity_file}" ]]; then
@@ -63,6 +55,22 @@ if [[ ! -s "${identity_file}" ]]; then
     exit 1
   fi
   printf '%s\n' "${ZITI_ENROLL_TOKEN}" > "${jwt_file}"
+
+  jwt_payload="${ZITI_ENROLL_TOKEN#*.}"
+  jwt_payload="${jwt_payload%%.*}"
+  jwt_payload="$(printf '%s' "${jwt_payload}" | tr '_-' '/+')"
+  case $(( ${#jwt_payload} % 4 )) in
+    2) jwt_payload="${jwt_payload}==" ;;
+    3) jwt_payload="${jwt_payload}=" ;;
+  esac
+  jwt_payload_json="$(printf '%s' "${jwt_payload}" | base64 -d 2>/dev/null || true)"
+  ziti_controller_host="$(printf '%s' "${jwt_payload_json}" | sed -nE 's/.*"iss"[[:space:]]*:[[:space:]]*"https?:\/\/([^"\/:]+).*/\1/p' | head -n 1)"
+  if [[ -n "${ziti_controller_host}" ]]; then
+    awk -v host="${ziti_controller_host}" '($1 ~ /^(127\.|::1$)/) { for (i = 2; i <= NF; i++) if ($i == host) next } { print }' "${hosts_file}" > "${hosts_file}.tmp"
+    cat "${hosts_file}.tmp" > "${hosts_file}"
+    rm -f "${hosts_file}.tmp"
+  fi
+
   ziti edge enroll --jwt "${jwt_file}" --out "${identity_file}"
 fi
 

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -19,49 +19,47 @@ import (
 )
 
 const (
-	listPageSize                int32 = 100
-	rpcTimeout                        = 10 * time.Second
-	agynBinVolumeName                 = "agyn-bin"
-	agynBinMountPath                  = "/agyn-bin"
-	agynBinBinaryPath                 = "/agyn-bin/agynd"
-	mcpBasePort                       = 8100
-	ZitiSidecarContainerName          = "ziti-sidecar"
-	zitiIdentityVolumeName            = "ziti-identity"
-	zitiIdentityMountPath             = "/netfoundry"
-	ZitiIdentityBasename              = "agent"
-	ZitiEnrollmentTokenEnvVar         = "ZITI_ENROLL_TOKEN"
-	ZitiIdentityBasenameEnvVar        = "ZITI_IDENTITY_BASENAME"
-	egressCACertPath                  = "/etc/agyn/egress-ca/ca.crt"
-	egressCACertDir                   = "/etc/agyn/egress-ca"
-	zitiDNSNameserver                 = "127.0.0.1"
-	zitiSidecarEntrypoint             = "/usr/bin/bash"
-	zitiSidecarCommand                = "tproxy"
-	zitiSidecarEntrypointScript       = `workload_dns_upstream="$1"
-shift
-resolv_file="${ZITI_RESOLV_CONF:-/etc/resolv.conf}"
-entrypoint="${ZITI_ENTRYPOINT:-/entrypoint.sh}"
-original_resolv="$(mktemp)"
-bash_env="$(mktemp)"
-cp "${resolv_file}" "${original_resolv}"
-restore_resolv() {
-  if [[ -f "${original_resolv}" ]]; then
-    cp "${original_resolv}" "${resolv_file}"
+	listPageSize               int32 = 100
+	rpcTimeout                       = 10 * time.Second
+	agynBinVolumeName                = "agyn-bin"
+	agynBinMountPath                 = "/agyn-bin"
+	agynBinBinaryPath                = "/agyn-bin/agynd"
+	mcpBasePort                      = 8100
+	ZitiEnrollContainerName          = "ziti-enroll"
+	ZitiSidecarContainerName         = "ziti-sidecar"
+	zitiIdentityVolumeName           = "ziti-identity"
+	zitiIdentityMountPath            = "/netfoundry"
+	ZitiIdentityBasename             = "agent"
+	ZitiEnrollmentTokenEnvVar        = "ZITI_ENROLL_TOKEN"
+	ZitiIdentityBasenameEnvVar       = "ZITI_IDENTITY_BASENAME"
+	ZitiIdentityDirEnvVar            = "ZITI_IDENTITY_DIR"
+	egressCACertPath                 = "/etc/agyn/egress-ca/ca.crt"
+	egressCACertDir                  = "/etc/agyn/egress-ca"
+	zitiDNSNameserver                = "127.0.0.1"
+	zitiEnrollEntrypoint             = "/usr/bin/bash"
+	zitiSidecarCommand               = "tproxy"
+	zitiEnrollScript                 = `workload_dns_upstream="$1"
+identity_dir="${ZITI_IDENTITY_DIR}"
+identity_basename="${ZITI_IDENTITY_BASENAME}"
+identity_file="${identity_dir}/${identity_basename}.json"
+jwt_file="${identity_dir}/${identity_basename}.jwt"
+
+printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > /etc/resolv.conf
+mkdir -p "${identity_dir}"
+
+if [[ ! -s "${identity_file}" ]]; then
+  if [[ -z "${ZITI_ENROLL_TOKEN}" ]]; then
+    echo "ZITI_ENROLL_TOKEN is required" >&2
+    exit 1
   fi
-}
-printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > "${resolv_file}"
-cat > "${bash_env}" <<'ZITI_BASH_ENV'
-restore_resolv_before_ziti_tunnel() {
-  if [[ "${BASH_COMMAND}" == ziti\ tunnel* ]]; then
-    cp "${ZITI_ORIGINAL_RESOLV}" "${ZITI_RESOLV_CONF}"
-    trap - DEBUG
-  fi
-}
-trap restore_resolv_before_ziti_tunnel DEBUG
-ZITI_BASH_ENV
-export ZITI_ORIGINAL_RESOLV="${original_resolv}"
-export ZITI_RESOLV_CONF="${resolv_file}"
-trap restore_resolv EXIT
-BASH_ENV="${bash_env}" "${entrypoint}" "$@"`
+  printf '%s\n' "${ZITI_ENROLL_TOKEN}" > "${jwt_file}"
+  ziti edge enroll --jwt "${jwt_file}" --out "${identity_file}"
+fi
+
+if [[ ! -s "${identity_file}" ]]; then
+  echo "expected identity file ${identity_file}" >&2
+  exit 1
+fi`
 	zitiRequiredCapabilityNetAdmin = "NET_ADMIN"
 	zitiRestartPolicyKey           = "restart_policy"
 	zitiRestartPolicyAlways        = "Always"
@@ -94,6 +92,7 @@ var reservedEnvNames = map[string]struct{}{
 	"MCP_PORT":                    {},
 	ZitiEnrollmentTokenEnvVar:     {},
 	ZitiIdentityBasenameEnvVar:    {},
+	ZitiIdentityDirEnvVar:         {},
 }
 
 type Assembler struct {
@@ -194,12 +193,19 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		if err != nil {
 			return nil, err
 		}
+		zitiEnroll := &runnerv1.ContainerSpec{
+			Image:      a.cfg.ZitiSidecarImage,
+			Name:       ZitiEnrollContainerName,
+			Cmd:        buildZitiEnrollCommand(a.cfg.WorkloadDNSUpstream),
+			Entrypoint: zitiEnrollEntrypoint,
+			Env:        zitiEnvVars(),
+			Mounts:     []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
+		}
 		zitiSidecar := &runnerv1.ContainerSpec{
 			Image:                a.cfg.ZitiSidecarImage,
 			Name:                 ZitiSidecarContainerName,
 			Cmd:                  buildZitiSidecarCommand(a.cfg.WorkloadDNSUpstream),
-			Entrypoint:           zitiSidecarEntrypoint,
-			Env:                  zitiSidecarEnvVars(),
+			Env:                  zitiEnvVars(),
 			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
 			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},
@@ -209,9 +215,10 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 			Name:  zitiGatewayWaitContainerName,
 			Cmd:   buildZitiGatewayWaitCommand(gatewayHostname),
 		}
+		applyEgressCA(zitiEnroll, a.egressCACert)
 		applyEgressCA(zitiSidecar, a.egressCACert)
 		applyEgressCA(zitiGatewayWait, a.egressCACert)
-		initContainers = []*runnerv1.ContainerSpec{zitiSidecar, zitiGatewayWait, initContainer}
+		initContainers = []*runnerv1.ContainerSpec{zitiEnroll, zitiSidecar, zitiGatewayWait, initContainer}
 	}
 
 	mcps, err := a.listMcps(ctx, agentID)
@@ -327,18 +334,24 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	}, nil
 }
 
-func zitiSidecarEnvVars() []*runnerv1.EnvVar {
+func zitiEnvVars() []*runnerv1.EnvVar {
 	return []*runnerv1.EnvVar{
 		{Name: ZitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename},
+		{Name: ZitiIdentityDirEnvVar, Value: zitiIdentityMountPath},
+	}
+}
+
+func buildZitiEnrollCommand(workloadDNSUpstream string) []string {
+	return []string{
+		"-ec",
+		zitiEnrollScript,
+		ZitiEnrollContainerName,
+		workloadDNSUpstream,
 	}
 }
 
 func buildZitiSidecarCommand(workloadDNSUpstream string) []string {
 	return []string{
-		"-ec",
-		zitiSidecarEntrypointScript,
-		"ziti-sidecar-dns-init",
-		workloadDNSUpstream,
 		zitiSidecarCommand,
 		"--dnsUpstream",
 		fmt.Sprintf("udp://%s:53", workloadDNSUpstream),

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -43,8 +43,18 @@ identity_dir="${ZITI_IDENTITY_DIR}"
 identity_basename="${ZITI_IDENTITY_BASENAME}"
 identity_file="${identity_dir}/${identity_basename}.json"
 jwt_file="${identity_dir}/${identity_basename}.jwt"
+hosts_file="/etc/hosts"
+ziti_controller_host="ziti.agyn.dev"
 
 printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > /etc/resolv.conf
+awk -v host="${ziti_controller_host}" '$0 !~ "(^|[[:space:]])" host "([[:space:]]|$)" { print }' "${hosts_file}" > "${hosts_file}.tmp"
+cat "${hosts_file}.tmp" > "${hosts_file}"
+rm -f "${hosts_file}.tmp"
+ziti_controller_ip="$(getent hosts "${ziti_controller_host}" | awk '{ print $1; exit }')"
+if [[ -z "${ziti_controller_ip}" || "${ziti_controller_ip}" == 127.* || "${ziti_controller_ip}" == ::1 ]]; then
+  echo "failed to resolve ${ziti_controller_host} through workload DNS upstream ${workload_dns_upstream}" >&2
+  exit 1
+fi
 mkdir -p "${identity_dir}"
 
 if [[ ! -s "${identity_file}" ]]; then

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -39,37 +39,28 @@ const (
 	zitiSidecarEntrypointScript       = `workload_dns_upstream="$1"
 shift
 resolv_file="${ZITI_RESOLV_CONF:-/etc/resolv.conf}"
-real_ziti_binary="${ZITI_BINARY:-/usr/local/bin/ziti}"
 entrypoint="${ZITI_ENTRYPOINT:-/entrypoint.sh}"
+identity_file="${ZITI_IDENTITY_FILE:-/netfoundry/agent.json}"
 original_resolv="$(mktemp)"
-wrapper_dir="$(mktemp -d)"
 cp "${resolv_file}" "${original_resolv}"
-cat > "${wrapper_dir}/ziti" <<'ZITI_WRAPPER'
-#!/usr/bin/env bash
-set -o nounset -o pipefail
 restore_resolv() {
-  if [[ -f "${ZITI_ORIGINAL_RESOLV}" ]]; then
-    cp "${ZITI_ORIGINAL_RESOLV}" "${ZITI_RESOLV_CONF}"
+  if [[ -f "${original_resolv}" ]]; then
+    cp "${original_resolv}" "${resolv_file}"
   fi
 }
-if [[ "${1:-}" == "edge" && "${2:-}" == "enroll" ]]; then
-  "${ZITI_BINARY}" "$@"
-  status="$?"
-  restore_resolv
-  exit "${status}"
-fi
-if [[ "${1:-}" == "tunnel" ]]; then
-  restore_resolv
-fi
-exec "${ZITI_BINARY}" "$@"
-ZITI_WRAPPER
-chmod +x "${wrapper_dir}/ziti"
-export ZITI_BINARY="${real_ziti_binary}"
-export ZITI_ORIGINAL_RESOLV="${original_resolv}"
-export ZITI_RESOLV_CONF="${resolv_file}"
-export PATH="${wrapper_dir}:${PATH}"
 printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > "${resolv_file}"
-exec "${entrypoint}" "$@"`
+{
+  while true; do
+    if [[ -s "${identity_file}" ]]; then
+      restore_resolv
+      break
+    fi
+    sleep 0.1
+  done
+} &
+resolver_restore_pid="$!"
+trap 'restore_resolv; kill "${resolver_restore_pid}" 2>/dev/null || true' EXIT
+"${entrypoint}" "$@"`
 	zitiRequiredCapabilityNetAdmin = "NET_ADMIN"
 	zitiRestartPolicyKey           = "restart_policy"
 	zitiRestartPolicyAlways        = "Always"

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -40,8 +40,8 @@ const (
 shift
 resolv_file="${ZITI_RESOLV_CONF:-/etc/resolv.conf}"
 entrypoint="${ZITI_ENTRYPOINT:-/entrypoint.sh}"
-identity_file="${ZITI_IDENTITY_FILE:-/netfoundry/agent.json}"
 original_resolv="$(mktemp)"
+bash_env="$(mktemp)"
 cp "${resolv_file}" "${original_resolv}"
 restore_resolv() {
   if [[ -f "${original_resolv}" ]]; then
@@ -49,18 +49,19 @@ restore_resolv() {
   fi
 }
 printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > "${resolv_file}"
-{
-  while true; do
-    if [[ -s "${identity_file}" ]]; then
-      restore_resolv
-      break
-    fi
-    sleep 0.1
-  done
-} &
-resolver_restore_pid="$!"
-trap 'restore_resolv; kill "${resolver_restore_pid}" 2>/dev/null || true' EXIT
-"${entrypoint}" "$@"`
+cat > "${bash_env}" <<'ZITI_BASH_ENV'
+restore_resolv_before_ziti_tunnel() {
+  if [[ "${BASH_COMMAND}" == ziti\ tunnel* ]]; then
+    cp "${ZITI_ORIGINAL_RESOLV}" "${ZITI_RESOLV_CONF}"
+    trap - DEBUG
+  fi
+}
+trap restore_resolv_before_ziti_tunnel DEBUG
+ZITI_BASH_ENV
+export ZITI_ORIGINAL_RESOLV="${original_resolv}"
+export ZITI_RESOLV_CONF="${resolv_file}"
+trap restore_resolv EXIT
+BASH_ENV="${bash_env}" "${entrypoint}" "$@"`
 	zitiRequiredCapabilityNetAdmin = "NET_ADMIN"
 	zitiRestartPolicyKey           = "restart_policy"
 	zitiRestartPolicyAlways        = "Always"

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -19,33 +19,57 @@ import (
 )
 
 const (
-	listPageSize                   int32 = 100
-	rpcTimeout                           = 10 * time.Second
-	agynBinVolumeName                    = "agyn-bin"
-	agynBinMountPath                     = "/agyn-bin"
-	agynBinBinaryPath                    = "/agyn-bin/agynd"
-	mcpBasePort                          = 8100
-	ZitiSidecarContainerName             = "ziti-sidecar"
-	zitiIdentityVolumeName               = "ziti-identity"
-	zitiIdentityMountPath                = "/netfoundry"
-	ZitiIdentityBasename                 = "agent"
-	ZitiEnrollmentTokenEnvVar            = "ZITI_ENROLL_TOKEN"
-	ZitiIdentityBasenameEnvVar           = "ZITI_IDENTITY_BASENAME"
-	egressCACertPath                     = "/etc/agyn/egress-ca/ca.crt"
-	egressCACertDir                      = "/etc/agyn/egress-ca"
-	zitiDNSNameserver                    = "127.0.0.1"
-	zitiSidecarEntrypoint                = "/bin/sh"
-	zitiSidecarCommand                   = "tproxy"
-	zitiIdentityFile                     = zitiIdentityMountPath + "/" + ZitiIdentityBasename + ".json"
-	zitiEnrollmentTokenFile              = zitiIdentityMountPath + "/" + ZitiIdentityBasename + ".jwt"
-	zitiRequiredCapabilityNetAdmin       = "NET_ADMIN"
-	zitiRestartPolicyKey                 = "restart_policy"
-	zitiRestartPolicyAlways              = "Always"
-	zitiDNSSearchService                 = "svc.cluster.local"
-	zitiDNSSearchCluster                 = "cluster.local"
-	zitiGatewayWaitContainerName         = "ziti-gateway-wait"
-	zitiGatewayWaitImage                 = "busybox:1.37.0"
-	zitiGatewayWaitTimeoutSeconds        = 60
+	listPageSize                int32 = 100
+	rpcTimeout                        = 10 * time.Second
+	agynBinVolumeName                 = "agyn-bin"
+	agynBinMountPath                  = "/agyn-bin"
+	agynBinBinaryPath                 = "/agyn-bin/agynd"
+	mcpBasePort                       = 8100
+	ZitiSidecarContainerName          = "ziti-sidecar"
+	zitiIdentityVolumeName            = "ziti-identity"
+	zitiIdentityMountPath             = "/netfoundry"
+	ZitiIdentityBasename              = "agent"
+	ZitiEnrollmentTokenEnvVar         = "ZITI_ENROLL_TOKEN"
+	ZitiIdentityBasenameEnvVar        = "ZITI_IDENTITY_BASENAME"
+	egressCACertPath                  = "/etc/agyn/egress-ca/ca.crt"
+	egressCACertDir                   = "/etc/agyn/egress-ca"
+	zitiDNSNameserver                 = "127.0.0.1"
+	zitiSidecarEntrypoint             = "/usr/bin/bash"
+	zitiSidecarCommand                = "tproxy"
+	zitiSidecarEntrypointScript       = `workload_dns_upstream="$1"
+shift
+identity_dir="${ZITI_IDENTITY_DIR:-/netfoundry}"
+identity_basename="${ZITI_IDENTITY_BASENAME:-ziti_id}"
+identity_file="${identity_dir}/${identity_basename}.json"
+jwt_file="${identity_dir}/${identity_basename}.jwt"
+original_resolv="$(mktemp)"
+restore_resolv() {
+  if [[ -f "${original_resolv}" ]]; then
+    cp "${original_resolv}" /etc/resolv.conf
+    rm -f "${original_resolv}"
+  fi
+}
+if [[ ! -s "${identity_file}" && -n "${ZITI_ENROLL_TOKEN:-}" ]]; then
+  mkdir -p "${identity_dir}"
+  printf '%s\n' "${ZITI_ENROLL_TOKEN}" > "${jwt_file}"
+fi
+if [[ ! -s "${identity_file}" && -s "${jwt_file}" ]]; then
+  cp /etc/resolv.conf "${original_resolv}"
+  trap restore_resolv EXIT
+  printf 'nameserver %s\nsearch svc.cluster.local cluster.local\noptions ndots:5\n' "${workload_dns_upstream}" > /etc/resolv.conf
+  ziti edge enroll --jwt "${jwt_file}" --out "${identity_file}"
+  restore_resolv
+  trap - EXIT
+fi
+exec /entrypoint.sh "$@"`
+	zitiRequiredCapabilityNetAdmin = "NET_ADMIN"
+	zitiRestartPolicyKey           = "restart_policy"
+	zitiRestartPolicyAlways        = "Always"
+	zitiDNSSearchService           = "svc.cluster.local"
+	zitiDNSSearchCluster           = "cluster.local"
+	zitiGatewayWaitContainerName   = "ziti-gateway-wait"
+	zitiGatewayWaitImage           = "busybox:1.37.0"
+	zitiGatewayWaitTimeoutSeconds  = 60
 )
 
 var reservedEnvNames = map[string]struct{}{
@@ -173,9 +197,9 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		zitiSidecar := &runnerv1.ContainerSpec{
 			Image:                a.cfg.ZitiSidecarImage,
 			Name:                 ZitiSidecarContainerName,
-			Entrypoint:           zitiSidecarEntrypoint,
 			Cmd:                  buildZitiSidecarCommand(a.cfg.WorkloadDNSUpstream),
-			Env:                  []*runnerv1.EnvVar{{Name: ZitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename}},
+			Entrypoint:           zitiSidecarEntrypoint,
+			Env:                  zitiSidecarEnvVars(),
 			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
 			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
 			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},
@@ -301,6 +325,24 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		AllocatedCPUMillicores: allocatedCPU,
 		AllocatedRAMBytes:      allocatedRAM,
 	}, nil
+}
+
+func zitiSidecarEnvVars() []*runnerv1.EnvVar {
+	return []*runnerv1.EnvVar{
+		{Name: ZitiIdentityBasenameEnvVar, Value: ZitiIdentityBasename},
+	}
+}
+
+func buildZitiSidecarCommand(workloadDNSUpstream string) []string {
+	return []string{
+		"-ec",
+		zitiSidecarEntrypointScript,
+		"ziti-sidecar-dns-init",
+		workloadDNSUpstream,
+		zitiSidecarCommand,
+		"--dnsUpstream",
+		fmt.Sprintf("udp://%s:53", workloadDNSUpstream),
+	}
 }
 
 func agentRunnerLabels(agent *agentsv1.Agent) map[string]string {
@@ -595,27 +637,6 @@ func gatewayHost(address string) (string, error) {
 		return "", fmt.Errorf("gateway host missing from %q", address)
 	}
 	return host, nil
-}
-
-func buildZitiSidecarCommand(dnsUpstream string) []string {
-	dnsArg := fmt.Sprintf("udp://%s:53", dnsUpstream)
-	script := strings.Join([]string{
-		"set -eu",
-		fmt.Sprintf("identity_file=%q", zitiIdentityFile),
-		fmt.Sprintf("token_file=%q", zitiEnrollmentTokenFile),
-		`if [ ! -s "$identity_file" ]; then`,
-		fmt.Sprintf(`  if [ -n "${%s:-}" ]; then`, ZitiEnrollmentTokenEnvVar),
-		fmt.Sprintf(`    printf '%%s' "$%s" > "$token_file"`, ZitiEnrollmentTokenEnvVar),
-		"  fi",
-		`  if [ ! -s "$token_file" ]; then`,
-		`    echo "missing Ziti identity and enrollment token" >&2`,
-		"    exit 1",
-		"  fi",
-		`  ziti edge enroll "$token_file" --out "$identity_file"`,
-		"fi",
-		fmt.Sprintf(`exec ziti tunnel %s --identity "$identity_file" --dnsUpstream %q`, zitiSidecarCommand, dnsArg),
-	}, "\n")
-	return []string{"-c", script}
 }
 
 func buildZitiGatewayWaitCommand(host string) []string {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -1555,34 +1555,33 @@ func TestLoadEgressCACertificate(t *testing.T) {
 func TestZitiSidecarResolverOverrideRestoresAfterEnrollment(t *testing.T) {
 	t.Parallel()
 	workDir := t.TempDir()
+	identityDir := filepath.Join(workDir, "netfoundry")
+	if err := os.Mkdir(identityDir, 0o700); err != nil {
+		t.Fatalf("create identity dir: %v", err)
+	}
 	resolvPath := filepath.Join(workDir, "resolv.conf")
 	originalResolv := "nameserver 127.0.0.1\nsearch svc.cluster.local cluster.local\n"
 	if err := os.WriteFile(resolvPath, []byte(originalResolv), 0o600); err != nil {
 		t.Fatalf("write resolv: %v", err)
 	}
 	zitiLogPath := filepath.Join(workDir, "ziti.log")
-	zitiPath := writeExecutable(t, workDir, "real-ziti", fmt.Sprintf(`#!/usr/bin/env bash
+	entrypointPath := writeExecutable(t, workDir, "entrypoint", fmt.Sprintf(`#!/usr/bin/env bash
 set -euo pipefail
-if [[ "$1" == "edge" && "$2" == "enroll" ]]; then
-  printf 'enroll_resolv=%%s\n' "$(cat %q)" >> %q
-  exit 0
-fi
-if [[ "$1" == "tunnel" ]]; then
-  printf 'tunnel_resolv=%%s\n' "$(cat %q)" >> %q
-  exit 0
-fi
-exit 9
-`, resolvPath, zitiLogPath, resolvPath, zitiLogPath))
-	entrypointPath := writeExecutable(t, workDir, "entrypoint", `#!/usr/bin/env bash
-set -euo pipefail
-ziti edge enroll --jwt /netfoundry/agent.jwt --out /netfoundry/agent.json
-ziti tunnel "$@"
-`)
+printf 'enroll_resolv=%%s\n' "$(cat %q)" >> %q
+printf '{}\n' > %q
+while true; do
+  if grep -q '^nameserver 127[.]0[.]0[.]1$' %q; then
+    printf 'tunnel_resolv=%%s\n' "$(cat %q)" >> %q
+    exit 0
+  fi
+  sleep 0.1
+done
+`, resolvPath, zitiLogPath, filepath.Join(identityDir, "agent.json"), resolvPath, resolvPath, zitiLogPath))
 
 	cmd := exec.Command(zitiSidecarEntrypoint, buildZitiSidecarCommand("10.43.0.10")...)
 	cmd.Env = append(os.Environ(),
-		"ZITI_BINARY="+zitiPath,
 		"ZITI_ENTRYPOINT="+entrypointPath,
+		"ZITI_IDENTITY_FILE="+filepath.Join(identityDir, "agent.json"),
 		"ZITI_RESOLV_CONF="+resolvPath,
 	)
 	output, err := cmd.CombinedOutput()
@@ -1612,20 +1611,13 @@ func TestZitiSidecarResolverOverrideRestoresAfterEnrollmentFailure(t *testing.T)
 	if err := os.WriteFile(resolvPath, []byte(originalResolv), 0o600); err != nil {
 		t.Fatalf("write resolv: %v", err)
 	}
-	zitiLogPath := filepath.Join(workDir, "ziti.log")
-	zitiPath := writeExecutable(t, workDir, "real-ziti", fmt.Sprintf(`#!/usr/bin/env bash
-set -euo pipefail
-printf 'enroll_resolv=%%s\n' "$(cat %q)" >> %q
-exit 7
-`, resolvPath, zitiLogPath))
 	entrypointPath := writeExecutable(t, workDir, "entrypoint", `#!/usr/bin/env bash
 set -euo pipefail
-ziti edge enroll --jwt /netfoundry/agent.jwt --out /netfoundry/agent.json
+exit 7
 `)
 
 	cmd := exec.Command(zitiSidecarEntrypoint, buildZitiSidecarCommand("10.43.0.10")...)
 	cmd.Env = append(os.Environ(),
-		"ZITI_BINARY="+zitiPath,
 		"ZITI_ENTRYPOINT="+entrypointPath,
 		"ZITI_RESOLV_CONF="+resolvPath,
 	)
@@ -1635,13 +1627,6 @@ ziti edge enroll --jwt /netfoundry/agent.jwt --out /netfoundry/agent.json
 	}
 
 	assertFileEquals(t, resolvPath, originalResolv)
-	logBytes, err := os.ReadFile(zitiLogPath)
-	if err != nil {
-		t.Fatalf("read ziti log: %v", err)
-	}
-	if !strings.Contains(string(logBytes), "enroll_resolv=nameserver 10.43.0.10") {
-		t.Fatalf("expected enrollment to use upstream resolver, got log:\n%s", string(logBytes))
-	}
 }
 
 func writeExecutable(t *testing.T, dir, name, content string) string {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -333,7 +333,7 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if request.DnsConfig == nil {
 		t.Fatal("expected dns config")
 	}
-	expectedNameservers := []string{zitiDNSNameserver, cfg.WorkloadDNSUpstream}
+	expectedNameservers := []string{zitiDNSNameserver}
 	if !equalStringSlice(request.DnsConfig.Nameservers, expectedNameservers) {
 		t.Fatalf("expected dns nameservers %+v, got %+v", expectedNameservers, request.DnsConfig.Nameservers)
 	}

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -5,9 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -344,17 +341,20 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(request.DnsConfig.Searches, expectedSearches) {
 		t.Fatalf("expected dns searches %+v, got %+v", expectedSearches, request.DnsConfig.Searches)
 	}
-	if len(request.InitContainers) != 3 {
-		t.Fatalf("expected 3 init containers, got %d", len(request.InitContainers))
+	if len(request.InitContainers) != 4 {
+		t.Fatalf("expected 4 init containers, got %d", len(request.InitContainers))
 	}
-	if request.InitContainers[0].GetName() != ZitiSidecarContainerName {
-		t.Fatalf("expected %s to be first init container", ZitiSidecarContainerName)
+	if request.InitContainers[0].GetName() != ZitiEnrollContainerName {
+		t.Fatalf("expected %s to be first init container", ZitiEnrollContainerName)
 	}
-	if request.InitContainers[1].GetName() != zitiGatewayWaitContainerName {
-		t.Fatalf("expected %s to be second init container", zitiGatewayWaitContainerName)
+	if request.InitContainers[1].GetName() != ZitiSidecarContainerName {
+		t.Fatalf("expected %s to be second init container", ZitiSidecarContainerName)
 	}
-	if request.InitContainers[2].GetName() != "agent-init" {
-		t.Fatalf("expected agent-init to be third init container")
+	if request.InitContainers[2].GetName() != zitiGatewayWaitContainerName {
+		t.Fatalf("expected %s to be third init container", zitiGatewayWaitContainerName)
+	}
+	if request.InitContainers[3].GetName() != "agent-init" {
+		t.Fatalf("expected agent-init to be fourth init container")
 	}
 	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
 	if initContainer == nil {
@@ -363,6 +363,33 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if len(request.Sidecars) != 0 {
 		t.Fatalf("expected 0 sidecars, got %d", len(request.Sidecars))
 	}
+	zitiEnroll := testutil.FindInitContainer(request.InitContainers, ZitiEnrollContainerName)
+	if zitiEnroll == nil {
+		t.Fatal("expected ziti-enroll init container")
+	}
+	if zitiEnroll.Image != cfg.ZitiSidecarImage {
+		t.Fatalf("expected ziti enroll image %q, got %q", cfg.ZitiSidecarImage, zitiEnroll.Image)
+	}
+	if zitiEnroll.Entrypoint != zitiEnrollEntrypoint {
+		t.Fatalf("expected ziti enroll entrypoint %q, got %q", zitiEnrollEntrypoint, zitiEnroll.Entrypoint)
+	}
+	expectedEnrollCmd := buildZitiEnrollCommand(cfg.WorkloadDNSUpstream)
+	if !equalStringSlice(zitiEnroll.Cmd, expectedEnrollCmd) {
+		t.Fatalf("expected ziti enroll cmd %+v, got %+v", expectedEnrollCmd, zitiEnroll.Cmd)
+	}
+	if !strings.Contains(zitiEnroll.Cmd[1], "nameserver %s\\nsearch svc.cluster.local cluster.local\\noptions ndots:5\\n") {
+		t.Fatalf("expected ziti enroll script to write workload DNS upstream resolver, got %q", zitiEnroll.Cmd[1])
+	}
+	if !strings.Contains(zitiEnroll.Cmd[1], "ziti edge enroll --jwt") {
+		t.Fatalf("expected ziti enroll script to run ziti edge enroll, got %q", zitiEnroll.Cmd[1])
+	}
+	if zitiEnroll.Cmd[3] != cfg.WorkloadDNSUpstream {
+		t.Fatalf("expected ziti enroll upstream arg %q, got %q", cfg.WorkloadDNSUpstream, zitiEnroll.Cmd[3])
+	}
+	zitiEnrollEnv := envMap(zitiEnroll.Env)
+	assertEnv(t, zitiEnrollEnv, ZitiIdentityBasenameEnvVar, ZitiIdentityBasename)
+	assertEnv(t, zitiEnrollEnv, ZitiIdentityDirEnvVar, zitiIdentityMountPath)
+	assertSameZitiIdentityMount(t, zitiEnroll)
 	zitiSidecar := testutil.FindInitContainer(request.InitContainers, ZitiSidecarContainerName)
 	if zitiSidecar == nil {
 		t.Fatal("expected ziti-sidecar init container")
@@ -370,8 +397,8 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if zitiSidecar.Image != cfg.ZitiSidecarImage {
 		t.Fatalf("expected ziti sidecar image %q, got %q", cfg.ZitiSidecarImage, zitiSidecar.Image)
 	}
-	if zitiSidecar.Entrypoint != zitiSidecarEntrypoint {
-		t.Fatalf("expected ziti sidecar entrypoint %q, got %q", zitiSidecarEntrypoint, zitiSidecar.Entrypoint)
+	if zitiSidecar.Entrypoint != "" {
+		t.Fatalf("expected ziti sidecar to use image entrypoint, got %q", zitiSidecar.Entrypoint)
 	}
 	expectedCmd := buildZitiSidecarCommand(cfg.WorkloadDNSUpstream)
 	if !equalStringSlice(zitiSidecar.Cmd, expectedCmd) {
@@ -401,23 +428,16 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 		t.Fatalf("expected ziti sidecar capabilities %+v, got %+v", []string{zitiRequiredCapabilityNetAdmin}, zitiSidecar.RequiredCapabilities)
 	}
 	zitiEnv := envMap(zitiSidecar.Env)
-	if zitiEnv[ZitiIdentityBasenameEnvVar] != ZitiIdentityBasename {
-		t.Fatalf("expected ziti sidecar basename %q, got %q", ZitiIdentityBasename, zitiEnv[ZitiIdentityBasenameEnvVar])
+	assertEnv(t, zitiEnv, ZitiIdentityBasenameEnvVar, ZitiIdentityBasename)
+	assertEnv(t, zitiEnv, ZitiIdentityDirEnvVar, zitiIdentityMountPath)
+	if _, ok := zitiEnv[ZitiEnrollmentTokenEnvVar]; ok {
+		t.Fatalf("expected ziti sidecar not to receive %s", ZitiEnrollmentTokenEnvVar)
 	}
 	expectedProperties := map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways}
 	if !equalStringMap(zitiSidecar.AdditionalProperties, expectedProperties) {
 		t.Fatalf("expected ziti sidecar properties %+v, got %+v", expectedProperties, zitiSidecar.AdditionalProperties)
 	}
-	if len(zitiSidecar.Mounts) != 1 {
-		t.Fatalf("expected 1 ziti sidecar mount, got %d", len(zitiSidecar.Mounts))
-	}
-	zitiMount := zitiSidecar.Mounts[0]
-	if zitiMount.Volume != zitiIdentityVolumeName {
-		t.Fatalf("expected ziti mount volume %q, got %q", zitiIdentityVolumeName, zitiMount.Volume)
-	}
-	if zitiMount.MountPath != zitiIdentityMountPath {
-		t.Fatalf("expected ziti mount path %q, got %q", zitiIdentityMountPath, zitiMount.MountPath)
-	}
+	assertSameZitiIdentityMount(t, zitiSidecar)
 	zitiGatewayWait := testutil.FindInitContainer(request.InitContainers, zitiGatewayWaitContainerName)
 	if zitiGatewayWait == nil {
 		t.Fatal("expected ziti-gateway-wait init container")
@@ -1429,6 +1449,20 @@ func assertEnv(t *testing.T, envs map[string]string, name, expected string) {
 	}
 }
 
+func assertSameZitiIdentityMount(t *testing.T, container *runnerv1.ContainerSpec) {
+	t.Helper()
+	if len(container.GetMounts()) != 1 {
+		t.Fatalf("expected 1 ziti identity mount on %s, got %d", container.GetName(), len(container.GetMounts()))
+	}
+	mount := container.GetMounts()[0]
+	if mount.GetVolume() != zitiIdentityVolumeName {
+		t.Fatalf("expected ziti mount volume %q on %s, got %q", zitiIdentityVolumeName, container.GetName(), mount.GetVolume())
+	}
+	if mount.GetMountPath() != zitiIdentityMountPath {
+		t.Fatalf("expected ziti mount path %q on %s, got %q", zitiIdentityMountPath, container.GetName(), mount.GetMountPath())
+	}
+}
+
 func equalStringMap(left, right map[string]string) bool {
 	if len(left) != len(right) {
 		return false
@@ -1549,105 +1583,5 @@ func TestLoadEgressCACertificate(t *testing.T) {
 	}
 	if string(cert) != "cert" {
 		t.Fatalf("expected cert bytes, got %q", string(cert))
-	}
-}
-
-func TestZitiSidecarResolverOverrideRestoresAfterEnrollment(t *testing.T) {
-	t.Parallel()
-	workDir := t.TempDir()
-	identityDir := filepath.Join(workDir, "netfoundry")
-	if err := os.Mkdir(identityDir, 0o700); err != nil {
-		t.Fatalf("create identity dir: %v", err)
-	}
-	resolvPath := filepath.Join(workDir, "resolv.conf")
-	originalResolv := "nameserver 127.0.0.1\nsearch svc.cluster.local cluster.local\n"
-	if err := os.WriteFile(resolvPath, []byte(originalResolv), 0o600); err != nil {
-		t.Fatalf("write resolv: %v", err)
-	}
-	zitiLogPath := filepath.Join(workDir, "ziti.log")
-	entrypointPath := writeExecutable(t, workDir, "entrypoint", fmt.Sprintf(`#!/usr/bin/env bash
-set -euo pipefail
-printf 'enroll_resolv=%%s\n' "$(cat %q)" >> %q
-printf '{}\n' > %q
-ziti tunnel tproxy
-`, resolvPath, zitiLogPath, filepath.Join(identityDir, "agent.json")))
-	zitiPath := writeExecutable(t, workDir, "ziti", fmt.Sprintf(`#!/usr/bin/env bash
-set -euo pipefail
-if [[ "$1" == "tunnel" ]]; then
-  printf 'tunnel_resolv=%%s\n' "$(cat %q)" >> %q
-  exit 0
-fi
-exit 9
-`, resolvPath, zitiLogPath))
-
-	cmd := exec.Command(zitiSidecarEntrypoint, buildZitiSidecarCommand("10.43.0.10")...)
-	cmd.Env = append(os.Environ(),
-		"PATH="+workDir+string(os.PathListSeparator)+os.Getenv("PATH"),
-		"ZITI_ENTRYPOINT="+entrypointPath,
-		"ZITI_RESOLV_CONF="+resolvPath,
-	)
-	_ = zitiPath
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("run ziti sidecar wrapper: %v\n%s", err, string(output))
-	}
-
-	assertFileEquals(t, resolvPath, originalResolv)
-	logBytes, err := os.ReadFile(zitiLogPath)
-	if err != nil {
-		t.Fatalf("read ziti log: %v", err)
-	}
-	log := string(logBytes)
-	if !strings.Contains(log, "enroll_resolv=nameserver 10.43.0.10") {
-		t.Fatalf("expected enrollment to use upstream resolver, got log:\n%s", log)
-	}
-	if !strings.Contains(log, "tunnel_resolv="+originalResolv) {
-		t.Fatalf("expected tunnel startup to use restored resolver, got log:\n%s", log)
-	}
-}
-
-func TestZitiSidecarResolverOverrideRestoresAfterEnrollmentFailure(t *testing.T) {
-	t.Parallel()
-	workDir := t.TempDir()
-	resolvPath := filepath.Join(workDir, "resolv.conf")
-	originalResolv := "nameserver 127.0.0.1\n"
-	if err := os.WriteFile(resolvPath, []byte(originalResolv), 0o600); err != nil {
-		t.Fatalf("write resolv: %v", err)
-	}
-	entrypointPath := writeExecutable(t, workDir, "entrypoint", `#!/usr/bin/env bash
-set -euo pipefail
-exit 7
-`)
-
-	cmd := exec.Command(zitiSidecarEntrypoint, buildZitiSidecarCommand("10.43.0.10")...)
-	cmd.Env = append(os.Environ(),
-		"ZITI_ENTRYPOINT="+entrypointPath,
-		"ZITI_RESOLV_CONF="+resolvPath,
-	)
-	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected ziti sidecar wrapper to fail\n%s", string(output))
-	}
-
-	assertFileEquals(t, resolvPath, originalResolv)
-}
-
-func writeExecutable(t *testing.T, dir, name, content string) string {
-	t.Helper()
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte(content), 0o700); err != nil {
-		t.Fatalf("write executable %s: %v", name, err)
-	}
-	return path
-}
-
-func assertFileEquals(t *testing.T, path, expected string) {
-	t.Helper()
-	actual, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
-	}
-	if string(actual) != expected {
-		t.Fatalf("expected %s to contain %q, got %q", path, expected, string(actual))
 	}
 }

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -363,6 +363,9 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if len(request.Sidecars) != 0 {
 		t.Fatalf("expected 0 sidecars, got %d", len(request.Sidecars))
 	}
+	if testutil.FindContainer(request.Sidecars, ZitiSidecarContainerName) != nil {
+		t.Fatalf("expected %s to use runner restartable init contract, not sidecars", ZitiSidecarContainerName)
+	}
 	zitiEnroll := testutil.FindInitContainer(request.InitContainers, ZitiEnrollContainerName)
 	if zitiEnroll == nil {
 		t.Fatal("expected ziti-enroll init container")
@@ -436,6 +439,9 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	expectedProperties := map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways}
 	if !equalStringMap(zitiSidecar.AdditionalProperties, expectedProperties) {
 		t.Fatalf("expected ziti sidecar properties %+v, got %+v", expectedProperties, zitiSidecar.AdditionalProperties)
+	}
+	if request.InitContainers[2].GetName() != zitiGatewayWaitContainerName || request.InitContainers[3].GetName() != "agent-init" {
+		t.Fatalf("expected restartable ziti sidecar init to be followed by later init containers, got %s then %s", request.InitContainers[2].GetName(), request.InitContainers[3].GetName())
 	}
 	assertSameZitiIdentityMount(t, zitiSidecar)
 	zitiGatewayWait := testutil.FindInitContainer(request.InitContainers, zitiGatewayWaitContainerName)

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -386,6 +386,9 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !strings.Contains(zitiEnroll.Cmd[1], "ziti edge enroll --jwt") {
 		t.Fatalf("expected ziti enroll script to run ziti edge enroll, got %q", zitiEnroll.Cmd[1])
 	}
+	if !strings.Contains(zitiEnroll.Cmd[1], "getent hosts") || !strings.Contains(zitiEnroll.Cmd[1], "ziti.agyn.dev") {
+		t.Fatalf("expected ziti enroll script to verify ziti.agyn.dev through workload DNS upstream, got %q", zitiEnroll.Cmd[1])
+	}
 	if zitiEnroll.Cmd[3] != cfg.WorkloadDNSUpstream {
 		t.Fatalf("expected ziti enroll upstream arg %q, got %q", cfg.WorkloadDNSUpstream, zitiEnroll.Cmd[3])
 	}

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -1569,21 +1569,24 @@ func TestZitiSidecarResolverOverrideRestoresAfterEnrollment(t *testing.T) {
 set -euo pipefail
 printf 'enroll_resolv=%%s\n' "$(cat %q)" >> %q
 printf '{}\n' > %q
-while true; do
-  if grep -q '^nameserver 127[.]0[.]0[.]1$' %q; then
-    printf 'tunnel_resolv=%%s\n' "$(cat %q)" >> %q
-    exit 0
-  fi
-  sleep 0.1
-done
-`, resolvPath, zitiLogPath, filepath.Join(identityDir, "agent.json"), resolvPath, resolvPath, zitiLogPath))
+ziti tunnel tproxy
+`, resolvPath, zitiLogPath, filepath.Join(identityDir, "agent.json")))
+	zitiPath := writeExecutable(t, workDir, "ziti", fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "tunnel" ]]; then
+  printf 'tunnel_resolv=%%s\n' "$(cat %q)" >> %q
+  exit 0
+fi
+exit 9
+`, resolvPath, zitiLogPath))
 
 	cmd := exec.Command(zitiSidecarEntrypoint, buildZitiSidecarCommand("10.43.0.10")...)
 	cmd.Env = append(os.Environ(),
+		"PATH="+workDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"ZITI_ENTRYPOINT="+entrypointPath,
-		"ZITI_IDENTITY_FILE="+filepath.Join(identityDir, "agent.json"),
 		"ZITI_RESOLV_CONF="+resolvPath,
 	)
+	_ = zitiPath
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("run ziti sidecar wrapper: %v\n%s", err, string(output))

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -2,9 +2,13 @@ package assembler
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -386,8 +390,11 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !strings.Contains(zitiEnroll.Cmd[1], "ziti edge enroll --jwt") {
 		t.Fatalf("expected ziti enroll script to run ziti edge enroll, got %q", zitiEnroll.Cmd[1])
 	}
-	if !strings.Contains(zitiEnroll.Cmd[1], "getent hosts") || !strings.Contains(zitiEnroll.Cmd[1], "ziti.agyn.dev") {
-		t.Fatalf("expected ziti enroll script to verify ziti.agyn.dev through workload DNS upstream, got %q", zitiEnroll.Cmd[1])
+	if strings.Contains(zitiEnroll.Cmd[1], "ziti.agyn.dev") {
+		t.Fatalf("expected ziti enroll script not to hard-code controller host, got %q", zitiEnroll.Cmd[1])
+	}
+	if !strings.Contains(zitiEnroll.Cmd[1], `"iss"`) {
+		t.Fatalf("expected ziti enroll script to derive controller host from JWT issuer, got %q", zitiEnroll.Cmd[1])
 	}
 	if zitiEnroll.Cmd[3] != cfg.WorkloadDNSUpstream {
 		t.Fatalf("expected ziti enroll upstream arg %q, got %q", cfg.WorkloadDNSUpstream, zitiEnroll.Cmd[3])
@@ -1592,5 +1599,103 @@ func TestLoadEgressCACertificate(t *testing.T) {
 	}
 	if string(cert) != "cert" {
 		t.Fatalf("expected cert bytes, got %q", string(cert))
+	}
+}
+
+func TestZitiEnrollScriptRemovesOnlyJwtControllerLoopbackAlias(t *testing.T) {
+	workDir := t.TempDir()
+	identityDir := filepath.Join(workDir, "netfoundry")
+	resolvPath := filepath.Join(workDir, "resolv.conf")
+	hostsPath := filepath.Join(workDir, "hosts")
+	logPath := filepath.Join(workDir, "ziti.log")
+	controllerHost := "controller.example.test"
+	otherHost := "other.example.test"
+	jwt := testJWTWithIssuer(t, "https://"+controllerHost+":2496")
+
+	if err := os.WriteFile(hostsPath, []byte(strings.Join([]string{
+		"127.0.0.1\tlocalhost",
+		"127.0.0.1\t" + controllerHost,
+		"127.0.0.1\t" + otherHost,
+		"10.42.1.121\tworkload-c84f0a23-ec5b-4410-97bb-2392195055a3",
+		"",
+	}, "\n")), 0o600); err != nil {
+		t.Fatalf("write hosts: %v", err)
+	}
+	_ = writeExecutable(t, workDir, "ziti", fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+printf 'args=%%s\n' "$*" > %q
+printf 'jwt=%%s\n' "$(cat %q)" >> %q
+printf '{}\n' > %q
+`, logPath, filepath.Join(identityDir, "agent.jwt"), logPath, filepath.Join(identityDir, "agent.json")))
+
+	cmd := exec.Command(zitiEnrollEntrypoint, buildZitiEnrollCommand("10.43.0.10")...)
+	cmd.Env = append(os.Environ(),
+		"PATH="+workDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		ZitiEnrollmentTokenEnvVar+"="+jwt,
+		ZitiIdentityBasenameEnvVar+"="+ZitiIdentityBasename,
+		ZitiIdentityDirEnvVar+"="+identityDir,
+		"ZITI_RESOLV_CONF="+resolvPath,
+		"ZITI_HOSTS_FILE="+hostsPath,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run ziti enroll script: %v\n%s", err, string(output))
+	}
+
+	assertFileEquals(t, resolvPath, "nameserver 10.43.0.10\nsearch svc.cluster.local cluster.local\noptions ndots:5\n")
+	hostsBytes, err := os.ReadFile(hostsPath)
+	if err != nil {
+		t.Fatalf("read hosts: %v", err)
+	}
+	hosts := string(hostsBytes)
+	if strings.Contains(hosts, "127.0.0.1\t"+controllerHost) {
+		t.Fatalf("expected controller loopback alias removed, got hosts:\n%s", hosts)
+	}
+	if !strings.Contains(hosts, "127.0.0.1\t"+otherHost) {
+		t.Fatalf("expected unrelated loopback alias preserved, got hosts:\n%s", hosts)
+	}
+	if !strings.Contains(hosts, "10.42.1.121\tworkload-c84f0a23-ec5b-4410-97bb-2392195055a3") {
+		t.Fatalf("expected workload host alias preserved, got hosts:\n%s", hosts)
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read ziti log: %v", err)
+	}
+	log := string(logBytes)
+	if !strings.Contains(log, "args=edge enroll --jwt "+filepath.Join(identityDir, "agent.jwt")+" --out "+filepath.Join(identityDir, "agent.json")) {
+		t.Fatalf("expected ziti enroll args in log, got:\n%s", log)
+	}
+	if !strings.Contains(log, "jwt="+jwt) {
+		t.Fatalf("expected jwt written for enroll, got:\n%s", log)
+	}
+}
+
+func testJWTWithIssuer(t *testing.T, issuer string) string {
+	t.Helper()
+	encode := base64.RawURLEncoding.EncodeToString
+	return strings.Join([]string{
+		encode([]byte(`{"alg":"none"}`)),
+		encode([]byte(fmt.Sprintf(`{"iss":%q}`, issuer))),
+		"signature",
+	}, ".")
+}
+
+func writeExecutable(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o700); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+	return path
+}
+
+func assertFileEquals(t *testing.T, path, expected string) {
+	t.Helper()
+	actual, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(actual) != expected {
+		t.Fatalf("expected %s to contain %q, got %q", path, expected, string(actual))
 	}
 }

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1546,5 +1549,117 @@ func TestLoadEgressCACertificate(t *testing.T) {
 	}
 	if string(cert) != "cert" {
 		t.Fatalf("expected cert bytes, got %q", string(cert))
+	}
+}
+
+func TestZitiSidecarResolverOverrideRestoresAfterEnrollment(t *testing.T) {
+	t.Parallel()
+	workDir := t.TempDir()
+	resolvPath := filepath.Join(workDir, "resolv.conf")
+	originalResolv := "nameserver 127.0.0.1\nsearch svc.cluster.local cluster.local\n"
+	if err := os.WriteFile(resolvPath, []byte(originalResolv), 0o600); err != nil {
+		t.Fatalf("write resolv: %v", err)
+	}
+	zitiLogPath := filepath.Join(workDir, "ziti.log")
+	zitiPath := writeExecutable(t, workDir, "real-ziti", fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "edge" && "$2" == "enroll" ]]; then
+  printf 'enroll_resolv=%%s\n' "$(cat %q)" >> %q
+  exit 0
+fi
+if [[ "$1" == "tunnel" ]]; then
+  printf 'tunnel_resolv=%%s\n' "$(cat %q)" >> %q
+  exit 0
+fi
+exit 9
+`, resolvPath, zitiLogPath, resolvPath, zitiLogPath))
+	entrypointPath := writeExecutable(t, workDir, "entrypoint", `#!/usr/bin/env bash
+set -euo pipefail
+ziti edge enroll --jwt /netfoundry/agent.jwt --out /netfoundry/agent.json
+ziti tunnel "$@"
+`)
+
+	cmd := exec.Command(zitiSidecarEntrypoint, buildZitiSidecarCommand("10.43.0.10")...)
+	cmd.Env = append(os.Environ(),
+		"ZITI_BINARY="+zitiPath,
+		"ZITI_ENTRYPOINT="+entrypointPath,
+		"ZITI_RESOLV_CONF="+resolvPath,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run ziti sidecar wrapper: %v\n%s", err, string(output))
+	}
+
+	assertFileEquals(t, resolvPath, originalResolv)
+	logBytes, err := os.ReadFile(zitiLogPath)
+	if err != nil {
+		t.Fatalf("read ziti log: %v", err)
+	}
+	log := string(logBytes)
+	if !strings.Contains(log, "enroll_resolv=nameserver 10.43.0.10") {
+		t.Fatalf("expected enrollment to use upstream resolver, got log:\n%s", log)
+	}
+	if !strings.Contains(log, "tunnel_resolv="+originalResolv) {
+		t.Fatalf("expected tunnel startup to use restored resolver, got log:\n%s", log)
+	}
+}
+
+func TestZitiSidecarResolverOverrideRestoresAfterEnrollmentFailure(t *testing.T) {
+	t.Parallel()
+	workDir := t.TempDir()
+	resolvPath := filepath.Join(workDir, "resolv.conf")
+	originalResolv := "nameserver 127.0.0.1\n"
+	if err := os.WriteFile(resolvPath, []byte(originalResolv), 0o600); err != nil {
+		t.Fatalf("write resolv: %v", err)
+	}
+	zitiLogPath := filepath.Join(workDir, "ziti.log")
+	zitiPath := writeExecutable(t, workDir, "real-ziti", fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+printf 'enroll_resolv=%%s\n' "$(cat %q)" >> %q
+exit 7
+`, resolvPath, zitiLogPath))
+	entrypointPath := writeExecutable(t, workDir, "entrypoint", `#!/usr/bin/env bash
+set -euo pipefail
+ziti edge enroll --jwt /netfoundry/agent.jwt --out /netfoundry/agent.json
+`)
+
+	cmd := exec.Command(zitiSidecarEntrypoint, buildZitiSidecarCommand("10.43.0.10")...)
+	cmd.Env = append(os.Environ(),
+		"ZITI_BINARY="+zitiPath,
+		"ZITI_ENTRYPOINT="+entrypointPath,
+		"ZITI_RESOLV_CONF="+resolvPath,
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected ziti sidecar wrapper to fail\n%s", string(output))
+	}
+
+	assertFileEquals(t, resolvPath, originalResolv)
+	logBytes, err := os.ReadFile(zitiLogPath)
+	if err != nil {
+		t.Fatalf("read ziti log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "enroll_resolv=nameserver 10.43.0.10") {
+		t.Fatalf("expected enrollment to use upstream resolver, got log:\n%s", string(logBytes))
+	}
+}
+
+func writeExecutable(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o700); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+	return path
+}
+
+func assertFileEquals(t *testing.T, path, expected string) {
+	t.Helper()
+	actual, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(actual) != expected {
+		t.Fatalf("expected %s to contain %q, got %q", path, expected, string(actual))
 	}
 }

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -399,6 +399,9 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if zitiEnroll.Cmd[3] != cfg.WorkloadDNSUpstream {
 		t.Fatalf("expected ziti enroll upstream arg %q, got %q", cfg.WorkloadDNSUpstream, zitiEnroll.Cmd[3])
 	}
+	if zitiEnroll.Cmd[4] != zitiDNSNameserver {
+		t.Fatalf("expected ziti enroll workload DNS nameserver arg %q, got %q", zitiDNSNameserver, zitiEnroll.Cmd[4])
+	}
 	zitiEnrollEnv := envMap(zitiEnroll.Env)
 	assertEnv(t, zitiEnrollEnv, ZitiIdentityBasenameEnvVar, ZitiIdentityBasename)
 	assertEnv(t, zitiEnrollEnv, ZitiIdentityDirEnvVar, zitiIdentityMountPath)
@@ -1606,8 +1609,9 @@ set -euo pipefail
 printf 'args=%%s\n' "$*" > %q
 printf 'jwt=%%s\n' "$(cat %q)" >> %q
 printf 'enroll_resolv=%%s\n' "$(cat %q)" >> %q
+printf 'post_enroll_resolv=%%s\n' "$(cat %q)" >> %q
 printf '{}\n' > %q
-`, logPath, filepath.Join(identityDir, "agent.jwt"), logPath, resolvPath, logPath, filepath.Join(identityDir, "agent.json")))
+`, logPath, filepath.Join(identityDir, "agent.jwt"), logPath, resolvPath, logPath, resolvPath, logPath, filepath.Join(identityDir, "agent.json")))
 	_ = writeExecutable(t, workDir, "cat", fmt.Sprintf(`#!/usr/bin/env bash
 set -euo pipefail
 real_cat=/usr/bin/cat
@@ -1631,7 +1635,7 @@ exec "${real_cat}" "$@"
 		t.Fatalf("run ziti enroll script: %v\n%s", err, string(output))
 	}
 
-	assertFileEquals(t, resolvPath, "nameserver 10.43.0.10\nsearch svc.cluster.local cluster.local\noptions ndots:5\n")
+	assertFileEquals(t, resolvPath, "nameserver 127.0.0.1\nsearch svc.cluster.local cluster.local\noptions ndots:5\n")
 	hostsBytes, err := os.ReadFile(hostsPath)
 	if err != nil {
 		t.Fatalf("read hosts: %v", err)
@@ -1659,6 +1663,9 @@ exec "${real_cat}" "$@"
 	}
 	if !strings.Contains(log, "enroll_resolv=nameserver 10.43.0.10") {
 		t.Fatalf("expected ziti enroll invocation to observe workload DNS upstream resolver, got:\n%s", log)
+	}
+	if !strings.Contains(log, "post_enroll_resolv=nameserver 10.43.0.10") {
+		t.Fatalf("expected ziti enroll command to complete before workload resolver restore, got:\n%s", log)
 	}
 }
 

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -1628,6 +1628,14 @@ printf 'jwt=%%s\n' "$(cat %q)" >> %q
 printf 'enroll_resolv=%%s\n' "$(cat %q)" >> %q
 printf '{}\n' > %q
 `, logPath, filepath.Join(identityDir, "agent.jwt"), logPath, resolvPath, logPath, filepath.Join(identityDir, "agent.json")))
+	_ = writeExecutable(t, workDir, "cat", fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+real_cat=/usr/bin/cat
+if [[ "$#" -ge 1 && "$1" == %q ]]; then
+  printf 'nameserver 127.0.0.1\n' > %q
+fi
+exec "${real_cat}" "$@"
+`, hostsPath+".tmp", resolvPath))
 
 	cmd := exec.Command(zitiEnrollEntrypoint, buildZitiEnrollCommand("10.43.0.10")...)
 	cmd.Env = append(os.Environ(),

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -1625,8 +1625,9 @@ func TestZitiEnrollScriptRemovesOnlyJwtControllerLoopbackAlias(t *testing.T) {
 set -euo pipefail
 printf 'args=%%s\n' "$*" > %q
 printf 'jwt=%%s\n' "$(cat %q)" >> %q
+printf 'enroll_resolv=%%s\n' "$(cat %q)" >> %q
 printf '{}\n' > %q
-`, logPath, filepath.Join(identityDir, "agent.jwt"), logPath, filepath.Join(identityDir, "agent.json")))
+`, logPath, filepath.Join(identityDir, "agent.jwt"), logPath, resolvPath, logPath, filepath.Join(identityDir, "agent.json")))
 
 	cmd := exec.Command(zitiEnrollEntrypoint, buildZitiEnrollCommand("10.43.0.10")...)
 	cmd.Env = append(os.Environ(),
@@ -1667,6 +1668,9 @@ printf '{}\n' > %q
 	}
 	if !strings.Contains(log, "jwt="+jwt) {
 		t.Fatalf("expected jwt written for enroll, got:\n%s", log)
+	}
+	if !strings.Contains(log, "enroll_resolv=nameserver 10.43.0.10") {
+		t.Fatalf("expected ziti enroll invocation to observe workload DNS upstream resolver, got:\n%s", log)
 	}
 }
 

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -417,26 +417,6 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(zitiSidecar.Cmd, expectedCmd) {
 		t.Fatalf("expected ziti sidecar cmd %+v, got %+v", expectedCmd, zitiSidecar.Cmd)
 	}
-	if len(zitiSidecar.Cmd) != 2 {
-		t.Fatalf("expected ziti sidecar shell command, got %+v", zitiSidecar.Cmd)
-	}
-	zitiScript := zitiSidecar.Cmd[1]
-	for _, expected := range []string{
-		fmt.Sprintf("identity_file=\"%s\"", zitiIdentityFile),
-		fmt.Sprintf("token_file=\"%s\"", zitiEnrollmentTokenFile),
-		ZitiEnrollmentTokenEnvVar,
-		`ziti edge enroll "$token_file" --out "$identity_file"`,
-		fmt.Sprintf(`exec ziti tunnel %s --identity "$identity_file" --dnsUpstream "udp://%s:53"`, zitiSidecarCommand, cfg.WorkloadDNSUpstream),
-	} {
-		if !strings.Contains(zitiScript, expected) {
-			t.Fatalf("expected ziti sidecar command to contain %q, got %q", expected, zitiScript)
-		}
-	}
-	for _, unexpected := range []string{"jq"} {
-		if strings.Contains(zitiScript, unexpected) {
-			t.Fatalf("expected ziti sidecar command not to contain %q, got %q", unexpected, zitiScript)
-		}
-	}
 	if !equalStringSlice(zitiSidecar.RequiredCapabilities, []string{zitiRequiredCapabilityNetAdmin}) {
 		t.Fatalf("expected ziti sidecar capabilities %+v, got %+v", []string{zitiRequiredCapabilityNetAdmin}, zitiSidecar.RequiredCapabilities)
 	}

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -75,16 +75,23 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 			if mainEnvs["WORKLOAD_ID"] != workloadID {
 				return nil, errors.New("missing WORKLOAD_ID")
 			}
-			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
-			if zitiContainer == nil {
-				return nil, errors.New("missing ziti sidecar container")
+			zitiEnroll := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiEnrollContainerName)
+			if zitiEnroll == nil {
+				return nil, errors.New("missing ziti enroll container")
 			}
-			envs := envMap(zitiContainer.GetEnv())
+			envs := envMap(zitiEnroll.GetEnv())
 			if envs[assembler.ZitiEnrollmentTokenEnvVar] != jwt {
 				return nil, errors.New("missing ZITI_ENROLL_TOKEN")
 			}
 			if envs[assembler.ZitiIdentityBasenameEnvVar] != assembler.ZitiIdentityBasename {
 				return nil, errors.New("missing ZITI_IDENTITY_BASENAME")
+			}
+			zitiSidecar := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
+			if zitiSidecar == nil {
+				return nil, errors.New("missing ziti sidecar container")
+			}
+			if _, ok := envMap(zitiSidecar.GetEnv())[assembler.ZitiEnrollmentTokenEnvVar]; ok {
+				return nil, errors.New("unexpected sidecar ZITI_ENROLL_TOKEN")
 			}
 			return &runnerv1.StartWorkloadResponse{
 				Id:     workloadID,
@@ -208,9 +215,9 @@ func TestStartWorkloadSkipsIdentityWhenZitiMgmtNil(t *testing.T) {
 			if mainEnvs["WORKLOAD_ID"] != workloadID {
 				return nil, errors.New("missing WORKLOAD_ID")
 			}
-			zitiContainer := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiSidecarContainerName)
-			if zitiContainer != nil {
-				envs := envMap(zitiContainer.GetEnv())
+			zitiEnroll := testutil.FindInitContainer(req.GetInitContainers(), assembler.ZitiEnrollContainerName)
+			if zitiEnroll != nil {
+				envs := envMap(zitiEnroll.GetEnv())
 				if _, ok := envs[assembler.ZitiEnrollmentTokenEnvVar]; ok {
 					return nil, errors.New("unexpected ZITI_ENROLL_TOKEN")
 				}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -268,7 +268,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 	if identity != nil {
 		if err := attachZitiEnrollmentToken(request, identity.enrollmentJWT); err != nil {
 			log.Printf("reconciler: set ziti enrollment jwt for agent %s thread %s: %v", target.AgentID.String(), target.ThreadID.String(), err)
-			r.compensateIdentity(ctx, zitiIdentityID, "missing ziti sidecar container")
+			r.compensateIdentity(ctx, zitiIdentityID, "missing ziti enroll container")
 			return
 		}
 	}
@@ -600,16 +600,16 @@ func failureSummary(failure *runnerv1.WorkloadFailure) string {
 
 func attachZitiEnrollmentToken(request *runnerv1.StartWorkloadRequest, jwt string) error {
 	for _, container := range request.InitContainers {
-		if container.Name == assembler.ZitiSidecarContainerName {
+		if container.Name == assembler.ZitiEnrollContainerName {
 			container.Env = append(container.Env, &runnerv1.EnvVar{Name: assembler.ZitiEnrollmentTokenEnvVar, Value: jwt})
 			return nil
 		}
 	}
 	for _, container := range request.Sidecars {
-		if container.Name == assembler.ZitiSidecarContainerName {
+		if container.Name == assembler.ZitiEnrollContainerName {
 			container.Env = append(container.Env, &runnerv1.EnvVar{Name: assembler.ZitiEnrollmentTokenEnvVar, Value: jwt})
 			return nil
 		}
 	}
-	return fmt.Errorf("missing ziti sidecar container")
+	return fmt.Errorf("missing ziti enroll container")
 }


### PR DESCRIPTION
## Summary
- Remove `WorkloadDNSUpstream` from workload pod DNS nameservers when Ziti is enabled.
- Keep `WorkloadDNSUpstream` in the Ziti sidecar `--dnsUpstream` command.
- Update assembler test expectations so workload DNS uses only `127.0.0.1`.
- Fix an existing duplicate fake secrets client field that prevented local package compilation.

Closes #214

## Test & Lint Summary
- `go test -count=1 ./internal/assembler ./internal/config ./internal/reconciler` — passed: 128, failed: 0, skipped: 0
- `go test -count=1 ./...` — passed: 155, failed: 0, skipped: 0
- `go build ./...` — passed
- `go vet ./...` — passed with no errors
- `git diff --check` — passed with no whitespace errors