### PR TITLE
ci(e2e): bump agent init images

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,11 +18,11 @@ on:
 env:
   BOOTSTRAP_REF: main
   K8S_RUNNER_REF: main
-  CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.38
-  AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.38
-  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.6
-  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.6
-  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.29
+  CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.40
+  AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13.40
+  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.8
+  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.5.8
+  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1.31
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #222

## Summary
- Bump AO E2E Codex init image pins to `ghcr.io/agynio/agent-init-codex:0.13.40`.
- Bump AO E2E Agn init image pins to `ghcr.io/agynio/agent-init-agn:0.5.8`.
- Bump AO E2E Claude init image pin to `ghcr.io/agynio/agent-init-claude:0.1.31`.

Note: `origin/noa/issue-222` already existed from an old unrelated branch with no open PR, so this rollout PR uses `noa/issue-222-rollout` and still closes #222.

## Validation
- `git diff --check`: passed with no whitespace errors.
- Workflow pin assertions for all five expected image env vars: 5 passed / 0 failed.
- `docker manifest inspect ghcr.io/agynio/agent-init-codex:0.13.40`: passed.
- `docker manifest inspect ghcr.io/agynio/agent-init-agn:0.5.8`: passed.
- `docker manifest inspect ghcr.io/agynio/agent-init-claude:0.1.31`: passed.
- `CGO_ENABLED=0 go test ./...`: 8 packages passed / 0 failed / 5 packages with no test files.
- `CGO_ENABLED=0 go build ./...`: build passed.
- `helm dependency build charts/agents-orchestrator && helm lint charts/agents-orchestrator`: 1 chart linted / 0 failed.