### PR TITLE
feat(orchestrator): sync agent group attrs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
             --path agynio/api/agents/v1 \
             --path agynio/api/secrets/v1 \
             --path agynio/api/ziti_management/v1 \
+            --path agynio/api/groups/v1 \
             --path agynio/api/identity/v1 \
             --path agynio/api/llm/v1 \
             --path agynio/api/users/v1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN buf generate buf.build/agynio/api \
     --path agynio/api/agents/v1 \
     --path agynio/api/secrets/v1 \
     --path agynio/api/ziti_management/v1 \
+    --path agynio/api/groups/v1 \
     --path agynio/api/identity/v1 \
     --path agynio/api/llm/v1 \
     --path agynio/api/users/v1 \

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -16,6 +16,7 @@ inputs:
       - agynio/api/agents/v1
       - agynio/api/secrets/v1
       - agynio/api/ziti_management/v1
+      - agynio/api/groups/v1
       - agynio/api/identity/v1
       - agynio/api/llm/v1
       - agynio/api/users/v1

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -88,6 +88,8 @@ env:
     value: "2m"
   - name: ZITI_MANAGEMENT_ADDRESS
     value: "ziti-management:50051"
+  - name: GROUP_SYNC_ENABLED
+    value: "false"
   - name: GROUPS_ADDRESS
     value: "groups:50051"
   - name: NATS_URL

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -88,6 +88,10 @@ env:
     value: "2m"
   - name: ZITI_MANAGEMENT_ADDRESS
     value: "ziti-management:50051"
+  - name: GROUPS_ADDRESS
+    value: "groups:50051"
+  - name: NATS_URL
+    value: ""
   # Upstream DNS resolver used for Ziti-enabled workload pods.
   - name: WORKLOAD_DNS_UPSTREAM
     value: ""

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -96,12 +96,6 @@ func run() error {
 	}
 	defer closeConn(meteringConn)
 
-	groupsConn, err := grpc.NewClient(cfg.GroupsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return fmt.Errorf("dial groups: %w", err)
-	}
-	defer closeConn(groupsConn)
-
 	var (
 		runnerDialer   runnerdial.RunnerDialer
 		zitiMgmtConn   *grpc.ClientConn
@@ -140,7 +134,16 @@ func run() error {
 	secretsClient := secretsv1.NewSecretsServiceClient(secretsConn)
 	runnersClient := runnersv1.NewRunnersServiceClient(runnersConn)
 	meteringClient := meteringv1.NewMeteringServiceClient(meteringConn)
-	groupsClient := groupsv1.NewGroupsServiceClient(groupsConn)
+	var groupsClient groupsv1.GroupsServiceClient
+	var groupsConn *grpc.ClientConn
+	if cfg.GroupSyncEnabled {
+		groupsConn, err = grpc.NewClient(cfg.GroupsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return fmt.Errorf("dial groups: %w", err)
+		}
+		defer closeConn(groupsConn)
+		groupsClient = groupsv1.NewGroupsServiceClient(groupsConn)
+	}
 	subscriber := subscriber.New(notificationsClient, agentsClient)
 	egressCANamespace, err := k8sclient.ResolveNamespace(cfg.EgressCANamespace, "egress CA")
 	if err != nil {
@@ -178,7 +181,7 @@ func run() error {
 
 	start := func(leadCtx context.Context) {
 		group, groupCtx := errgroup.WithContext(leadCtx)
-		if cfg.NATSURL != "" {
+		if cfg.GroupSyncEnabled && cfg.NATSURL != "" {
 			reconciler.StartGroupMembershipConsumerLoop(groupCtx, cfg.NATSURL)
 		}
 		group.Go(func() error {

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	groupsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/groups/v1"
 	meteringv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/metering/v1"
 	notificationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/notifications/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
@@ -95,6 +96,12 @@ func run() error {
 	}
 	defer closeConn(meteringConn)
 
+	groupsConn, err := grpc.NewClient(cfg.GroupsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial groups: %w", err)
+	}
+	defer closeConn(groupsConn)
+
 	var (
 		runnerDialer   runnerdial.RunnerDialer
 		zitiMgmtConn   *grpc.ClientConn
@@ -133,6 +140,7 @@ func run() error {
 	secretsClient := secretsv1.NewSecretsServiceClient(secretsConn)
 	runnersClient := runnersv1.NewRunnersServiceClient(runnersConn)
 	meteringClient := meteringv1.NewMeteringServiceClient(meteringConn)
+	groupsClient := groupsv1.NewGroupsServiceClient(groupsConn)
 	subscriber := subscriber.New(notificationsClient, agentsClient)
 	egressCANamespace, err := k8sclient.ResolveNamespace(cfg.EgressCANamespace, "egress CA")
 	if err != nil {
@@ -156,6 +164,7 @@ func run() error {
 		Agents:                    agentsClient,
 		RunnerDialer:              runnerDialer,
 		ZitiMgmt:                  zitiMgmtClient,
+		Groups:                    groupsClient,
 		Runners:                   runnersClient,
 		Metering:                  meteringClient,
 		Assembler:                 assembler,
@@ -169,6 +178,9 @@ func run() error {
 
 	start := func(leadCtx context.Context) {
 		group, groupCtx := errgroup.WithContext(leadCtx)
+		if cfg.NATSURL != "" {
+			reconciler.StartGroupMembershipConsumerLoop(groupCtx, cfg.NATSURL)
+		}
 		group.Go(func() error {
 			return subscriber.Run(groupCtx)
 		})

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -27,15 +27,19 @@ functions:
     fi
   ensure_egress_ca_rbac: |-
     echo "Ensuring agents-orchestrator can read egress CA secret..."
+    EGRESS_CA_NAMESPACE="$(kubectl get deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} -o jsonpath='{range .spec.template.spec.containers[?(@.name=="agents-orchestrator")].env[?(@.name=="EGRESS_CA_NAMESPACE")]}{.value}{end}')"
+    if [ -z "${EGRESS_CA_NAMESPACE}" ]; then
+      EGRESS_CA_NAMESPACE="${ORCHESTRATOR_NAMESPACE}"
+    fi
     kubectl create role agents-orchestrator-egress-ca \
-      -n ${ORCHESTRATOR_NAMESPACE} \
+      -n ${EGRESS_CA_NAMESPACE} \
       --verb=get \
       --resource=secrets \
       --resource-name=egress-ca \
       --dry-run=client \
       -o yaml | kubectl apply -f -
     kubectl create rolebinding agents-orchestrator-egress-ca \
-      -n ${ORCHESTRATOR_NAMESPACE} \
+      -n ${EGRESS_CA_NAMESPACE} \
       --role=agents-orchestrator-egress-ca \
       --serviceaccount=${ORCHESTRATOR_NAMESPACE}:agents-orchestrator \
       --dry-run=client \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -25,9 +25,23 @@ functions:
     else
       echo "WARNING: ArgoCD Application 'agents-orchestrator' not found in argocd namespace."
     fi
+  egress_ca_namespace: |-
+    if kubectl get secret egress-ca -n ${ORCHESTRATOR_NAMESPACE} >/dev/null 2>&1; then
+      echo "${ORCHESTRATOR_NAMESPACE}"
+      exit 0
+    fi
+    namespace="$(kubectl get certificate -A -o jsonpath='{range .items[?(@.spec.secretName=="egress-ca")]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null | head -n 1)"
+    if [ -z "${namespace}" ]; then
+      namespace="$(kubectl get secret -A --field-selector metadata.name=egress-ca -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null | head -n 1)"
+    fi
+    if [ -z "${namespace}" ]; then
+      echo "ERROR: egress-ca secret namespace could not be determined" >&2
+      exit 1
+    fi
+    echo "${namespace}"
   ensure_egress_ca_rbac: |-
     echo "Ensuring agents-orchestrator can read egress CA secret..."
-    EGRESS_CA_NAMESPACE="${ORCHESTRATOR_NAMESPACE}"
+    EGRESS_CA_NAMESPACE="$(egress_ca_namespace)"
     kubectl create role agents-orchestrator-egress-ca \
       -n ${EGRESS_CA_NAMESPACE} \
       --verb=get \
@@ -43,7 +57,8 @@ functions:
       -o yaml | kubectl apply -f -
   patch_deployment: |-
     echo "Patching agents-orchestrator deployment for DevSpace..."
-    kubectl patch deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    EGRESS_CA_NAMESPACE="$(egress_ca_namespace)"
+    patch="$(cat <<'EOF'
     spec:
       template:
         spec:
@@ -64,7 +79,7 @@ functions:
                 - name: WORKLOAD_RECONCILE_INTERVAL
                   value: "10s"
                 - name: EGRESS_CA_NAMESPACE
-                  value: "platform"
+                  value: "__EGRESS_CA_NAMESPACE__"
               command:
                 - sh
                 - -c
@@ -122,6 +137,8 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
+    patch="${patch/__EGRESS_CA_NAMESPACE__/${EGRESS_CA_NAMESPACE}}"
+    kubectl patch deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} --type strategic --patch "${patch}"
   wait_for_orchestrator: |-
     echo "Waiting for orchestrator deployment to roll out..."
     kubectl rollout status deployment/agents-orchestrator \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -93,6 +93,7 @@ functions:
                     --path agynio/api/agents/v1 \
                     --path agynio/api/secrets/v1 \
                     --path agynio/api/ziti_management/v1 \
+                    --path agynio/api/groups/v1 \
                     --path agynio/api/identity/v1 \
                     --path agynio/api/llm/v1 \
                     --path agynio/api/users/v1 \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -27,10 +27,7 @@ functions:
     fi
   ensure_egress_ca_rbac: |-
     echo "Ensuring agents-orchestrator can read egress CA secret..."
-    EGRESS_CA_NAMESPACE="$(kubectl get deployment agents-orchestrator -n ${ORCHESTRATOR_NAMESPACE} -o jsonpath='{range .spec.template.spec.containers[?(@.name=="agents-orchestrator")].env[?(@.name=="EGRESS_CA_NAMESPACE")]}{.value}{end}')"
-    if [ -z "${EGRESS_CA_NAMESPACE}" ]; then
-      EGRESS_CA_NAMESPACE="${ORCHESTRATOR_NAMESPACE}"
-    fi
+    EGRESS_CA_NAMESPACE="${ORCHESTRATOR_NAMESPACE}"
     kubectl create role agents-orchestrator-egress-ca \
       -n ${EGRESS_CA_NAMESPACE} \
       --verb=get \
@@ -66,6 +63,8 @@ functions:
                   value: "10s"
                 - name: WORKLOAD_RECONCILE_INTERVAL
                   value: "10s"
+                - name: EGRESS_CA_NAMESPACE
+                  value: "platform"
               command:
                 - sh
                 - -c

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kataras/go-events v0.0.3 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -78,6 +79,9 @@ require (
 	github.com/muhlemmer/gu v0.3.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/nats-io/nats.go v1.47.0 // indirect
+	github.com/nats-io/nkeys v0.4.11 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/openziti/channel/v4 v4.3.9 // indirect
 	github.com/openziti/foundation/v2 v2.0.90 // indirect

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/kataras/go-events v0.0.3 h1:o5YK53uURXtrlg7qE/vovxd/yKOJcLuFtPQbf1rYM
 github.com/kataras/go-events v0.0.3/go.mod h1:bFBgtzwwzrag7kQmGuU1ZaVxhK2qseYPQomXoVEMsj4=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -337,6 +339,12 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/nats-io/nats.go v1.47.0 h1:YQdADw6J/UfGUd2Oy6tn4Hq6YHxCaJrVKayxxFqYrgM=
+github.com/nats-io/nats.go v1.47.0/go.mod h1:iRWIPokVIFbVijxuMQq4y9ttaBTMe0SFdlZfMDd+33g=
+github.com/nats-io/nkeys v0.4.11 h1:q44qGV008kYd9W1b1nEBkNzvnWxtRSQ7A8BoqRrcfa0=
+github.com/nats-io/nkeys v0.4.11/go.mod h1:szDimtgmfOi9n25JpfIdGw12tZFYXqhGxjhVxsatHVE=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	ZitiEnabled               bool
 	ZitiManagementAddress     string
 	GroupsAddress             string
+	GroupSyncEnabled          bool
 	NATSURL                   string
 	ZitiLeaseRenewalInterval  time.Duration
 	ZitiEnrollmentTimeout     time.Duration
@@ -114,6 +115,14 @@ func FromEnv() (Config, error) {
 	cfg.ZitiManagementAddress = os.Getenv("ZITI_MANAGEMENT_ADDRESS")
 	if cfg.ZitiManagementAddress == "" {
 		cfg.ZitiManagementAddress = "ziti-management:50051"
+	}
+	groupSyncEnabled := os.Getenv("GROUP_SYNC_ENABLED")
+	if groupSyncEnabled != "" {
+		parsed, err := strconv.ParseBool(groupSyncEnabled)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse GROUP_SYNC_ENABLED: %w", err)
+		}
+		cfg.GroupSyncEnabled = parsed
 	}
 	cfg.GroupsAddress = os.Getenv("GROUPS_ADDRESS")
 	if cfg.GroupsAddress == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	MeteringSampleInterval    time.Duration
 	ZitiEnabled               bool
 	ZitiManagementAddress     string
+	GroupsAddress             string
+	NATSURL                   string
 	ZitiLeaseRenewalInterval  time.Duration
 	ZitiEnrollmentTimeout     time.Duration
 	ZitiSidecarImage          string
@@ -113,6 +115,11 @@ func FromEnv() (Config, error) {
 	if cfg.ZitiManagementAddress == "" {
 		cfg.ZitiManagementAddress = "ziti-management:50051"
 	}
+	cfg.GroupsAddress = os.Getenv("GROUPS_ADDRESS")
+	if cfg.GroupsAddress == "" {
+		cfg.GroupsAddress = "groups:50051"
+	}
+	cfg.NATSURL = os.Getenv("NATS_URL")
 	zitiLeaseRenewalInterval := os.Getenv("ZITI_LEASE_RENEWAL_INTERVAL")
 	if zitiLeaseRenewalInterval == "" {
 		cfg.ZitiLeaseRenewalInterval = 2 * time.Minute

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,12 @@ func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	if cfg.MeteringSampleInterval != time.Minute {
 		t.Fatalf("expected metering sample interval %q, got %q", time.Minute, cfg.MeteringSampleInterval)
 	}
+	if cfg.GroupsAddress != "groups:50051" {
+		t.Fatalf("expected groups address %q, got %q", "groups:50051", cfg.GroupsAddress)
+	}
+	if cfg.NATSURL != "" {
+		t.Fatalf("expected empty nats url, got %q", cfg.NATSURL)
+	}
 	if cfg.WorkloadReconcileInterval != time.Minute {
 		t.Fatalf("expected workload reconcile interval %q, got %q", time.Minute, cfg.WorkloadReconcileInterval)
 	}
@@ -139,6 +145,8 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("METERING_SERVICE_ADDRESS", "")
 	t.Setenv("METERING_SAMPLE_INTERVAL", "")
 	t.Setenv("ZITI_MANAGEMENT_ADDRESS", "")
+	t.Setenv("GROUPS_ADDRESS", "")
+	t.Setenv("NATS_URL", "")
 	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "")
 	t.Setenv("ZITI_ENROLLMENT_TIMEOUT", "")
 	t.Setenv("ZITI_SIDECAR_IMAGE", "")
@@ -154,4 +162,21 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("LEASE_NAME", "")
 	t.Setenv("LEASE_NAMESPACE", "")
 	t.Setenv("EGRESS_CA_NAMESPACE", "")
+}
+
+func TestFromEnvGroupSyncConfig(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("GROUPS_ADDRESS", "groups.internal:50051")
+	t.Setenv("NATS_URL", "nats://nats:4222")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.GroupsAddress != "groups.internal:50051" {
+		t.Fatalf("expected groups address %q, got %q", "groups.internal:50051", cfg.GroupsAddress)
+	}
+	if cfg.NATSURL != "nats://nats:4222" {
+		t.Fatalf("expected nats url %q, got %q", "nats://nats:4222", cfg.NATSURL)
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,9 @@ func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	if cfg.MeteringSampleInterval != time.Minute {
 		t.Fatalf("expected metering sample interval %q, got %q", time.Minute, cfg.MeteringSampleInterval)
 	}
+	if cfg.GroupSyncEnabled {
+		t.Fatal("expected group sync to be disabled")
+	}
 	if cfg.GroupsAddress != "groups:50051" {
 		t.Fatalf("expected groups address %q, got %q", "groups:50051", cfg.GroupsAddress)
 	}
@@ -145,6 +148,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("METERING_SERVICE_ADDRESS", "")
 	t.Setenv("METERING_SAMPLE_INTERVAL", "")
 	t.Setenv("ZITI_MANAGEMENT_ADDRESS", "")
+	t.Setenv("GROUP_SYNC_ENABLED", "")
 	t.Setenv("GROUPS_ADDRESS", "")
 	t.Setenv("NATS_URL", "")
 	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "")
@@ -166,6 +170,7 @@ func setBaseEnv(t *testing.T) {
 
 func TestFromEnvGroupSyncConfig(t *testing.T) {
 	setBaseEnv(t)
+	t.Setenv("GROUP_SYNC_ENABLED", "true")
 	t.Setenv("GROUPS_ADDRESS", "groups.internal:50051")
 	t.Setenv("NATS_URL", "nats://nats:4222")
 
@@ -173,10 +178,23 @@ func TestFromEnvGroupSyncConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FromEnv: %v", err)
 	}
+	if !cfg.GroupSyncEnabled {
+		t.Fatal("expected group sync to be enabled")
+	}
 	if cfg.GroupsAddress != "groups.internal:50051" {
 		t.Fatalf("expected groups address %q, got %q", "groups.internal:50051", cfg.GroupsAddress)
 	}
 	if cfg.NATSURL != "nats://nats:4222" {
 		t.Fatalf("expected nats url %q, got %q", "nats://nats:4222", cfg.NATSURL)
+	}
+}
+
+func TestFromEnvGroupSyncEnabledInvalid(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("GROUP_SYNC_ENABLED", "not-bool")
+
+	_, err := FromEnv()
+	if err == nil {
+		t.Fatal("expected GROUP_SYNC_ENABLED parse error")
 	}
 }

--- a/internal/reconciler/group_consumer.go
+++ b/internal/reconciler/group_consumer.go
@@ -1,0 +1,118 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+const groupMembershipConsumerName = "agents-orchestrator-group-sync"
+
+type groupMembershipSubscription interface {
+	Unsubscribe() error
+}
+
+type groupMembershipSubscriber func(context.Context) (groupMembershipSubscription, error)
+
+func (r *Reconciler) StartGroupMembershipConsumerLoop(ctx context.Context, natsURL string) {
+	r.StartGroupMembershipConsumerLoopWithSubscriber(ctx, func(ctx context.Context) (groupMembershipSubscription, error) {
+		return r.subscribeGroupMembershipEvents(ctx, natsURL)
+	})
+}
+
+func (r *Reconciler) StartGroupMembershipConsumerLoopWithSubscriber(ctx context.Context, subscribe groupMembershipSubscriber) {
+	go func() {
+		backoff := groupMembershipRetryInitial
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			subscription, err := subscribe(ctx)
+			if err != nil {
+				log.Printf("reconciler: group membership consumer subscribe failed: %v", err)
+				if !sleepWithContext(ctx, backoff) {
+					return
+				}
+				backoff *= 2
+				if backoff > groupMembershipRetryMax {
+					backoff = groupMembershipRetryMax
+				}
+				continue
+			}
+			backoff = groupMembershipRetryInitial
+			<-ctx.Done()
+			if subscription != nil {
+				if err := subscription.Unsubscribe(); err != nil {
+					log.Printf("reconciler: group membership consumer unsubscribe failed: %v", err)
+				}
+			}
+			return
+		}
+	}()
+}
+
+func (r *Reconciler) subscribeGroupMembershipEvents(ctx context.Context, natsURL string) (groupMembershipSubscription, error) {
+	if natsURL == "" {
+		return nil, errors.New("nats url is empty")
+	}
+	conn, err := nats.Connect(natsURL)
+	if err != nil {
+		return nil, fmt.Errorf("connect nats: %w", err)
+	}
+	js, err := conn.JetStream()
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("create jetstream context: %w", err)
+	}
+	subscription, err := js.QueueSubscribe(
+		"agyn.groups.membership.*",
+		groupMembershipConsumerName,
+		func(msg *nats.Msg) {
+			if err := r.HandleGroupMembershipEvent(ctx, msg.Subject, msg.Data); err != nil {
+				log.Printf("reconciler: group membership event failed subject=%s: %v", msg.Subject, err)
+				_ = msg.Nak()
+				return
+			}
+			_ = msg.Ack()
+		},
+		nats.Durable(groupMembershipConsumerName),
+		nats.ManualAck(),
+		nats.AckExplicit(),
+	)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("subscribe group membership events: %w", err)
+	}
+	return &natsGroupMembershipSubscription{conn: conn, sub: subscription}, nil
+}
+
+type natsGroupMembershipSubscription struct {
+	conn *nats.Conn
+	sub  *nats.Subscription
+}
+
+func (s *natsGroupMembershipSubscription) Unsubscribe() error {
+	var err error
+	if s.sub != nil {
+		err = s.sub.Unsubscribe()
+	}
+	if s.conn != nil {
+		s.conn.Close()
+	}
+	return err
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/reconciler/group_sync.go
+++ b/internal/reconciler/group_sync.go
@@ -27,10 +27,6 @@ const (
 	groupWorkloadPageSize         = int32(100)
 )
 
-type zitiIdentityPatcher interface {
-	PatchIdentityRoleAttributes(context.Context, *zitimgmtv1.PatchIdentityRoleAttributesRequest, ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error)
-}
-
 type groupsClient interface {
 	ListMemberGroups(context.Context, *groupsv1.ListMemberGroupsRequest, ...grpc.CallOption) (*groupsv1.ListMemberGroupsResponse, error)
 }
@@ -66,10 +62,14 @@ func (r *Reconciler) agentGroupRoleAttributes(ctx context.Context, agentID uuid.
 }
 
 func (r *Reconciler) listAgentGroups(ctx context.Context, agentID uuid.UUID, organizationID string) ([]*groupsv1.Group, error) {
+	groupsCtx, err := r.runnerIdentityContextForAgent(ctx, agentID)
+	if err != nil {
+		return nil, err
+	}
 	groups := []*groupsv1.Group{}
 	pageToken := ""
 	for {
-		response, err := r.groups.ListMemberGroups(ctx, &groupsv1.ListMemberGroupsRequest{
+		response, err := r.groups.ListMemberGroups(groupsCtx, &groupsv1.ListMemberGroupsRequest{
 			MemberType:     groupsv1.GroupMemberType_GROUP_MEMBER_TYPE_AGENT,
 			MemberId:       agentID.String(),
 			OrganizationId: organizationID,
@@ -195,7 +195,7 @@ func (r *Reconciler) patchWorkloadToCurrentGroupRoles(ctx context.Context, workl
 	if err != nil {
 		return err
 	}
-	_, err = r.zitiPatcher.PatchIdentityRoleAttributes(ctx, &zitimgmtv1.PatchIdentityRoleAttributesRequest{
+	_, err = r.zitiMgmt.PatchIdentityRoleAttributes(ctx, &zitimgmtv1.PatchIdentityRoleAttributesRequest{
 		ZitiIdentityId: zitiIdentityID,
 		Add:            desiredAttributes,
 		Remove:         staleCandidateAttributes(desiredAttributes, candidateRemoveAttributes),

--- a/internal/reconciler/group_sync.go
+++ b/internal/reconciler/group_sync.go
@@ -1,0 +1,228 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	groupsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/groups/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	zitimgmtv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/ziti_management/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	groupMembershipRetryInitial = time.Second
+	groupMembershipRetryMax     = 30 * time.Second
+)
+
+const (
+	groupMembershipAddedSubject   = "agyn.groups.membership.added"
+	groupMembershipRemovedSubject = "agyn.groups.membership.removed"
+	groupRoleAttributePrefix      = "group-"
+	groupMembershipPageSize       = int32(100)
+	groupWorkloadPageSize         = int32(100)
+)
+
+type zitiIdentityPatcher interface {
+	PatchIdentityRoleAttributes(context.Context, *zitimgmtv1.PatchIdentityRoleAttributesRequest, ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error)
+}
+
+type groupsClient interface {
+	ListMemberGroups(context.Context, *groupsv1.ListMemberGroupsRequest, ...grpc.CallOption) (*groupsv1.ListMemberGroupsResponse, error)
+}
+
+func groupRoleAttribute(groupID string) string {
+	return groupRoleAttributePrefix + groupID
+}
+
+func (r *Reconciler) agentGroupRoleAttributes(ctx context.Context, agentID uuid.UUID, organizationID string) ([]string, error) {
+	if r.groups == nil {
+		return nil, nil
+	}
+	groups, err := r.listAgentGroups(ctx, agentID, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	roleAttributes := make([]string, 0, len(groups))
+	seen := map[string]struct{}{}
+	for _, group := range groups {
+		groupID := group.GetMeta().GetId()
+		if groupID == "" {
+			return nil, fmt.Errorf("groups list returned group without id")
+		}
+		attribute := groupRoleAttribute(groupID)
+		if _, ok := seen[attribute]; ok {
+			continue
+		}
+		seen[attribute] = struct{}{}
+		roleAttributes = append(roleAttributes, attribute)
+	}
+	sort.Strings(roleAttributes)
+	return roleAttributes, nil
+}
+
+func (r *Reconciler) listAgentGroups(ctx context.Context, agentID uuid.UUID, organizationID string) ([]*groupsv1.Group, error) {
+	groups := []*groupsv1.Group{}
+	pageToken := ""
+	for {
+		response, err := r.groups.ListMemberGroups(ctx, &groupsv1.ListMemberGroupsRequest{
+			MemberType:     groupsv1.GroupMemberType_GROUP_MEMBER_TYPE_AGENT,
+			MemberId:       agentID.String(),
+			OrganizationId: organizationID,
+			PageSize:       groupMembershipPageSize,
+			PageToken:      pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list agent groups: %w", err)
+		}
+		groups = append(groups, response.GetGroups()...)
+		pageToken = response.GetNextPageToken()
+		if pageToken == "" {
+			return groups, nil
+		}
+	}
+}
+
+func (r *Reconciler) HandleGroupMembershipEvent(ctx context.Context, subject string, data []byte) error {
+	switch subject {
+	case groupMembershipAddedSubject:
+		event := &groupsv1.GroupMembershipAddedEvent{}
+		if err := proto.Unmarshal(data, event); err != nil {
+			return fmt.Errorf("unmarshal group membership added event: %w", err)
+		}
+		return r.handleAgentMembershipChange(ctx, event.GetMemberType(), event.GetMemberId(), event.GetGroupId())
+	case groupMembershipRemovedSubject:
+		event := &groupsv1.GroupMembershipRemovedEvent{}
+		if err := proto.Unmarshal(data, event); err != nil {
+			return fmt.Errorf("unmarshal group membership removed event: %w", err)
+		}
+		return r.handleAgentMembershipChange(ctx, event.GetMemberType(), event.GetMemberId(), event.GetGroupId())
+	default:
+		return nil
+	}
+}
+
+func (r *Reconciler) handleAgentMembershipChange(ctx context.Context, memberType groupsv1.GroupMemberType, memberID string, groupID string) error {
+	if memberType != groupsv1.GroupMemberType_GROUP_MEMBER_TYPE_AGENT {
+		return nil
+	}
+	agentID, err := uuid.Parse(memberID)
+	if err != nil {
+		return fmt.Errorf("parse group membership member id: %w", err)
+	}
+	candidateRemoveAttributes := []string{}
+	if groupID != "" {
+		candidateRemoveAttributes = append(candidateRemoveAttributes, groupRoleAttribute(groupID))
+	}
+	return r.patchLiveAgentWorkloadGroupRoles(ctx, agentID, candidateRemoveAttributes)
+}
+
+func (r *Reconciler) patchLiveAgentWorkloadGroupRoles(ctx context.Context, agentID uuid.UUID, candidateRemoveAttributes []string) error {
+	workloads, err := r.listLiveAgentWorkloads(ctx, agentID)
+	if err != nil {
+		return err
+	}
+	for _, workload := range workloads {
+		if err := r.patchWorkloadToCurrentGroupRoles(ctx, workload, candidateRemoveAttributes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) listLiveAgentWorkloads(ctx context.Context, agentID uuid.UUID) ([]*runnersv1.Workload, error) {
+	workloads := []*runnersv1.Workload{}
+	pageToken := ""
+	statuses := []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING,
+	}
+	for {
+		response, err := r.runners.ListWorkloads(runnersContext(ctx), &runnersv1.ListWorkloadsRequest{
+			PageSize:  groupWorkloadPageSize,
+			PageToken: pageToken,
+			Filter: &runnersv1.ListWorkloadsFilter{
+				AgentIdIn: []string{agentID.String()},
+				StatusIn:  statuses,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list live agent workloads: %w", err)
+		}
+		workloads = append(workloads, response.GetWorkloads()...)
+		pageToken = response.GetNextPageToken()
+		if pageToken == "" {
+			return workloads, nil
+		}
+	}
+}
+
+func (r *Reconciler) ReconcileAllAgentGroupRoles(ctx context.Context) error {
+	orgIdentities, err := r.agentIdentityByOrg(ctx)
+	if err != nil {
+		return err
+	}
+	workloads, err := r.listActiveWorkloads(ctx, orgIdentities)
+	if err != nil {
+		return err
+	}
+	for _, workload := range workloads {
+		if err := r.patchWorkloadToCurrentGroupRoles(ctx, workload, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) patchWorkloadToCurrentGroupRoles(ctx context.Context, workload *runnersv1.Workload, candidateRemoveAttributes []string) error {
+	if workload == nil {
+		return fmt.Errorf("workload is nil")
+	}
+	zitiIdentityID := workload.GetZitiIdentityId()
+	if zitiIdentityID == "" {
+		return nil
+	}
+	agentID, err := uuid.Parse(workload.GetAgentId())
+	if err != nil {
+		return fmt.Errorf("parse workload agent id: %w", err)
+	}
+	desiredAttributes, err := r.agentGroupRoleAttributes(ctx, agentID, workload.GetOrganizationId())
+	if err != nil {
+		return err
+	}
+	_, err = r.zitiPatcher.PatchIdentityRoleAttributes(ctx, &zitimgmtv1.PatchIdentityRoleAttributesRequest{
+		ZitiIdentityId: zitiIdentityID,
+		Add:            desiredAttributes,
+		Remove:         staleCandidateAttributes(desiredAttributes, candidateRemoveAttributes),
+	})
+	if err != nil {
+		return fmt.Errorf("patch agent workload role attributes: %w", err)
+	}
+	return nil
+}
+
+func staleCandidateAttributes(desiredAttributes []string, candidateAttributes []string) []string {
+	desired := make(map[string]struct{}, len(desiredAttributes))
+	for _, attr := range desiredAttributes {
+		desired[attr] = struct{}{}
+	}
+	remove := []string{}
+	seen := map[string]struct{}{}
+	for _, attr := range candidateAttributes {
+		if _, ok := desired[attr]; ok {
+			continue
+		}
+		if _, ok := seen[attr]; ok {
+			continue
+		}
+		seen[attr] = struct{}{}
+		remove = append(remove, attr)
+	}
+	sort.Strings(remove)
+	return remove
+}

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
@@ -193,6 +194,7 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 	if fakeGroups.requests[0].GetMemberId() != agentID.String() {
 		t.Fatalf("expected groups lookup by agent id %s, got %s", agentID, fakeGroups.requests[0].GetMemberId())
 	}
+	assertStringSet(t, fakeGroups.identityIDs, []string{agentID.String()})
 	if !reflect.DeepEqual(calls, []string{"dial", "create", "create-workload", "start", "update-workload"}) {
 		t.Fatalf("unexpected call order: %v", calls)
 	}
@@ -1347,6 +1349,7 @@ func TestGroupMembershipEventPatchesLiveWorkloads(t *testing.T) {
 	if len(patchRequest.GetRemove()) != 0 {
 		t.Fatalf("expected no removals, got %v", patchRequest.GetRemove())
 	}
+	assertStringSet(t, fakeGroups.identityIDs, []string{agentID.String()})
 }
 
 func TestGroupMembershipEventsAreDuplicateAndOutOfOrderSafe(t *testing.T) {
@@ -1452,6 +1455,7 @@ func TestReconcileAllAgentGroupRolesPatchesMissingDesiredAttrs(t *testing.T) {
 	if len(patchRequest.GetRemove()) != 0 {
 		t.Fatalf("expected no removals, got %v", patchRequest.GetRemove())
 	}
+	assertStringSet(t, fakeGroups.identityIDs, []string{agentID.String()})
 }
 
 func TestGroupMembershipConsumerLoopRetriesWithoutBlocking(t *testing.T) {
@@ -2021,6 +2025,7 @@ func (f *fakeZitiMgmtClient) DeleteDeviceIdentity(ctx context.Context, req *ziti
 type fakeGroupsClient struct {
 	groupsByOrg map[string][]*groupsv1.Group
 	requests    []*groupsv1.ListMemberGroupsRequest
+	identityIDs []string
 }
 
 func (f *fakeGroupsClient) CreateGroup(context.Context, *groupsv1.CreateGroupRequest, ...grpc.CallOption) (*groupsv1.CreateGroupResponse, error) {
@@ -2055,8 +2060,10 @@ func (f *fakeGroupsClient) ListMembers(context.Context, *groupsv1.ListMembersReq
 	return nil, errNotImplemented
 }
 
-func (f *fakeGroupsClient) ListMemberGroups(_ context.Context, request *groupsv1.ListMemberGroupsRequest, _ ...grpc.CallOption) (*groupsv1.ListMemberGroupsResponse, error) {
-	f.requests = append(f.requests, request)
+func (f *fakeGroupsClient) ListMemberGroups(ctx context.Context, request *groupsv1.ListMemberGroupsRequest, _ ...grpc.CallOption) (*groupsv1.ListMemberGroupsResponse, error) {
+	metadataValues, _ := metadata.FromOutgoingContext(ctx)
+	f.identityIDs = append(f.identityIDs, metadataValues.Get(identityMetadataKey)...)
+	f.requests = append(f.requests, proto.Clone(request).(*groupsv1.ListMemberGroupsRequest))
 	return &groupsv1.ListMemberGroupsResponse{Groups: append([]*groupsv1.Group{}, f.groupsByOrg[request.GetOrganizationId()]...)}, nil
 }
 

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	groupsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/groups/v1"
 	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
@@ -20,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -47,6 +50,7 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 	zitiMgmt := &fakeZitiMgmtClient{
 		createAgentIdentity: func(_ context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 			calls = append(calls, "create")
+			assertStringSet(t, req.GetAdditionalRoleAttributes(), []string{groupRoleAttribute("group-a"), groupRoleAttribute("group-b")})
 			if req.GetAgentId() != agentID.String() {
 				return nil, errors.New("unexpected agent id")
 			}
@@ -172,14 +176,23 @@ func TestStartWorkloadCreatesIdentityAndStores(t *testing.T) {
 		},
 	}
 
+	fakeGroups := &fakeGroupsClient{groupsByOrg: map[string][]*groupsv1.Group{testOrganizationID: {{Meta: &groupsv1.EntityMeta{Id: "group-b"}}, {Meta: &groupsv1.EntityMeta{Id: "group-a"}}, {Meta: &groupsv1.EntityMeta{Id: "group-a"}}}}}
+
 	reconciler := newTestReconciler(Config{
 		RunnerDialer: runnerDialer,
 		Runners:      runners,
 		ZitiMgmt:     zitiMgmt,
+		Groups:       fakeGroups,
 		Assembler:    testAssembler,
 	})
 	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
 
+	if len(fakeGroups.requests) != 1 {
+		t.Fatalf("expected one groups lookup, got %d", len(fakeGroups.requests))
+	}
+	if fakeGroups.requests[0].GetMemberId() != agentID.String() {
+		t.Fatalf("expected groups lookup by agent id %s, got %s", agentID, fakeGroups.requests[0].GetMemberId())
+	}
 	if !reflect.DeepEqual(calls, []string{"dial", "create", "create-workload", "start", "update-workload"}) {
 		t.Fatalf("unexpected call order: %v", calls)
 	}
@@ -1284,6 +1297,209 @@ func TestFetchActualSkipsMissingRunnerID(t *testing.T) {
 	}
 }
 
+func TestGroupMembershipEventPatchesLiveWorkloads(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	groupID := "group-a"
+	zitiID := "ziti-workload-1"
+	var listRequest *runnersv1.ListWorkloadsRequest
+	var patchRequest *zitimgmtv1.PatchIdentityRoleAttributesRequest
+
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, req *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			listRequest = req
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{{
+				Meta:           &runnersv1.EntityMeta{Id: "workload-1"},
+				AgentId:        agentID.String(),
+				OrganizationId: testOrganizationID,
+				ZitiIdentityId: zitiID,
+			}}}, nil
+		},
+	}
+	zitiMgmt := &fakeZitiMgmtClient{
+		patchIdentityRoleAttributes: func(_ context.Context, req *zitimgmtv1.PatchIdentityRoleAttributesRequest, _ ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error) {
+			patchRequest = req
+			return &zitimgmtv1.PatchIdentityRoleAttributesResponse{}, nil
+		},
+	}
+	fakeGroups := &fakeGroupsClient{groupsByOrg: map[string][]*groupsv1.Group{testOrganizationID: {{Meta: &groupsv1.EntityMeta{Id: groupID}}}}}
+	reconciler := newTestReconciler(Config{Runners: runners, ZitiMgmt: zitiMgmt, Groups: fakeGroups})
+	payload := mustMarshal(t, &groupsv1.GroupMembershipAddedEvent{
+		GroupId:    groupID,
+		MemberType: groupsv1.GroupMemberType_GROUP_MEMBER_TYPE_AGENT,
+		MemberId:   agentID.String(),
+	})
+
+	if err := reconciler.HandleGroupMembershipEvent(ctx, groupMembershipAddedSubject, payload); err != nil {
+		t.Fatalf("HandleGroupMembershipEvent: %v", err)
+	}
+	if listRequest == nil {
+		t.Fatal("expected live workload lookup")
+	}
+	assertStringSet(t, listRequest.GetFilter().GetAgentIdIn(), []string{agentID.String()})
+	if patchRequest == nil {
+		t.Fatal("expected ziti patch")
+	}
+	if patchRequest.GetZitiIdentityId() != zitiID {
+		t.Fatalf("expected ziti identity %s, got %s", zitiID, patchRequest.GetZitiIdentityId())
+	}
+	assertStringSet(t, patchRequest.GetAdd(), []string{groupRoleAttribute(groupID)})
+	if len(patchRequest.GetRemove()) != 0 {
+		t.Fatalf("expected no removals, got %v", patchRequest.GetRemove())
+	}
+}
+
+func TestGroupMembershipEventsAreDuplicateAndOutOfOrderSafe(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	groupID := "group-a"
+	zitiID := "ziti-workload-1"
+	patchRequests := []*zitimgmtv1.PatchIdentityRoleAttributesRequest{}
+	runners := &fakeRunnersClient{
+		listWorkloads: func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{{
+				Meta:           &runnersv1.EntityMeta{Id: "workload-1"},
+				AgentId:        agentID.String(),
+				OrganizationId: testOrganizationID,
+				ZitiIdentityId: zitiID,
+			}}}, nil
+		},
+	}
+	zitiMgmt := &fakeZitiMgmtClient{
+		patchIdentityRoleAttributes: func(_ context.Context, req *zitimgmtv1.PatchIdentityRoleAttributesRequest, _ ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error) {
+			patchRequests = append(patchRequests, req)
+			return &zitimgmtv1.PatchIdentityRoleAttributesResponse{}, nil
+		},
+	}
+	fakeGroups := &fakeGroupsClient{groupsByOrg: map[string][]*groupsv1.Group{testOrganizationID: {}}}
+	reconciler := newTestReconciler(Config{Runners: runners, ZitiMgmt: zitiMgmt, Groups: fakeGroups})
+	removed := mustMarshal(t, &groupsv1.GroupMembershipRemovedEvent{
+		GroupId:    groupID,
+		MemberType: groupsv1.GroupMemberType_GROUP_MEMBER_TYPE_AGENT,
+		MemberId:   agentID.String(),
+	})
+	added := mustMarshal(t, &groupsv1.GroupMembershipAddedEvent{
+		GroupId:    groupID,
+		MemberType: groupsv1.GroupMemberType_GROUP_MEMBER_TYPE_AGENT,
+		MemberId:   agentID.String(),
+	})
+
+	if err := reconciler.HandleGroupMembershipEvent(ctx, groupMembershipRemovedSubject, removed); err != nil {
+		t.Fatalf("remove event: %v", err)
+	}
+	if err := reconciler.HandleGroupMembershipEvent(ctx, groupMembershipRemovedSubject, removed); err != nil {
+		t.Fatalf("duplicate remove event: %v", err)
+	}
+	if err := reconciler.HandleGroupMembershipEvent(ctx, groupMembershipAddedSubject, added); err != nil {
+		t.Fatalf("out-of-order add event: %v", err)
+	}
+	if len(patchRequests) != 3 {
+		t.Fatalf("expected three patch requests, got %d", len(patchRequests))
+	}
+	for _, request := range patchRequests {
+		if len(request.GetAdd()) != 0 {
+			t.Fatalf("expected no adds while source-of-truth is empty, got %v", request.GetAdd())
+		}
+		assertStringSet(t, request.GetRemove(), []string{groupRoleAttribute(groupID)})
+	}
+
+	fakeGroups.groupsByOrg[testOrganizationID] = []*groupsv1.Group{{Meta: &groupsv1.EntityMeta{Id: groupID}}}
+	if err := reconciler.HandleGroupMembershipEvent(ctx, groupMembershipAddedSubject, added); err != nil {
+		t.Fatalf("add event: %v", err)
+	}
+	last := patchRequests[len(patchRequests)-1]
+	assertStringSet(t, last.GetAdd(), []string{groupRoleAttribute(groupID)})
+	if len(last.GetRemove()) != 0 {
+		t.Fatalf("expected no removal for desired group, got %v", last.GetRemove())
+	}
+}
+
+func TestReconcileAllAgentGroupRolesPatchesMissingDesiredAttrs(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	groupID := "group-a"
+	zitiID := "ziti-workload-1"
+	var patchRequest *zitimgmtv1.PatchIdentityRoleAttributesRequest
+	agents := &testutil.FakeAgentsClient{ListAgentsFunc: func(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+		return &agentsv1.ListAgentsResponse{Agents: []*agentsv1.Agent{{
+			Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
+			OrganizationId: testOrganizationID,
+		}}}, nil
+	}}
+	runners := &fakeRunnersClient{listWorkloads: func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+		return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{{
+			Meta:           &runnersv1.EntityMeta{Id: "workload-1"},
+			RunnerId:       "runner-1",
+			AgentId:        agentID.String(),
+			OrganizationId: testOrganizationID,
+			ZitiIdentityId: zitiID,
+		}}}, nil
+	}}
+	zitiMgmt := &fakeZitiMgmtClient{patchIdentityRoleAttributes: func(_ context.Context, req *zitimgmtv1.PatchIdentityRoleAttributesRequest, _ ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error) {
+		patchRequest = req
+		return &zitimgmtv1.PatchIdentityRoleAttributesResponse{}, nil
+	}}
+	fakeGroups := &fakeGroupsClient{groupsByOrg: map[string][]*groupsv1.Group{testOrganizationID: {{Meta: &groupsv1.EntityMeta{Id: groupID}}}}}
+	reconciler := newTestReconciler(Config{Agents: agents, Runners: runners, ZitiMgmt: zitiMgmt, Groups: fakeGroups})
+
+	if err := reconciler.ReconcileAllAgentGroupRoles(ctx); err != nil {
+		t.Fatalf("ReconcileAllAgentGroupRoles: %v", err)
+	}
+	if patchRequest == nil {
+		t.Fatal("expected ziti patch")
+	}
+	assertStringSet(t, patchRequest.GetAdd(), []string{groupRoleAttribute(groupID)})
+	if len(patchRequest.GetRemove()) != 0 {
+		t.Fatalf("expected no removals, got %v", patchRequest.GetRemove())
+	}
+}
+
+func TestGroupMembershipConsumerLoopRetriesWithoutBlocking(t *testing.T) {
+	originalInitial := groupMembershipRetryInitial
+	originalMax := groupMembershipRetryMax
+	groupMembershipRetryInitial = time.Millisecond
+	groupMembershipRetryMax = time.Millisecond
+	defer func() {
+		groupMembershipRetryInitial = originalInitial
+		groupMembershipRetryMax = originalMax
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	subscription := &fakeGroupMembershipSubscription{}
+	var attempts int32
+	reconciler := newTestReconciler(Config{})
+	reconciler.StartGroupMembershipConsumerLoopWithSubscriber(ctx, func(context.Context) (groupMembershipSubscription, error) {
+		attempt := atomic.AddInt32(&attempts, 1)
+		if attempt < 2 {
+			return nil, errors.New("nats unavailable")
+		}
+		return subscription, nil
+	})
+
+	deadline := time.After(time.Second)
+	for atomic.LoadInt32(&attempts) < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("expected retry without blocking")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if subscription.unsubscribed {
+		t.Fatalf("did not expect unsubscribe before cancellation")
+	}
+	cancel()
+	deadline = time.After(time.Second)
+	for !subscription.unsubscribed {
+		select {
+		case <-deadline:
+			t.Fatalf("expected unsubscribe after cancellation")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
 func newTestReconciler(cfg Config) *Reconciler {
 	if cfg.Poll == 0 {
 		cfg.Poll = time.Second
@@ -1661,26 +1877,41 @@ func (f *fakeRunnerClient) CancelExecution(context.Context, *runnerv1.CancelExec
 }
 
 type fakeZitiMgmtClient struct {
-	createAgentIdentity    func(context.Context, *zitimgmtv1.CreateAgentIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error)
-	createAppIdentity      func(context.Context, *zitimgmtv1.CreateAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAppIdentityResponse, error)
-	createService          func(context.Context, *zitimgmtv1.CreateServiceRequest, ...grpc.CallOption) (*zitimgmtv1.CreateServiceResponse, error)
-	createRunnerIdentity   func(context.Context, *zitimgmtv1.CreateRunnerIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateRunnerIdentityResponse, error)
-	deleteAppIdentity      func(context.Context, *zitimgmtv1.DeleteAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteAppIdentityResponse, error)
-	deleteIdentity         func(context.Context, *zitimgmtv1.DeleteIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteIdentityResponse, error)
-	deleteRunnerIdentity   func(context.Context, *zitimgmtv1.DeleteRunnerIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteRunnerIdentityResponse, error)
-	listManagedIdentities  func(context.Context, *zitimgmtv1.ListManagedIdentitiesRequest, ...grpc.CallOption) (*zitimgmtv1.ListManagedIdentitiesResponse, error)
-	requestServiceIdentity func(context.Context, *zitimgmtv1.RequestServiceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.RequestServiceIdentityResponse, error)
-	extendIdentityLease    func(context.Context, *zitimgmtv1.ExtendIdentityLeaseRequest, ...grpc.CallOption) (*zitimgmtv1.ExtendIdentityLeaseResponse, error)
-	createServicePolicy    func(context.Context, *zitimgmtv1.CreateServicePolicyRequest, ...grpc.CallOption) (*zitimgmtv1.CreateServicePolicyResponse, error)
-	deleteServicePolicy    func(context.Context, *zitimgmtv1.DeleteServicePolicyRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteServicePolicyResponse, error)
-	deleteService          func(context.Context, *zitimgmtv1.DeleteServiceRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteServiceResponse, error)
-	createDeviceIdentity   func(context.Context, *zitimgmtv1.CreateDeviceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateDeviceIdentityResponse, error)
-	deleteDeviceIdentity   func(context.Context, *zitimgmtv1.DeleteDeviceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteDeviceIdentityResponse, error)
+	createAgentIdentity         func(context.Context, *zitimgmtv1.CreateAgentIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error)
+	patchIdentityRoleAttributes func(context.Context, *zitimgmtv1.PatchIdentityRoleAttributesRequest, ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error)
+	createAppIdentity           func(context.Context, *zitimgmtv1.CreateAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAppIdentityResponse, error)
+	createService               func(context.Context, *zitimgmtv1.CreateServiceRequest, ...grpc.CallOption) (*zitimgmtv1.CreateServiceResponse, error)
+	createRunnerIdentity        func(context.Context, *zitimgmtv1.CreateRunnerIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateRunnerIdentityResponse, error)
+	deleteAppIdentity           func(context.Context, *zitimgmtv1.DeleteAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteAppIdentityResponse, error)
+	deleteIdentity              func(context.Context, *zitimgmtv1.DeleteIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteIdentityResponse, error)
+	deleteRunnerIdentity        func(context.Context, *zitimgmtv1.DeleteRunnerIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteRunnerIdentityResponse, error)
+	listManagedIdentities       func(context.Context, *zitimgmtv1.ListManagedIdentitiesRequest, ...grpc.CallOption) (*zitimgmtv1.ListManagedIdentitiesResponse, error)
+	requestServiceIdentity      func(context.Context, *zitimgmtv1.RequestServiceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.RequestServiceIdentityResponse, error)
+	extendIdentityLease         func(context.Context, *zitimgmtv1.ExtendIdentityLeaseRequest, ...grpc.CallOption) (*zitimgmtv1.ExtendIdentityLeaseResponse, error)
+	createServicePolicy         func(context.Context, *zitimgmtv1.CreateServicePolicyRequest, ...grpc.CallOption) (*zitimgmtv1.CreateServicePolicyResponse, error)
+	deleteServicePolicy         func(context.Context, *zitimgmtv1.DeleteServicePolicyRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteServicePolicyResponse, error)
+	deleteService               func(context.Context, *zitimgmtv1.DeleteServiceRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteServiceResponse, error)
+	createDeviceIdentity        func(context.Context, *zitimgmtv1.CreateDeviceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateDeviceIdentityResponse, error)
+	deleteDeviceIdentity        func(context.Context, *zitimgmtv1.DeleteDeviceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteDeviceIdentityResponse, error)
+	createTunnelIdentity        func(context.Context, *zitimgmtv1.CreateTunnelIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateTunnelIdentityResponse, error)
+	deleteTunnelIdentity        func(context.Context, *zitimgmtv1.DeleteTunnelIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteTunnelIdentityResponse, error)
+	listServicesByTag           func(context.Context, *zitimgmtv1.ListServicesByTagRequest, ...grpc.CallOption) (*zitimgmtv1.ListServicesByTagResponse, error)
+	listIdentitiesByTag         func(context.Context, *zitimgmtv1.ListIdentitiesByTagRequest, ...grpc.CallOption) (*zitimgmtv1.ListIdentitiesByTagResponse, error)
+	listServicePoliciesByTag    func(context.Context, *zitimgmtv1.ListServicePoliciesByTagRequest, ...grpc.CallOption) (*zitimgmtv1.ListServicePoliciesByTagResponse, error)
+	updateService               func(context.Context, *zitimgmtv1.UpdateServiceRequest, ...grpc.CallOption) (*zitimgmtv1.UpdateServiceResponse, error)
+	getIdentityLiveness         func(context.Context, *zitimgmtv1.GetIdentityLivenessRequest, ...grpc.CallOption) (*zitimgmtv1.GetIdentityLivenessResponse, error)
 }
 
 func (f *fakeZitiMgmtClient) CreateAgentIdentity(ctx context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 	if f.createAgentIdentity != nil {
 		return f.createAgentIdentity(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) PatchIdentityRoleAttributes(ctx context.Context, req *zitimgmtv1.PatchIdentityRoleAttributesRequest, opts ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error) {
+	if f.patchIdentityRoleAttributes != nil {
+		return f.patchIdentityRoleAttributes(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }
@@ -1783,6 +2014,138 @@ func (f *fakeZitiMgmtClient) CreateDeviceIdentity(ctx context.Context, req *ziti
 func (f *fakeZitiMgmtClient) DeleteDeviceIdentity(ctx context.Context, req *zitimgmtv1.DeleteDeviceIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.DeleteDeviceIdentityResponse, error) {
 	if f.deleteDeviceIdentity != nil {
 		return f.deleteDeviceIdentity(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+type fakeGroupsClient struct {
+	groupsByOrg map[string][]*groupsv1.Group
+	requests    []*groupsv1.ListMemberGroupsRequest
+}
+
+func (f *fakeGroupsClient) CreateGroup(context.Context, *groupsv1.CreateGroupRequest, ...grpc.CallOption) (*groupsv1.CreateGroupResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeGroupsClient) GetGroup(context.Context, *groupsv1.GetGroupRequest, ...grpc.CallOption) (*groupsv1.GetGroupResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeGroupsClient) ListGroups(context.Context, *groupsv1.ListGroupsRequest, ...grpc.CallOption) (*groupsv1.ListGroupsResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeGroupsClient) UpdateGroup(context.Context, *groupsv1.UpdateGroupRequest, ...grpc.CallOption) (*groupsv1.UpdateGroupResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeGroupsClient) DeleteGroup(context.Context, *groupsv1.DeleteGroupRequest, ...grpc.CallOption) (*groupsv1.DeleteGroupResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeGroupsClient) AddMember(context.Context, *groupsv1.AddMemberRequest, ...grpc.CallOption) (*groupsv1.AddMemberResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeGroupsClient) RemoveMember(context.Context, *groupsv1.RemoveMemberRequest, ...grpc.CallOption) (*groupsv1.RemoveMemberResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeGroupsClient) ListMembers(context.Context, *groupsv1.ListMembersRequest, ...grpc.CallOption) (*groupsv1.ListMembersResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeGroupsClient) ListMemberGroups(_ context.Context, request *groupsv1.ListMemberGroupsRequest, _ ...grpc.CallOption) (*groupsv1.ListMemberGroupsResponse, error) {
+	f.requests = append(f.requests, request)
+	return &groupsv1.ListMemberGroupsResponse{Groups: append([]*groupsv1.Group{}, f.groupsByOrg[request.GetOrganizationId()]...)}, nil
+}
+
+func (f *fakeGroupsClient) ListMemberGroupsBatch(context.Context, *groupsv1.ListMemberGroupsBatchRequest, ...grpc.CallOption) (*groupsv1.ListMemberGroupsBatchResponse, error) {
+	return nil, errNotImplemented
+}
+
+type fakeGroupMembershipSubscription struct {
+	unsubscribed bool
+}
+
+func (s *fakeGroupMembershipSubscription) Unsubscribe() error {
+	s.unsubscribed = true
+	return nil
+}
+
+func mustMarshal(t *testing.T, message proto.Message) []byte {
+	t.Helper()
+	data, err := proto.Marshal(message)
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+	return data
+}
+
+func assertStringSet(t *testing.T, actual []string, expected []string) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
+	counts := map[string]int{}
+	for _, value := range actual {
+		counts[value]++
+	}
+	for _, value := range expected {
+		counts[value]--
+	}
+	for value, count := range counts {
+		if count != 0 {
+			t.Fatalf("expected %v, got %v; mismatch on %s", expected, actual, value)
+		}
+	}
+}
+
+func (f *fakeZitiMgmtClient) CreateTunnelIdentity(ctx context.Context, req *zitimgmtv1.CreateTunnelIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateTunnelIdentityResponse, error) {
+	if f.createTunnelIdentity != nil {
+		return f.createTunnelIdentity(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) DeleteTunnelIdentity(ctx context.Context, req *zitimgmtv1.DeleteTunnelIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.DeleteTunnelIdentityResponse, error) {
+	if f.deleteTunnelIdentity != nil {
+		return f.deleteTunnelIdentity(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) ListServicesByTag(ctx context.Context, req *zitimgmtv1.ListServicesByTagRequest, opts ...grpc.CallOption) (*zitimgmtv1.ListServicesByTagResponse, error) {
+	if f.listServicesByTag != nil {
+		return f.listServicesByTag(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) ListIdentitiesByTag(ctx context.Context, req *zitimgmtv1.ListIdentitiesByTagRequest, opts ...grpc.CallOption) (*zitimgmtv1.ListIdentitiesByTagResponse, error) {
+	if f.listIdentitiesByTag != nil {
+		return f.listIdentitiesByTag(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) UpdateService(ctx context.Context, req *zitimgmtv1.UpdateServiceRequest, opts ...grpc.CallOption) (*zitimgmtv1.UpdateServiceResponse, error) {
+	if f.updateService != nil {
+		return f.updateService(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) GetIdentityLiveness(ctx context.Context, req *zitimgmtv1.GetIdentityLivenessRequest, opts ...grpc.CallOption) (*zitimgmtv1.GetIdentityLivenessResponse, error) {
+	if f.getIdentityLiveness != nil {
+		return f.getIdentityLiveness(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) ListServicePoliciesByTag(ctx context.Context, req *zitimgmtv1.ListServicePoliciesByTagRequest, opts ...grpc.CallOption) (*zitimgmtv1.ListServicePoliciesByTagResponse, error) {
+	if f.listServicePoliciesByTag != nil {
+		return f.listServicePoliciesByTag(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -33,7 +33,6 @@ type Reconciler struct {
 	metering                  meteringv1.MeteringServiceClient
 	meteringSampleInterval    time.Duration
 	zitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
-	zitiPatcher               zitiIdentityPatcher
 	groups                    groupsClient
 	assembler                 *assembler.Assembler
 	wake                      <-chan struct{}
@@ -50,7 +49,6 @@ type Config struct {
 	Runners                   runnersv1.RunnersServiceClient
 	Metering                  meteringv1.MeteringServiceClient
 	ZitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
-	ZitiPatcher               zitiIdentityPatcher
 	Groups                    groupsClient
 	Assembler                 *assembler.Assembler
 	Wake                      <-chan struct{}
@@ -62,9 +60,6 @@ type Config struct {
 }
 
 func New(cfg Config) *Reconciler {
-	if cfg.ZitiPatcher == nil {
-		cfg.ZitiPatcher = cfg.ZitiMgmt
-	}
 	return &Reconciler{
 		threads:                   cfg.Threads,
 		agents:                    cfg.Agents,
@@ -73,7 +68,6 @@ func New(cfg Config) *Reconciler {
 		metering:                  cfg.Metering,
 		meteringSampleInterval:    cfg.MeteringSampleInterval,
 		zitiMgmt:                  cfg.ZitiMgmt,
-		zitiPatcher:               cfg.ZitiPatcher,
 		groups:                    cfg.Groups,
 		assembler:                 cfg.Assembler,
 		wake:                      cfg.Wake,
@@ -154,7 +148,7 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 			return err
 		}
 	}
-	if r.zitiPatcher != nil && r.groups != nil {
+	if r.zitiMgmt != nil && r.groups != nil {
 		if err := r.ReconcileAllAgentGroupRoles(ctx); err != nil {
 			return err
 		}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -33,6 +33,8 @@ type Reconciler struct {
 	metering                  meteringv1.MeteringServiceClient
 	meteringSampleInterval    time.Duration
 	zitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
+	zitiPatcher               zitiIdentityPatcher
+	groups                    groupsClient
 	assembler                 *assembler.Assembler
 	wake                      <-chan struct{}
 	poll                      time.Duration
@@ -48,6 +50,8 @@ type Config struct {
 	Runners                   runnersv1.RunnersServiceClient
 	Metering                  meteringv1.MeteringServiceClient
 	ZitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
+	ZitiPatcher               zitiIdentityPatcher
+	Groups                    groupsClient
 	Assembler                 *assembler.Assembler
 	Wake                      <-chan struct{}
 	Poll                      time.Duration
@@ -58,6 +62,9 @@ type Config struct {
 }
 
 func New(cfg Config) *Reconciler {
+	if cfg.ZitiPatcher == nil {
+		cfg.ZitiPatcher = cfg.ZitiMgmt
+	}
 	return &Reconciler{
 		threads:                   cfg.Threads,
 		agents:                    cfg.Agents,
@@ -66,6 +73,8 @@ func New(cfg Config) *Reconciler {
 		metering:                  cfg.Metering,
 		meteringSampleInterval:    cfg.MeteringSampleInterval,
 		zitiMgmt:                  cfg.ZitiMgmt,
+		zitiPatcher:               cfg.ZitiPatcher,
+		groups:                    cfg.Groups,
 		assembler:                 cfg.Assembler,
 		wake:                      cfg.Wake,
 		poll:                      cfg.Poll,
@@ -145,6 +154,11 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 			return err
 		}
 	}
+	if r.zitiPatcher != nil && r.groups != nil {
+		if err := r.ReconcileAllAgentGroupRoles(ctx); err != nil {
+			return err
+		}
+	}
 	log.Printf(
 		"reconciler: cycle complete - desired=%d actual=%d started=%d stopped=%d",
 		len(desired),
@@ -167,13 +181,18 @@ func (i *identityInfo) idPtr() *string {
 	return &i.id
 }
 
-func (r *Reconciler) createIdentity(ctx context.Context, target AgentThread, workloadID uuid.UUID) (*identityInfo, error) {
+func (r *Reconciler) createIdentity(ctx context.Context, target AgentThread, workloadID uuid.UUID, organizationID string) (*identityInfo, error) {
 	if r.zitiMgmt == nil {
 		return nil, nil
 	}
+	roleAttributes, err := r.agentGroupRoleAttributes(ctx, target.AgentID, organizationID)
+	if err != nil {
+		return nil, fmt.Errorf("list groups for agent %s thread %s: %w", target.AgentID.String(), target.ThreadID.String(), err)
+	}
 	identityResp, err := r.zitiMgmt.CreateAgentIdentity(ctx, &zitimgmtv1.CreateAgentIdentityRequest{
-		AgentId:    target.AgentID.String(),
-		WorkloadId: workloadID.String(),
+		AgentId:                  target.AgentID.String(),
+		WorkloadId:               workloadID.String(),
+		AdditionalRoleAttributes: roleAttributes,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create ziti identity for agent %s thread %s: %w", target.AgentID.String(), target.ThreadID.String(), err)
@@ -259,7 +278,7 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 	}
 	request.WorkloadId = workloadIDValue
 	request.Main.Env = append(request.Main.Env, &runnerv1.EnvVar{Name: "WORKLOAD_ID", Value: workloadIDValue})
-	identity, err := r.createIdentity(ctx, target, workloadID)
+	identity, err := r.createIdentity(ctx, target, workloadID, assembled.OrganizationID)
 	if err != nil {
 		log.Printf("reconciler: %v", err)
 		return

--- a/internal/zitimanager/manager_test.go
+++ b/internal/zitimanager/manager_test.go
@@ -634,3 +634,35 @@ func (f *fakeZitiContext) Events() ziti.Eventer { return nil }
 func (f *fakeZitiContext) Inspect() *inspect.ContextInspectResult { return nil }
 
 var errNotImplemented = errors.New("not implemented")
+
+func (f *fakeZitiMgmtClient) CreateTunnelIdentity(context.Context, *zitimgmtv1.CreateTunnelIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateTunnelIdentityResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) DeleteTunnelIdentity(context.Context, *zitimgmtv1.DeleteTunnelIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.DeleteTunnelIdentityResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) PatchIdentityRoleAttributes(context.Context, *zitimgmtv1.PatchIdentityRoleAttributesRequest, ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) GetIdentityLiveness(context.Context, *zitimgmtv1.GetIdentityLivenessRequest, ...grpc.CallOption) (*zitimgmtv1.GetIdentityLivenessResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) ListServicesByTag(context.Context, *zitimgmtv1.ListServicesByTagRequest, ...grpc.CallOption) (*zitimgmtv1.ListServicesByTagResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) ListIdentitiesByTag(context.Context, *zitimgmtv1.ListIdentitiesByTagRequest, ...grpc.CallOption) (*zitimgmtv1.ListIdentitiesByTagResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) ListServicePoliciesByTag(context.Context, *zitimgmtv1.ListServicePoliciesByTagRequest, ...grpc.CallOption) (*zitimgmtv1.ListServicePoliciesByTagResponse, error) {
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) UpdateService(context.Context, *zitimgmtv1.UpdateServiceRequest, ...grpc.CallOption) (*zitimgmtv1.UpdateServiceResponse, error) {
+	return nil, errNotImplemented
+}


### PR DESCRIPTION
## Summary
- Bootstraps agent workload Ziti identities with `group-*` attrs from Groups.
- Adds a durable, non-blocking NATS/JetStream group membership consumer.
- Patches live agent workload identities on group add/remove events by re-reading Groups source-of-truth.
- Adds reconciliation to repair live workload group-role drift.
- Wires Groups/NATS config and proto generation across CI, Docker, DevSpace, and chart values.

References #154

## Validation
- `buf generate --template buf.gen.yaml` — passed
- `CGO_ENABLED=0 go test ./... -count=1` — 161 passed, 0 failed, 0 skipped
- `CGO_ENABLED=0 go vet ./...` — passed with no errors
- `CGO_ENABLED=0 go build ./...` — passed
- `git diff --check` — passed
- `docker build --target build --progress=plain --network=host -t agents-orchestrator-group-sync-check .` — passed

Note: local Go checks were run with `CGO_ENABLED=0` because the local environment does not have `gcc`.