### PR TITLE
feat(orchestrator): add sandbox reconciler foundation

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -127,6 +127,8 @@ env:
     value: "ghcr.io/agynio/agent-init-codex:latest"
   - name: SANDBOX_WORKSPACE_SIZE_GB
     value: "10"
+  - name: SANDBOX_RECONCILE_ENABLED
+    value: "false"
   - name: POLL_INTERVAL
     value: "5s"
   - name: IDLE_TIMEOUT

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -129,6 +129,8 @@ env:
     value: "10"
   - name: SANDBOX_RECONCILE_ENABLED
     value: "false"
+  - name: SANDBOX_RECONCILE_ORGANIZATION_IDS
+    value: ""
   - name: POLL_INTERVAL
     value: "5s"
   - name: IDLE_TIMEOUT

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -123,6 +123,10 @@ env:
     value: ""
   - name: AGENT_TRACING_ADDRESS
     value: ""
+  - name: SANDBOX_INIT_IMAGE
+    value: "ghcr.io/agynio/agent-init-codex:latest"
+  - name: SANDBOX_WORKSPACE_SIZE_GB
+    value: "10"
   - name: POLL_INTERVAL
     value: "5s"
   - name: IDLE_TIMEOUT

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -177,6 +177,7 @@ func run() error {
 		Idle:                      cfg.IdleTimeout,
 		StopSec:                   cfg.StopTimeoutSec,
 		MeteringSampleInterval:    cfg.MeteringSampleInterval,
+		SandboxReconcileEnabled:   cfg.SandboxReconcileEnabled,
 	})
 
 	start := func(leadCtx context.Context) {

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -163,21 +163,22 @@ func run() error {
 	}
 	assembler := assembler.NewWithRunnersAndEgressCA(agentsClient, runnersClient, secretsClient, &cfg, egressCACert)
 	reconciler := reconciler.New(reconciler.Config{
-		Threads:                   threadsClient,
-		Agents:                    agentsClient,
-		RunnerDialer:              runnerDialer,
-		ZitiMgmt:                  zitiMgmtClient,
-		Groups:                    groupsClient,
-		Runners:                   runnersClient,
-		Metering:                  meteringClient,
-		Assembler:                 assembler,
-		Wake:                      subscriber.Wake(),
-		Poll:                      cfg.PollInterval,
-		WorkloadReconcileInterval: cfg.WorkloadReconcileInterval,
-		Idle:                      cfg.IdleTimeout,
-		StopSec:                   cfg.StopTimeoutSec,
-		MeteringSampleInterval:    cfg.MeteringSampleInterval,
-		SandboxReconcileEnabled:   cfg.SandboxReconcileEnabled,
+		Threads:                         threadsClient,
+		Agents:                          agentsClient,
+		RunnerDialer:                    runnerDialer,
+		ZitiMgmt:                        zitiMgmtClient,
+		Groups:                          groupsClient,
+		Runners:                         runnersClient,
+		Metering:                        meteringClient,
+		Assembler:                       assembler,
+		Wake:                            subscriber.Wake(),
+		Poll:                            cfg.PollInterval,
+		WorkloadReconcileInterval:       cfg.WorkloadReconcileInterval,
+		Idle:                            cfg.IdleTimeout,
+		StopSec:                         cfg.StopTimeoutSec,
+		MeteringSampleInterval:          cfg.MeteringSampleInterval,
+		SandboxReconcileOrganizationIDs: append([]string(nil), cfg.SandboxReconcileOrganizationIDs...),
+		SandboxReconcileEnabled:         cfg.SandboxReconcileEnabled,
 	})
 
 	start := func(leadCtx context.Context) {

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -161,7 +161,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	assembler := assembler.NewWithEgressCA(agentsClient, secretsClient, &cfg, egressCACert)
+	assembler := assembler.NewWithRunnersAndEgressCA(agentsClient, runnersClient, secretsClient, &cfg, egressCACert)
 	reconciler := reconciler.New(reconciler.Config{
 		Threads:                   threadsClient,
 		Agents:                    agentsClient,

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -346,7 +346,8 @@ var reservedEnvNames = map[string]struct{}{
 }
 
 type Assembler struct {
-	agents       agentsv1.AgentsServiceClient
+	agents       agentsClient
+	runners      runnersClient
 	secrets      secretsv1.SecretsServiceClient
 	cfg          *config.Config
 	egressCACert []byte
@@ -367,12 +368,20 @@ type PersistentVolumeInfo struct {
 	Spec   *runnerv1.VolumeSpec
 }
 
-func New(agents agentsv1.AgentsServiceClient, secrets secretsv1.SecretsServiceClient, cfg *config.Config) *Assembler {
+func New(agents agentsClient, secrets secretsv1.SecretsServiceClient, cfg *config.Config) *Assembler {
 	return NewWithEgressCA(agents, secrets, cfg, nil)
 }
 
-func NewWithEgressCA(agents agentsv1.AgentsServiceClient, secrets secretsv1.SecretsServiceClient, cfg *config.Config, egressCACert []byte) *Assembler {
-	return &Assembler{agents: agents, secrets: secrets, cfg: cfg, egressCACert: append([]byte(nil), egressCACert...)}
+func NewWithRunners(agents agentsClient, runners runnersClient, secrets secretsv1.SecretsServiceClient, cfg *config.Config) *Assembler {
+	return NewWithRunnersAndEgressCA(agents, runners, secrets, cfg, nil)
+}
+
+func NewWithEgressCA(agents agentsClient, secrets secretsv1.SecretsServiceClient, cfg *config.Config, egressCACert []byte) *Assembler {
+	return NewWithRunnersAndEgressCA(agents, nil, secrets, cfg, egressCACert)
+}
+
+func NewWithRunnersAndEgressCA(agents agentsClient, runners runnersClient, secrets secretsv1.SecretsServiceClient, cfg *config.Config, egressCACert []byte) *Assembler {
+	return &Assembler{agents: agents, runners: runners, secrets: secrets, cfg: cfg, egressCACert: append([]byte(nil), egressCACert...)}
 }
 
 func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (*AssembleResult, error) {
@@ -1106,13 +1115,13 @@ func (a *Assembler) baseAgentEnvVars(agent *agentsv1.Agent, agentID, threadID uu
 }
 
 type volumeResolver struct {
-	agents   agentsv1.AgentsServiceClient
+	agents   agentsClient
 	threadID uuid.UUID
 	cache    map[string]*agentsv1.Volume
 	specs    map[string]*runnerv1.VolumeSpec
 }
 
-func newVolumeResolver(agents agentsv1.AgentsServiceClient, threadID uuid.UUID) *volumeResolver {
+func newVolumeResolver(agents agentsClient, threadID uuid.UUID) *volumeResolver {
 	return &volumeResolver{
 		agents:   agents,
 		threadID: threadID,

--- a/internal/assembler/interfaces.go
+++ b/internal/assembler/interfaces.go
@@ -1,0 +1,24 @@
+package assembler
+
+import (
+	"context"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"google.golang.org/grpc"
+)
+
+type agentsClient interface {
+	GetAgent(context.Context, *agentsv1.GetAgentRequest, ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+	GetEnvironment(context.Context, *agentsv1.GetEnvironmentRequest, ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error)
+	ListMcps(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error)
+	ListHooks(context.Context, *agentsv1.ListHooksRequest, ...grpc.CallOption) (*agentsv1.ListHooksResponse, error)
+	ListEnvs(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error)
+	ListVolumeAttachments(context.Context, *agentsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error)
+	ListImagePullSecretAttachments(context.Context, *agentsv1.ListImagePullSecretAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error)
+	GetVolume(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
+}
+
+type runnersClient interface {
+	GetFlavor(context.Context, *runnersv1.GetFlavorRequest, ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error)
+}

--- a/internal/assembler/labels.go
+++ b/internal/assembler/labels.go
@@ -1,11 +1,14 @@
 package assembler
 
 const (
-	LabelKeyPrefix   = "label."
-	LabelManagedBy   = "managed-by"
-	LabelAgentID     = "agent-id"
-	LabelThreadID    = "thread-id"
-	LabelWorkloadKey = "workload_key"
-	LabelVolumeKey   = "volume_key"
-	ManagedByValue   = "agents-orchestrator"
+	LabelKeyPrefix      = "label."
+	LabelManagedBy      = "managed-by"
+	LabelAgentID        = "agent-id"
+	LabelSandboxID      = "sandbox-id"
+	LabelSandboxOwnerID = "sandbox-owner-id"
+	LabelEnvironmentID  = "environment-id"
+	LabelThreadID       = "thread-id"
+	LabelWorkloadKey    = "workload_key"
+	LabelVolumeKey      = "volume_key"
+	ManagedByValue      = "agents-orchestrator"
 )

--- a/internal/assembler/sandbox.go
+++ b/internal/assembler/sandbox.go
@@ -1,0 +1,300 @@
+package assembler
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agents-orchestrator/internal/uuidutil"
+	"github.com/google/uuid"
+)
+
+const (
+	sandboxWorkspaceVolumeName = "workspace"
+	SandboxWorkspaceMountPath  = "/workspace"
+	SandboxHolderMode          = "holder"
+)
+
+type SandboxAssembleResult struct {
+	Request                *runnerv1.StartWorkloadRequest
+	OrganizationID         string
+	EnvironmentID          uuid.UUID
+	OwnerID                uuid.UUID
+	RunnerID               string
+	WorkspaceVolumeID      string
+	WorkspaceSizeGB        string
+	AllocatedCPUMillicores int32
+	AllocatedRAMBytes      int64
+}
+
+func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandbox, workspaceVolumeID string) (*SandboxAssembleResult, error) {
+	if sandbox == nil {
+		return nil, fmt.Errorf("sandbox missing")
+	}
+	sandboxID, err := sandboxUUID(sandbox)
+	if err != nil {
+		return nil, err
+	}
+	environmentID, err := uuidutil.ParseUUID(sandbox.GetEnvironmentId(), "sandbox.environment_id")
+	if err != nil {
+		return nil, err
+	}
+	ownerID, err := uuidutil.ParseUUID(sandbox.GetOwnerId(), "sandbox.owner_id")
+	if err != nil {
+		return nil, err
+	}
+	workspaceVolumeID = strings.TrimSpace(workspaceVolumeID)
+	if workspaceVolumeID == "" {
+		return nil, fmt.Errorf("sandbox %s workspace volume id missing", sandboxID.String())
+	}
+	environment, err := a.fetchEnvironment(ctx, environmentID)
+	if err != nil {
+		return nil, err
+	}
+	flavor, err := a.fetchFlavor(ctx, environment.GetFlavorId())
+	if err != nil {
+		return nil, err
+	}
+	resolver := newEnvResolver(a.secrets)
+	imagePullResolver := newImagePullResolver(a.secrets)
+	environmentEnvs, err := a.listEnvs(ctx, &agentsv1.ListEnvsRequest{EnvironmentId: environmentID.String()})
+	if err != nil {
+		return nil, fmt.Errorf("list environment envs: %w", err)
+	}
+	environmentEnvVars, err := resolver.ResolveEnvVars(ctx, environmentEnvs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve environment envs: %w", err)
+	}
+	environmentImagePullAttachments, err := a.listImagePullSecretAttachments(ctx, &agentsv1.ListImagePullSecretAttachmentsRequest{EnvironmentId: environmentID.String()})
+	if err != nil {
+		return nil, fmt.Errorf("list environment image pull secret attachments: %w", err)
+	}
+	if err := imagePullResolver.Resolve(ctx, environmentImagePullAttachments); err != nil {
+		return nil, fmt.Errorf("resolve environment image pull secrets: %w", err)
+	}
+	imagePullCredentials, err := imagePullResolver.Credentials()
+	if err != nil {
+		return nil, fmt.Errorf("image pull credentials: %w", err)
+	}
+	allocatedCPU, allocatedRAM, err := flavorAllocatedResources(flavor)
+	if err != nil {
+		return nil, err
+	}
+	mainEnv := mergeEnvVars(a.baseSandboxEnvVars(sandbox, environment), environmentEnvVars, fmt.Sprintf("sandbox %s", sandboxID.String()))
+	mainEnv = appendEgressCAEnvVars(mainEnv)
+	main := &runnerv1.ContainerSpec{
+		Image:            environment.GetImage(),
+		Name:             fmt.Sprintf("sandbox-%s", sandboxID.String()[:8]),
+		Cmd:              []string{agynBinBinaryPath},
+		Env:              mainEnv,
+		WorkingDir:       SandboxWorkspaceMountPath,
+		Mounts:           []*runnerv1.VolumeMount{{Volume: sandboxWorkspaceVolumeName, MountPath: SandboxWorkspaceMountPath}, {Volume: agynBinVolumeName, MountPath: agynBinMountPath}},
+		InlineFileMounts: egressCAInlineFileMounts(a.egressCACert),
+	}
+	initImage := strings.TrimSpace(a.cfg.SandboxInitImage)
+	if initImage == "" {
+		return nil, fmt.Errorf("sandbox init image is required")
+	}
+	initContainer := &runnerv1.ContainerSpec{
+		Image: initImage,
+		Name:  "sandbox-init",
+		Mounts: []*runnerv1.VolumeMount{
+			{Volume: agynBinVolumeName, MountPath: agynBinMountPath},
+		},
+	}
+	applyEgressCA(initContainer, a.egressCACert)
+	initContainers := []*runnerv1.ContainerSpec{initContainer}
+	volumes := []*runnerv1.VolumeSpec{
+		{
+			Name:           sandboxWorkspaceVolumeName,
+			Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
+			PersistentName: sandboxWorkspacePersistentName(sandboxID),
+			Labels: map[string]string{
+				LabelManagedBy:      ManagedByValue,
+				LabelSandboxID:      sandboxID.String(),
+				LabelSandboxOwnerID: ownerID.String(),
+				LabelEnvironmentID:  environmentID.String(),
+				LabelVolumeKey:      workspaceVolumeID,
+			},
+		},
+		{
+			Name: agynBinVolumeName,
+			Kind: runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL,
+		},
+	}
+	if a.cfg.ZitiEnabled {
+		if _, err := gatewayHost(a.cfg.AgentGatewayAddress); err != nil {
+			return nil, err
+		}
+		llmProxyTarget, err := zitiServiceWaitTarget(a.cfg.AgentLLMBaseURL)
+		if err != nil {
+			return nil, err
+		}
+		zitiEnroll := &runnerv1.ContainerSpec{
+			Image:      a.cfg.ZitiSidecarImage,
+			Name:       ZitiEnrollContainerName,
+			Cmd:        buildZitiEnrollCommand(a.cfg.ZitiEnrollmentDNSUpstream, a.cfg.ZitiEnrollmentControllerResolveHost, a.cfg.ZitiEnrollmentControllerPort, a.cfg.ZitiRuntimeControllerResolveHost, a.cfg.ZitiRuntimeControllerPort),
+			Entrypoint: zitiEnrollEntrypoint,
+			Env:        zitiEnrollEnvVars(a.cfg.ZitiEnrollmentControllerResolveHost, a.cfg.ZitiEnrollmentControllerPort),
+			Mounts:     []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
+		}
+		zitiSidecar := &runnerv1.ContainerSpec{
+			Image:                a.cfg.ZitiSidecarImage,
+			Name:                 ZitiSidecarContainerName,
+			Cmd:                  buildZitiSidecarCommand(a.cfg.WorkloadDNSUpstream),
+			Entrypoint:           zitiSidecarEntrypoint,
+			Env:                  zitiSidecarEnvVars(a.cfg.WorkloadDNSUpstream),
+			Mounts:               []*runnerv1.VolumeMount{{Volume: zitiIdentityVolumeName, MountPath: zitiIdentityMountPath}},
+			RequiredCapabilities: []string{zitiRequiredCapabilityNetAdmin},
+			AdditionalProperties: map[string]string{zitiRestartPolicyKey: zitiRestartPolicyAlways},
+		}
+		zitiGatewayWait := &runnerv1.ContainerSpec{
+			Image:      a.cfg.ZitiSidecarImage,
+			Name:       zitiGatewayWaitContainerName,
+			Entrypoint: zitiSidecarEntrypoint,
+			Cmd:        buildZitiGatewayWaitCommand(a.cfg.AgentGatewayAddress, a.cfg.WorkloadDNSUpstream),
+		}
+		zitiServiceWait := &runnerv1.ContainerSpec{
+			Image:      a.cfg.ZitiSidecarImage,
+			Name:       zitiServiceWaitContainerName,
+			Entrypoint: zitiSidecarEntrypoint,
+			Cmd:        buildZitiServiceWaitCommand(llmProxyTarget, a.cfg.WorkloadDNSUpstream),
+		}
+		applyEgressCA(zitiEnroll, a.egressCACert)
+		applyEgressCA(zitiSidecar, a.egressCACert)
+		applyEgressCA(zitiGatewayWait, a.egressCACert)
+		applyEgressCA(zitiServiceWait, a.egressCACert)
+		initContainers = []*runnerv1.ContainerSpec{zitiEnroll, zitiSidecar, zitiGatewayWait, zitiServiceWait, initContainer}
+		volumes = append(volumes, &runnerv1.VolumeSpec{Name: zitiIdentityVolumeName, Kind: runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL})
+	}
+	sort.Slice(volumes, func(i, j int) bool { return volumes[i].Name < volumes[j].Name })
+	request := &runnerv1.StartWorkloadRequest{
+		Main:                 main,
+		Volumes:              volumes,
+		InitContainers:       initContainers,
+		ImagePullCredentials: imagePullCredentials,
+		InlineFiles:          a.inlineFiles(),
+		AdditionalProperties: map[string]string{
+			LabelKeyPrefix + LabelManagedBy:      ManagedByValue,
+			LabelKeyPrefix + LabelSandboxID:      sandboxID.String(),
+			LabelKeyPrefix + LabelSandboxOwnerID: ownerID.String(),
+			LabelKeyPrefix + LabelEnvironmentID:  environmentID.String(),
+		},
+	}
+	if a.cfg.ZitiEnabled {
+		request.DnsConfig = &runnerv1.DnsConfig{
+			Nameservers: []string{zitiDNSNameserver, a.cfg.WorkloadDNSUpstream},
+			Searches:    []string{zitiDNSSearchService, zitiDNSSearchCluster},
+		}
+	}
+	return &SandboxAssembleResult{
+		Request:                request,
+		OrganizationID:         sandbox.GetOrganizationId(),
+		EnvironmentID:          environmentID,
+		OwnerID:                ownerID,
+		RunnerID:               flavor.GetRunnerId(),
+		WorkspaceVolumeID:      workspaceVolumeID,
+		WorkspaceSizeGB:        a.cfg.SandboxWorkspaceSizeGB,
+		AllocatedCPUMillicores: allocatedCPU,
+		AllocatedRAMBytes:      allocatedRAM,
+	}, nil
+}
+
+func sandboxUUID(sandbox *agentsv1.Sandbox) (uuid.UUID, error) {
+	if sandbox == nil || sandbox.GetMeta() == nil {
+		return uuid.Nil, fmt.Errorf("sandbox meta missing")
+	}
+	return uuidutil.ParseUUID(sandbox.GetMeta().GetId(), "sandbox.meta.id")
+}
+
+func sandboxWorkspacePersistentName(sandboxID uuid.UUID) string {
+	return "sandbox-ws-" + sandboxID.String()
+}
+
+func (a *Assembler) fetchEnvironment(ctx context.Context, environmentID uuid.UUID) (*agentsv1.Environment, error) {
+	rctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	resp, err := a.agents.GetEnvironment(rctx, &agentsv1.GetEnvironmentRequest{Id: environmentID.String()})
+	cancel()
+	if err != nil {
+		return nil, fmt.Errorf("get environment %s: %w", environmentID.String(), err)
+	}
+	environment := resp.GetEnvironment()
+	if environment == nil {
+		return nil, fmt.Errorf("environment %s missing", environmentID.String())
+	}
+	if environment.GetImage() == "" {
+		return nil, fmt.Errorf("environment %s image is required", environmentID.String())
+	}
+	if environment.GetFlavorId() == "" {
+		return nil, fmt.Errorf("environment %s flavor_id is required", environmentID.String())
+	}
+	return environment, nil
+}
+
+func (a *Assembler) fetchFlavor(ctx context.Context, flavorID string) (*runnersv1.Flavor, error) {
+	flavorID = strings.TrimSpace(flavorID)
+	if flavorID == "" {
+		return nil, fmt.Errorf("flavor id missing")
+	}
+	rctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	resp, err := a.runners.GetFlavor(rctx, &runnersv1.GetFlavorRequest{Id: flavorID})
+	cancel()
+	if err != nil {
+		return nil, fmt.Errorf("get flavor %s: %w", flavorID, err)
+	}
+	flavor := resp.GetFlavor()
+	if flavor == nil {
+		return nil, fmt.Errorf("flavor %s missing", flavorID)
+	}
+	if flavor.GetRunnerId() == "" {
+		return nil, fmt.Errorf("flavor %s runner_id is required", flavorID)
+	}
+	return flavor, nil
+}
+
+func flavorAllocatedResources(flavor *runnersv1.Flavor) (int32, int64, error) {
+	if flavor == nil {
+		return 0, 0, fmt.Errorf("flavor missing")
+	}
+	resources := flavor.GetResources()
+	if resources == nil {
+		return 0, 0, nil
+	}
+	cpu, err := parseCPUMillicores(resources.GetRequestsCpu(), fmt.Sprintf("flavor %s", flavor.GetMeta().GetId()))
+	if err != nil {
+		return 0, 0, err
+	}
+	ram, err := parseRAMBytes(resources.GetRequestsMemory(), fmt.Sprintf("flavor %s", flavor.GetMeta().GetId()))
+	if err != nil {
+		return 0, 0, err
+	}
+	if cpu > int64(^uint32(0)>>1) {
+		return 0, 0, fmt.Errorf("allocated cpu millicores overflow: %d", cpu)
+	}
+	return int32(cpu), ram, nil
+}
+
+func (a *Assembler) baseSandboxEnvVars(sandbox *agentsv1.Sandbox, environment *agentsv1.Environment) []*runnerv1.EnvVar {
+	gatewayURL := buildGatewayURL(a.cfg.AgentGatewayAddress)
+	vars := []*runnerv1.EnvVar{
+		{Name: "AGYND_MODE", Value: SandboxHolderMode},
+		{Name: "SANDBOX_ID", Value: sandbox.GetMeta().GetId()},
+		{Name: "SANDBOX_NAME", Value: sandbox.GetName()},
+		{Name: "SANDBOX_OWNER_ID", Value: sandbox.GetOwnerId()},
+		{Name: "ENVIRONMENT_ID", Value: environment.GetMeta().GetId()},
+		{Name: "ENVIRONMENT_NAME", Value: environment.GetName()},
+		{Name: "WORKSPACE_DIR", Value: SandboxWorkspaceMountPath},
+		{Name: "GATEWAY_ADDRESS", Value: a.cfg.AgentGatewayAddress},
+		{Name: "AGYN_GATEWAY_URL", Value: gatewayURL},
+		{Name: "LLM_BASE_URL", Value: a.cfg.AgentLLMBaseURL},
+	}
+	if a.cfg.AgentTracingAddress != "" {
+		vars = append(vars, &runnerv1.EnvVar{Name: "TRACING_ADDRESS", Value: a.cfg.AgentTracingAddress})
+		vars = append(vars, &runnerv1.EnvVar{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://localhost:4317"})
+	}
+	return vars
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	AgentGatewayAddress                 string
 	AgentTracingAddress                 string
 	AgentLLMBaseURL                     string
+	SandboxInitImage                    string
+	SandboxWorkspaceSizeGB              string
 	PollInterval                        time.Duration
 	WorkloadReconcileInterval           time.Duration
 	IdleTimeout                         time.Duration
@@ -116,6 +118,17 @@ func FromEnv() (Config, error) {
 		} else {
 			cfg.AgentLLMBaseURL = "http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080/v1"
 		}
+	}
+	cfg.SandboxInitImage = os.Getenv("SANDBOX_INIT_IMAGE")
+	if cfg.SandboxInitImage == "" {
+		cfg.SandboxInitImage = "ghcr.io/agynio/agent-init-codex:latest"
+	}
+	cfg.SandboxWorkspaceSizeGB = os.Getenv("SANDBOX_WORKSPACE_SIZE_GB")
+	if cfg.SandboxWorkspaceSizeGB == "" {
+		cfg.SandboxWorkspaceSizeGB = "10"
+	}
+	if _, err := strconv.ParseFloat(cfg.SandboxWorkspaceSizeGB, 64); err != nil {
+		return Config{}, fmt.Errorf("parse SANDBOX_WORKSPACE_SIZE_GB: %w", err)
 	}
 	cfg.ZitiManagementAddress = os.Getenv("ZITI_MANAGEMENT_ADDRESS")
 	if cfg.ZitiManagementAddress == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	MeteringServiceAddress              string
 	MeteringSampleInterval              time.Duration
 	ZitiEnabled                         bool
+	SandboxReconcileEnabled             bool
 	ZitiManagementAddress               string
 	GroupsAddress                       string
 	GroupSyncEnabled                    bool
@@ -129,6 +130,14 @@ func FromEnv() (Config, error) {
 	}
 	if _, err := strconv.ParseFloat(cfg.SandboxWorkspaceSizeGB, 64); err != nil {
 		return Config{}, fmt.Errorf("parse SANDBOX_WORKSPACE_SIZE_GB: %w", err)
+	}
+	sandboxReconcileEnabled := os.Getenv("SANDBOX_RECONCILE_ENABLED")
+	if sandboxReconcileEnabled != "" {
+		parsed, err := strconv.ParseBool(sandboxReconcileEnabled)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse SANDBOX_RECONCILE_ENABLED: %w", err)
+		}
+		cfg.SandboxReconcileEnabled = parsed
 	}
 	cfg.ZitiManagementAddress = os.Getenv("ZITI_MANAGEMENT_ADDRESS")
 	if cfg.ZitiManagementAddress == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Config struct {
@@ -18,6 +21,7 @@ type Config struct {
 	MeteringSampleInterval              time.Duration
 	ZitiEnabled                         bool
 	SandboxReconcileEnabled             bool
+	SandboxReconcileOrganizationIDs     []string
 	ZitiManagementAddress               string
 	GroupsAddress                       string
 	GroupSyncEnabled                    bool
@@ -138,6 +142,11 @@ func FromEnv() (Config, error) {
 			return Config{}, fmt.Errorf("parse SANDBOX_RECONCILE_ENABLED: %w", err)
 		}
 		cfg.SandboxReconcileEnabled = parsed
+	}
+	var err error
+	cfg.SandboxReconcileOrganizationIDs, err = parseUUIDList(os.Getenv("SANDBOX_RECONCILE_ORGANIZATION_IDS"), "SANDBOX_RECONCILE_ORGANIZATION_IDS")
+	if err != nil {
+		return Config{}, err
 	}
 	cfg.ZitiManagementAddress = os.Getenv("ZITI_MANAGEMENT_ADDRESS")
 	if cfg.ZitiManagementAddress == "" {
@@ -289,4 +298,25 @@ func FromEnv() (Config, error) {
 	cfg.LeaseNamespace = os.Getenv("LEASE_NAMESPACE")
 	cfg.EgressCANamespace = os.Getenv("EGRESS_CA_NAMESPACE")
 	return cfg, nil
+}
+
+func parseUUIDList(raw string, name string) ([]string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	parts := strings.Split(trimmed, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		parsed, err := uuid.Parse(value)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", name, err)
+		}
+		values = append(values, parsed.String())
+	}
+	return values, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -302,6 +302,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("SANDBOX_INIT_IMAGE", "")
 	t.Setenv("SANDBOX_WORKSPACE_SIZE_GB", "")
 	t.Setenv("SANDBOX_RECONCILE_ENABLED", "")
+	t.Setenv("SANDBOX_RECONCILE_ORGANIZATION_IDS", "")
 	t.Setenv("POLL_INTERVAL", "")
 	t.Setenv("WORKLOAD_RECONCILE_INTERVAL", "")
 	t.Setenv("IDLE_TIMEOUT", "")
@@ -432,5 +433,33 @@ func TestFromEnvZitiRuntimeControllerPortInvalid(t *testing.T) {
 	_, err := FromEnv()
 	if err == nil {
 		t.Fatal("expected ZITI_RUNTIME_CONTROLLER_PORT parse error")
+	}
+}
+
+func TestFromEnvSandboxReconcileOrganizationIDs(t *testing.T) {
+	setBaseEnv(t)
+	first := "11111111-1111-1111-1111-111111111111"
+	second := "22222222-2222-2222-2222-222222222222"
+	t.Setenv("SANDBOX_RECONCILE_ORGANIZATION_IDS", first+", "+second)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if len(cfg.SandboxReconcileOrganizationIDs) != 2 {
+		t.Fatalf("expected 2 organization ids, got %d", len(cfg.SandboxReconcileOrganizationIDs))
+	}
+	if cfg.SandboxReconcileOrganizationIDs[0] != first || cfg.SandboxReconcileOrganizationIDs[1] != second {
+		t.Fatalf("unexpected organization ids: %v", cfg.SandboxReconcileOrganizationIDs)
+	}
+}
+
+func TestFromEnvSandboxReconcileOrganizationIDsInvalid(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("SANDBOX_RECONCILE_ORGANIZATION_IDS", "not-a-uuid")
+
+	_, err := FromEnv()
+	if err == nil {
+		t.Fatal("expected SANDBOX_RECONCILE_ORGANIZATION_IDS parse error")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,6 +47,9 @@ func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	if cfg.GroupSyncEnabled {
 		t.Fatal("expected group sync to be disabled")
 	}
+	if cfg.SandboxReconcileEnabled {
+		t.Fatal("expected sandbox reconciliation to be disabled")
+	}
 	if cfg.GroupsAddress != "groups:50051" {
 		t.Fatalf("expected groups address %q, got %q", "groups:50051", cfg.GroupsAddress)
 	}
@@ -296,6 +299,9 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("AGENT_GATEWAY_ADDRESS", "")
 	t.Setenv("AGENT_TRACING_ADDRESS", "")
 	t.Setenv("AGENT_LLM_BASE_URL", "")
+	t.Setenv("SANDBOX_INIT_IMAGE", "")
+	t.Setenv("SANDBOX_WORKSPACE_SIZE_GB", "")
+	t.Setenv("SANDBOX_RECONCILE_ENABLED", "")
 	t.Setenv("POLL_INTERVAL", "")
 	t.Setenv("WORKLOAD_RECONCILE_INTERVAL", "")
 	t.Setenv("IDLE_TIMEOUT", "")
@@ -303,6 +309,29 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("LEASE_NAME", "")
 	t.Setenv("LEASE_NAMESPACE", "")
 	t.Setenv("EGRESS_CA_NAMESPACE", "")
+}
+
+func TestFromEnvSandboxReconcileEnabled(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("SANDBOX_RECONCILE_ENABLED", "true")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if !cfg.SandboxReconcileEnabled {
+		t.Fatal("expected sandbox reconciliation to be enabled")
+	}
+}
+
+func TestFromEnvSandboxReconcileEnabledInvalid(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("SANDBOX_RECONCILE_ENABLED", "not-bool")
+
+	_, err := FromEnv()
+	if err == nil {
+		t.Fatal("expected SANDBOX_RECONCILE_ENABLED parse error")
+	}
 }
 
 func TestFromEnvGroupSyncConfig(t *testing.T) {

--- a/internal/reconciler/actual.go
+++ b/internal/reconciler/actual.go
@@ -56,6 +56,9 @@ func (r *Reconciler) listActiveWorkloads(ctx context.Context, orgIdentities map[
 			return nil, fmt.Errorf("list workloads: %w", err)
 		}
 		for _, workload := range resp.GetWorkloads() {
+			if workload.GetOwnerKind() == runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
+				continue
+			}
 			if workload == nil {
 				return nil, fmt.Errorf("workload is nil")
 			}

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -262,3 +262,11 @@ func TestFetchDesiredSkipsPassiveLookupWithoutMessages(t *testing.T) {
 		t.Fatalf("expected no get threads call")
 	}
 }
+
+func (f *fakeAgentsClient) ListSandboxes(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeAgentsClient) DeleteSandbox(context.Context, *agentsv1.DeleteSandboxRequest, ...grpc.CallOption) (*agentsv1.DeleteSandboxResponse, error) {
+	return nil, errors.New("not implemented")
+}

--- a/internal/reconciler/interfaces.go
+++ b/internal/reconciler/interfaces.go
@@ -1,0 +1,31 @@
+package reconciler
+
+import (
+	"context"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"google.golang.org/grpc"
+)
+
+type agentsClient interface {
+	ListAgents(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error)
+	GetVolume(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
+	ListSandboxes(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error)
+	DeleteSandbox(context.Context, *agentsv1.DeleteSandboxRequest, ...grpc.CallOption) (*agentsv1.DeleteSandboxResponse, error)
+}
+
+type runnersClient interface {
+	ListRunners(context.Context, *runnersv1.ListRunnersRequest, ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error)
+	GetRunner(context.Context, *runnersv1.GetRunnerRequest, ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error)
+	CreateWorkload(context.Context, *runnersv1.CreateWorkloadRequest, ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error)
+	UpdateWorkload(context.Context, *runnersv1.UpdateWorkloadRequest, ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error)
+	ListWorkloads(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error)
+	ListWorkloadsByThread(context.Context, *runnersv1.ListWorkloadsByThreadRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsByThreadResponse, error)
+	CreateVolume(context.Context, *runnersv1.CreateVolumeRequest, ...grpc.CallOption) (*runnersv1.CreateVolumeResponse, error)
+	UpdateVolume(context.Context, *runnersv1.UpdateVolumeRequest, ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error)
+	ListVolumes(context.Context, *runnersv1.ListVolumesRequest, ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error)
+	ListVolumesByThread(context.Context, *runnersv1.ListVolumesByThreadRequest, ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error)
+	BatchUpdateWorkloadSampledAt(context.Context, *runnersv1.BatchUpdateWorkloadSampledAtRequest, ...grpc.CallOption) (*runnersv1.BatchUpdateWorkloadSampledAtResponse, error)
+	BatchUpdateVolumeSampledAt(context.Context, *runnersv1.BatchUpdateVolumeSampledAtRequest, ...grpc.CallOption) (*runnersv1.BatchUpdateVolumeSampledAtResponse, error)
+}

--- a/internal/reconciler/lifecycle_helpers.go
+++ b/internal/reconciler/lifecycle_helpers.go
@@ -67,6 +67,9 @@ func (r *Reconciler) createWorkloadRecord(ctx context.Context, workloadID, runne
 		ZitiIdentityId:         zitiIdentityValue,
 		AllocatedCpuMillicores: allocatedCPUMillicores,
 		AllocatedRamBytes:      allocatedRAMBytes,
+		OwnerKind:              runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_AGENT_INSTANCE,
+		OwnerId:                target.ThreadID.String(),
+		AgentClassId:           stringPtr(target.AgentID.String()),
 	})
 	return err
 }
@@ -95,6 +98,9 @@ func (r *Reconciler) createVolumeRecords(ctx context.Context, records []volumeRe
 			VolumeId:       record.volumeID,
 			SizeGb:         record.sizeGB,
 			Status:         runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
+			OwnerKind:      runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_AGENT_INSTANCE,
+			OwnerId:        target.ThreadID.String(),
+			AgentClassId:   stringPtr(target.AgentID.String()),
 		}
 		if _, err := r.runners.CreateVolume(runnersContext(ctx), req); err != nil {
 			return created, err

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -1893,7 +1893,6 @@ func (f *fakeRunnerClient) CancelExecution(context.Context, *runnerv1.CancelExec
 
 type fakeZitiMgmtClient struct {
 	createAgentIdentity         func(context.Context, *zitimgmtv1.CreateAgentIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error)
-	createSandboxIdentity       func(context.Context, *zitimgmtv1.CreateSandboxIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error)
 	patchIdentityRoleAttributes func(context.Context, *zitimgmtv1.PatchIdentityRoleAttributesRequest, ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error)
 	createAppIdentity           func(context.Context, *zitimgmtv1.CreateAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAppIdentityResponse, error)
 	createService               func(context.Context, *zitimgmtv1.CreateServiceRequest, ...grpc.CallOption) (*zitimgmtv1.CreateServiceResponse, error)
@@ -1925,13 +1924,6 @@ type fakeZitiMgmtClient struct {
 func (f *fakeZitiMgmtClient) CreateAgentIdentity(ctx context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 	if f.createAgentIdentity != nil {
 		return f.createAgentIdentity(ctx, req, opts...)
-	}
-	return nil, errNotImplemented
-}
-
-func (f *fakeZitiMgmtClient) CreateSandboxIdentity(ctx context.Context, req *zitimgmtv1.CreateSandboxIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error) {
-	if f.createSandboxIdentity != nil {
-		return f.createSandboxIdentity(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -1893,6 +1893,7 @@ func (f *fakeRunnerClient) CancelExecution(context.Context, *runnerv1.CancelExec
 
 type fakeZitiMgmtClient struct {
 	createAgentIdentity         func(context.Context, *zitimgmtv1.CreateAgentIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error)
+	createSandboxIdentity       func(context.Context, *zitimgmtv1.CreateSandboxIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error)
 	patchIdentityRoleAttributes func(context.Context, *zitimgmtv1.PatchIdentityRoleAttributesRequest, ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error)
 	createAppIdentity           func(context.Context, *zitimgmtv1.CreateAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAppIdentityResponse, error)
 	createService               func(context.Context, *zitimgmtv1.CreateServiceRequest, ...grpc.CallOption) (*zitimgmtv1.CreateServiceResponse, error)
@@ -1924,6 +1925,13 @@ type fakeZitiMgmtClient struct {
 func (f *fakeZitiMgmtClient) CreateAgentIdentity(ctx context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 	if f.createAgentIdentity != nil {
 		return f.createAgentIdentity(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) CreateSandboxIdentity(ctx context.Context, req *zitimgmtv1.CreateSandboxIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error) {
+	if f.createSandboxIdentity != nil {
+		return f.createSandboxIdentity(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -1640,6 +1640,7 @@ func (f *fakeRunnerDialer) Close() {}
 type fakeRunnersClient struct {
 	createWorkload        func(context.Context, *runnersv1.CreateWorkloadRequest, ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error)
 	createVolume          func(context.Context, *runnersv1.CreateVolumeRequest, ...grpc.CallOption) (*runnersv1.CreateVolumeResponse, error)
+	getFlavor             func(context.Context, *runnersv1.GetFlavorRequest, ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error)
 	deleteWorkload        func(context.Context, *runnersv1.DeleteWorkloadRequest, ...grpc.CallOption) (*runnersv1.DeleteWorkloadResponse, error)
 	getRunner             func(context.Context, *runnersv1.GetRunnerRequest, ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error)
 	listWorkloads         func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error)
@@ -1662,6 +1663,13 @@ func (f *fakeRunnersClient) RegisterRunner(context.Context, *runnersv1.RegisterR
 func (f *fakeRunnersClient) GetRunner(ctx context.Context, req *runnersv1.GetRunnerRequest, opts ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
 	if f.getRunner != nil {
 		return f.getRunner(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeRunnersClient) GetFlavor(ctx context.Context, req *runnersv1.GetFlavorRequest, opts ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
+	if f.getFlavor != nil {
+		return f.getFlavor(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }

--- a/internal/reconciler/metering_sample.go
+++ b/internal/reconciler/metering_sample.go
@@ -24,6 +24,8 @@ const (
 	labelKind                    = "kind"
 	labelThreadID                = "thread_id"
 	labelAgentID                 = "agent_id"
+	labelSandboxID               = "sandbox_id"
+	labelOwnerKind               = "owner_kind"
 	labelRunnerID                = "runner_id"
 	labelIdentityID              = "identity_id"
 	resourceWorkload             = "workload"
@@ -353,49 +355,65 @@ func sampleWindow(kind, id string, createdAt, lastSampledAt, removedAt *timestam
 }
 
 func workloadLabels(workload *runnersv1.Workload, workloadID string) (map[string]string, error) {
-	threadID := strings.TrimSpace(workload.GetThreadId())
-	if threadID == "" {
-		return nil, fmt.Errorf("workload %s thread id missing", workloadID)
-	}
-	agentID := strings.TrimSpace(workload.GetAgentId())
-	if agentID == "" {
-		return nil, fmt.Errorf("workload %s agent id missing", workloadID)
-	}
 	runnerID := strings.TrimSpace(workload.GetRunnerId())
 	if runnerID == "" {
 		return nil, fmt.Errorf("workload %s runner id missing", workloadID)
 	}
-	return map[string]string{
+	labels := map[string]string{
 		labelResource:   resourceWorkload,
 		labelResourceID: workloadID,
-		labelThreadID:   threadID,
-		labelAgentID:    agentID,
 		labelRunnerID:   runnerID,
-		labelIdentityID: agentID,
-	}, nil
+	}
+	if err := applyOwnerLabels(labels, workloadID, workload.GetOwnerKind(), workload.GetOwnerId(), workload.GetAgentId(), workload.GetThreadId()); err != nil {
+		return nil, err
+	}
+	return labels, nil
 }
 
 func volumeLabels(volume *runnersv1.Volume, volumeID string) (map[string]string, error) {
-	threadID := strings.TrimSpace(volume.GetThreadId())
-	if threadID == "" {
-		return nil, fmt.Errorf("volume %s thread id missing", volumeID)
-	}
-	agentID := strings.TrimSpace(volume.GetAgentId())
-	if agentID == "" {
-		return nil, fmt.Errorf("volume %s agent id missing", volumeID)
-	}
 	runnerID := strings.TrimSpace(volume.GetRunnerId())
 	if runnerID == "" {
 		return nil, fmt.Errorf("volume %s runner id missing", volumeID)
 	}
-	return map[string]string{
+	labels := map[string]string{
 		labelResource:   resourceVolume,
 		labelResourceID: volumeID,
-		labelThreadID:   threadID,
-		labelAgentID:    agentID,
 		labelRunnerID:   runnerID,
-		labelIdentityID: agentID,
-	}, nil
+	}
+	if err := applyOwnerLabels(labels, volumeID, volume.GetOwnerKind(), volume.GetOwnerId(), volume.GetAgentId(), volume.GetThreadId()); err != nil {
+		return nil, err
+	}
+	return labels, nil
+}
+
+func applyOwnerLabels(labels map[string]string, resourceID string, ownerKind runnersv1.RuntimeOwnerKind, ownerID, agentID, threadID string) error {
+	switch ownerKind {
+	case runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX:
+		sandboxID := strings.TrimSpace(ownerID)
+		if sandboxID == "" {
+			return fmt.Errorf("resource %s sandbox owner id missing", resourceID)
+		}
+		labels[labelOwnerKind] = "sandbox"
+		labels[labelSandboxID] = sandboxID
+		labels[labelIdentityID] = sandboxID
+	case runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_UNSPECIFIED,
+		runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_AGENT_INSTANCE:
+		cleanAgentID := strings.TrimSpace(agentID)
+		cleanThreadID := strings.TrimSpace(threadID)
+		if cleanAgentID == "" {
+			return fmt.Errorf("resource %s agent id missing", resourceID)
+		}
+		if cleanThreadID == "" {
+			return fmt.Errorf("resource %s thread id missing", resourceID)
+		}
+		labels[labelOwnerKind] = "agent_instance"
+		labels[labelThreadID] = cleanThreadID
+		labels[labelAgentID] = cleanAgentID
+		labels[labelIdentityID] = cleanAgentID
+	default:
+		return fmt.Errorf("resource %s owner kind %s unsupported", resourceID, ownerKind.String())
+	}
+	return nil
 }
 
 func microCoreSeconds(cpuMillicores int64, duration time.Duration) (int64, error) {

--- a/internal/reconciler/reconcile_loops.go
+++ b/internal/reconciler/reconcile_loops.go
@@ -20,6 +20,28 @@ func (r *Reconciler) runWorkloadReconcileLoop(ctx context.Context) {
 	}
 }
 
+func (r *Reconciler) runSandboxReconcileLoop(ctx context.Context) {
+	ticker := time.NewTicker(r.workloadReconcileInterval)
+	defer ticker.Stop()
+	r.runSandboxReconcileCycle(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.runSandboxReconcileCycle(ctx)
+		}
+	}
+}
+
+func (r *Reconciler) runSandboxReconcileCycle(ctx context.Context) {
+	rctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+	defer cancel()
+	if err := r.reconcileSandboxes(rctx); err != nil {
+		log.Printf("reconciler: sandbox reconciliation failed: %v", err)
+	}
+}
+
 func (r *Reconciler) runWorkloadReconcileCycle(ctx context.Context) {
 	rctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
 	defer cancel()

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -11,6 +11,8 @@ import (
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
 	zitimgmtv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/ziti_management/v1"
+	"github.com/agynio/agents-orchestrator/internal/assembler"
+	"github.com/agynio/agents-orchestrator/internal/config"
 	"github.com/agynio/agents-orchestrator/internal/testutil"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
@@ -1338,5 +1340,219 @@ func TestRunnerIdentityForWorkloadsRejectsAmbiguousClusterRunner(t *testing.T) {
 	}
 	if _, err := runnerIdentityForWorkloads("runner-1", "", map[string]string{testOrganizationID: testAgentID}, workloads); err == nil {
 		t.Fatal("expected multiple identities error")
+	}
+}
+
+func TestReconcileVolumesSkipsSandboxOwnedVolumes(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	agentVolumeKey := "volume-agent"
+	sandboxVolumeKey := "volume-sandbox"
+	instanceID := "volume-instance-1"
+	threadID := uuid.New().String()
+	sandboxID := uuid.New().String()
+
+	var updateReq *runnersv1.UpdateVolumeRequest
+	runners := &fakeRunnersClient{
+		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
+				{Meta: &runnersv1.EntityMeta{Id: sandboxVolumeKey}, RunnerId: runnerID, OrganizationId: testOrganizationID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, OwnerKind: runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX, OwnerId: sandboxID},
+				{Meta: &runnersv1.EntityMeta{Id: agentVolumeKey}, RunnerId: runnerID, AgentId: testAgentID, OrganizationId: testOrganizationID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING, ThreadId: threadID, VolumeId: uuid.NewString()},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateVolume: func(_ context.Context, req *runnersv1.UpdateVolumeRequest, _ ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateVolumeResponse{}, nil
+		},
+	}
+	runner := &fakeRunnerClient{
+		listVolumes: func(_ context.Context, _ *runnerv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnerv1.ListVolumesResponse, error) {
+			return &runnerv1.ListVolumesResponse{Volumes: []*runnerv1.VolumeListItem{
+				{VolumeKey: agentVolumeKey, InstanceId: instanceID},
+				{VolumeKey: sandboxVolumeKey, InstanceId: "sandbox-volume-instance"},
+			}}, nil
+		},
+		removeVolume: func(_ context.Context, req *runnerv1.RemoveVolumeRequest, _ ...grpc.CallOption) (*runnerv1.RemoveVolumeResponse, error) {
+			if req.GetVolumeName() == sandboxVolumeKey {
+				return nil, errors.New("sandbox volume should not be reconciled as an orphan")
+			}
+			return &runnerv1.RemoveVolumeResponse{}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+		if id != runnerID {
+			return nil, errors.New("unexpected runner id")
+		}
+		return runner, nil
+	}}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       &testutil.FakeAgentsClient{},
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileVolumes(ctx); err != nil {
+		t.Fatalf("reconcile volumes: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected agent volume update")
+	}
+	if updateReq.GetId() != agentVolumeKey {
+		t.Fatalf("unexpected volume update: %v", updateReq.GetId())
+	}
+	if updateReq.GetStatus() != runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE {
+		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
+	}
+}
+
+func TestListTrackedSandboxesDoesNotRequireAgents(t *testing.T) {
+	ctx := context.Background()
+	sandboxID := uuid.NewString()
+	listAgentsCalled := false
+	var requests []*agentsv1.ListSandboxesRequest
+	agents := &testutil.FakeAgentsClient{
+		ListAgentsFunc: func(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+			listAgentsCalled = true
+			return &agentsv1.ListAgentsResponse{}, nil
+		},
+		ListSandboxesFunc: func(_ context.Context, req *agentsv1.ListSandboxesRequest, _ ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error) {
+			requests = append(requests, req)
+			return &agentsv1.ListSandboxesResponse{Sandboxes: []*agentsv1.Sandbox{
+				{Meta: &agentsv1.EntityMeta{Id: sandboxID}, OrganizationId: testOrganizationID, Status: agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING},
+			}}, nil
+		},
+	}
+	reconciler := newTestReconciler(Config{Agents: agents})
+
+	sandboxes, err := reconciler.listTrackedSandboxes(ctx)
+	if err != nil {
+		t.Fatalf("list tracked sandboxes: %v", err)
+	}
+	if listAgentsCalled {
+		t.Fatal("expected sandbox inventory not to call ListAgents")
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 list sandboxes request, got %d", len(requests))
+	}
+	if requests[0].GetOrganizationId() != "" {
+		t.Fatalf("expected unscoped sandbox list, got org %q", requests[0].GetOrganizationId())
+	}
+	if !requests[0].GetIncludeTerminated() {
+		t.Fatal("expected terminated sandboxes included")
+	}
+	if len(sandboxes) != 1 || sandboxes[0].GetMeta().GetId() != sandboxID {
+		t.Fatalf("unexpected sandboxes: %v", sandboxes)
+	}
+}
+
+func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	environmentID := uuid.NewString()
+	ownerID := uuid.NewString()
+	sandboxID := uuid.NewString()
+	flavorID := "flavor-1"
+	var createWorkloadReq *runnersv1.CreateWorkloadRequest
+	var createVolumeReq *runnersv1.CreateVolumeRequest
+	var updateWorkloadReq *runnersv1.UpdateWorkloadRequest
+	var startedWorkloadID string
+	agents := &testutil.FakeAgentsClient{
+		GetEnvironmentFunc: func(_ context.Context, req *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
+			if req.GetId() != environmentID {
+				return nil, errors.New("unexpected environment id")
+			}
+			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{Meta: &agentsv1.EntityMeta{Id: environmentID}, OrganizationId: testOrganizationID, Name: "sandbox-env", FlavorId: flavorID, Image: "sandbox-image"}}, nil
+		},
+		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
+			return &agentsv1.ListEnvsResponse{}, nil
+		},
+		ListImagePullSecretAttachmentsFunc: func(context.Context, *agentsv1.ListImagePullSecretAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error) {
+			return &agentsv1.ListImagePullSecretAttachmentsResponse{}, nil
+		},
+	}
+	runners := &fakeRunnersClient{
+		getFlavor: func(_ context.Context, req *runnersv1.GetFlavorRequest, _ ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
+			if req.GetId() != flavorID {
+				return nil, errors.New("unexpected flavor id")
+			}
+			return &runnersv1.GetFlavorResponse{Flavor: &runnersv1.Flavor{Meta: &runnersv1.EntityMeta{Id: flavorID}, RunnerId: runnerID, Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"}}}, nil
+		},
+		getRunner: func(_ context.Context, req *runnersv1.GetRunnerRequest, _ ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
+			if req.GetId() != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return &runnersv1.GetRunnerResponse{Runner: buildRunner(runnerID)}, nil
+		},
+		createVolume: func(_ context.Context, req *runnersv1.CreateVolumeRequest, _ ...grpc.CallOption) (*runnersv1.CreateVolumeResponse, error) {
+			createVolumeReq = req
+			return &runnersv1.CreateVolumeResponse{}, nil
+		},
+		createWorkload: func(_ context.Context, req *runnersv1.CreateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error) {
+			createWorkloadReq = req
+			return &runnersv1.CreateWorkloadResponse{}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateWorkloadReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+	runner := &fakeRunnerClient{startWorkload: func(_ context.Context, req *runnerv1.StartWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StartWorkloadResponse, error) {
+		startedWorkloadID = req.GetWorkloadId()
+		return &runnerv1.StartWorkloadResponse{Id: req.GetWorkloadId(), Status: runnerv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING}, nil
+	}}
+	runnerDialer := &fakeRunnerDialer{dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+		if id != runnerID {
+			return nil, errors.New("unexpected runner id")
+		}
+		return runner, nil
+	}}
+	cfg := &config.Config{
+		AgentGatewayAddress:    "gateway:50051",
+		AgentLLMBaseURL:        "http://llm:8080/v1",
+		SandboxInitImage:       "sandbox-init-image",
+		SandboxWorkspaceSizeGB: "10",
+	}
+	sandboxAssembler := assembler.NewWithRunners(agents, runners, &testutil.FakeSecretsClient{}, cfg)
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       agents,
+		Assembler:    sandboxAssembler,
+	})
+	plan := &sandboxWorkloadPlan{sandboxID: uuid.MustParse(sandboxID), sandbox: &agentsv1.Sandbox{Meta: &agentsv1.EntityMeta{Id: sandboxID}, OrganizationId: testOrganizationID, Name: "sandbox", EnvironmentId: environmentID, OwnerId: ownerID, Status: agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING}}
+
+	if err := reconciler.startSandboxWorkload(ctx, plan); err != nil {
+		t.Fatalf("start sandbox workload: %v", err)
+	}
+	if createVolumeReq == nil {
+		t.Fatal("expected workspace volume create")
+	}
+	if createVolumeReq.GetAgentId() != "" {
+		t.Fatalf("expected no agent id on sandbox volume, got %q", createVolumeReq.GetAgentId())
+	}
+	if createVolumeReq.GetOwnerKind() != runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX || createVolumeReq.GetOwnerId() != sandboxID {
+		t.Fatalf("unexpected volume owner: %v %q", createVolumeReq.GetOwnerKind(), createVolumeReq.GetOwnerId())
+	}
+	if createWorkloadReq == nil {
+		t.Fatal("expected workload create")
+	}
+	if createWorkloadReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING {
+		t.Fatalf("unexpected create workload status: %v", createWorkloadReq.GetStatus())
+	}
+	if updateWorkloadReq == nil {
+		t.Fatal("expected workload update")
+	}
+	if updateWorkloadReq.GetId() == "" || updateWorkloadReq.GetId() != startedWorkloadID {
+		t.Fatalf("unexpected workload update id: %q started %q", updateWorkloadReq.GetId(), startedWorkloadID)
+	}
+	if updateWorkloadReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+		t.Fatalf("unexpected update workload status: %v", updateWorkloadReq.GetStatus())
+	}
+	if updateWorkloadReq.GetInstanceId() != startedWorkloadID {
+		t.Fatalf("unexpected instance id: %q", updateWorkloadReq.GetInstanceId())
 	}
 }

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -1409,40 +1409,54 @@ func TestReconcileVolumesSkipsSandboxOwnedVolumes(t *testing.T) {
 	}
 }
 
-func TestListTrackedSandboxesDoesNotRequireAgents(t *testing.T) {
+func TestListTrackedSandboxesUsesConfiguredOrganizations(t *testing.T) {
 	ctx := context.Background()
 	sandboxID := uuid.NewString()
-	listAgentsCalled := false
+	configuredOrgID := uuid.New().String()
 	var requests []*agentsv1.ListSandboxesRequest
 	agents := &testutil.FakeAgentsClient{
 		ListAgentsFunc: func(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
-			listAgentsCalled = true
 			return &agentsv1.ListAgentsResponse{}, nil
 		},
 		ListSandboxesFunc: func(_ context.Context, req *agentsv1.ListSandboxesRequest, _ ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error) {
 			requests = append(requests, req)
+			if req.GetOrganizationId() == "" {
+				return nil, errors.New("organization id is required")
+			}
+			if req.GetOrganizationId() != configuredOrgID {
+				return &agentsv1.ListSandboxesResponse{}, nil
+			}
 			return &agentsv1.ListSandboxesResponse{Sandboxes: []*agentsv1.Sandbox{
-				{Meta: &agentsv1.EntityMeta{Id: sandboxID}, OrganizationId: testOrganizationID, Status: agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING},
+				{Meta: &agentsv1.EntityMeta{Id: sandboxID}, OrganizationId: configuredOrgID, Status: agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING},
 			}}, nil
 		},
 	}
-	reconciler := newTestReconciler(Config{Agents: agents})
+	reconciler := newTestReconciler(Config{
+		Agents:                          agents,
+		SandboxReconcileOrganizationIDs: []string{configuredOrgID},
+	})
 
 	sandboxes, err := reconciler.listTrackedSandboxes(ctx)
 	if err != nil {
 		t.Fatalf("list tracked sandboxes: %v", err)
 	}
-	if listAgentsCalled {
-		t.Fatal("expected sandbox inventory not to call ListAgents")
-	}
 	if len(requests) != 1 {
 		t.Fatalf("expected 1 list sandboxes request, got %d", len(requests))
 	}
-	if requests[0].GetOrganizationId() != "" {
-		t.Fatalf("expected unscoped sandbox list, got org %q", requests[0].GetOrganizationId())
+	seenConfigured := false
+	for _, request := range requests {
+		if request.GetOrganizationId() == "" {
+			t.Fatal("expected org-scoped sandbox list")
+		}
+		if !request.GetIncludeTerminated() {
+			t.Fatal("expected terminated sandboxes included")
+		}
+		if request.GetOrganizationId() == configuredOrgID {
+			seenConfigured = true
+		}
 	}
-	if !requests[0].GetIncludeTerminated() {
-		t.Fatal("expected terminated sandboxes included")
+	if !seenConfigured {
+		t.Fatal("expected configured sandbox org to be listed")
 	}
 	if len(sandboxes) != 1 || sandboxes[0].GetMeta().GetId() != sandboxID {
 		t.Fatalf("unexpected sandboxes: %v", sandboxes)
@@ -1554,5 +1568,74 @@ func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
 	}
 	if updateWorkloadReq.GetInstanceId() != startedWorkloadID {
 		t.Fatalf("unexpected instance id: %q", updateWorkloadReq.GetInstanceId())
+	}
+}
+
+func TestReconcileSandboxPromotesStartingWorkload(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	sandboxID := uuid.NewString()
+	ownerID := uuid.NewString()
+	workloadID := uuid.NewString()
+	createdAt := timestamppb.New(time.Now().Add(-time.Minute))
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, req *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			if len(req.GetFilter().GetOwnerKindIn()) != 1 || req.GetFilter().GetOwnerKindIn()[0] != runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
+				return nil, errors.New("expected sandbox owner filter")
+			}
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: workloadID, CreatedAt: createdAt}, RunnerId: runnerID, OrganizationId: testOrganizationID, Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING, InstanceId: stringPtr(workloadID), OwnerKind: runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX, OwnerId: sandboxID},
+			}}, nil
+		},
+		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+	runner := &fakeRunnerClient{
+		inspectWorkload: func(_ context.Context, req *runnerv1.InspectWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.InspectWorkloadResponse, error) {
+			if req.GetWorkloadId() != workloadID {
+				return nil, errors.New("unexpected workload id")
+			}
+			return &runnerv1.InspectWorkloadResponse{
+				StateRunning: true,
+				Containers: []*runnerv1.WorkloadContainer{
+					{Name: "sandbox", Role: runnerv1.ContainerRole_CONTAINER_ROLE_MAIN, Status: runnerv1.ContainerStatus_CONTAINER_STATUS_RUNNING},
+				},
+			}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+		if id != runnerID {
+			return nil, errors.New("unexpected runner id")
+		}
+		return runner, nil
+	}}
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       &testutil.FakeAgentsClient{},
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	sandbox := &agentsv1.Sandbox{Meta: &agentsv1.EntityMeta{Id: sandboxID, CreatedAt: createdAt}, OrganizationId: testOrganizationID, OwnerId: ownerID, Status: agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING}
+
+	if err := reconciler.reconcileSandbox(ctx, sandbox, time.Now().UTC()); err != nil {
+		t.Fatalf("reconcile sandbox: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected workload update")
+	}
+	if updateReq.GetId() != workloadID {
+		t.Fatalf("unexpected workload id: %s", updateReq.GetId())
+	}
+	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
+	}
+	if len(updateReq.GetContainers()) != 1 || updateReq.GetContainers()[0].GetStatus() != runnersv1.ContainerStatus_CONTAINER_STATUS_RUNNING {
+		t.Fatalf("expected running container update")
 	}
 }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"time"
 
-	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	meteringv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/metering/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
@@ -27,9 +26,9 @@ const (
 
 type Reconciler struct {
 	threads                   threadsv1.ThreadsServiceClient
-	agents                    agentsv1.AgentsServiceClient
+	agents                    agentsClient
 	runnerDialer              runnerdial.RunnerDialer
-	runners                   runnersv1.RunnersServiceClient
+	runners                   runnersClient
 	metering                  meteringv1.MeteringServiceClient
 	meteringSampleInterval    time.Duration
 	zitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
@@ -44,9 +43,9 @@ type Reconciler struct {
 
 type Config struct {
 	Threads                   threadsv1.ThreadsServiceClient
-	Agents                    agentsv1.AgentsServiceClient
+	Agents                    agentsClient
 	RunnerDialer              runnerdial.RunnerDialer
-	Runners                   runnersv1.RunnersServiceClient
+	Runners                   runnersClient
 	Metering                  meteringv1.MeteringServiceClient
 	ZitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
 	Groups                    groupsClient
@@ -86,6 +85,7 @@ func (r *Reconciler) Run(ctx context.Context) error {
 		return fmt.Errorf("metering sample interval must be greater than 0")
 	}
 	go r.runWorkloadReconcileLoop(ctx)
+	go r.runSandboxReconcileLoop(ctx)
 	go r.runVolumeReconcileLoop(ctx)
 	go r.runMeteringSampleLoop(ctx)
 
@@ -351,55 +351,56 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 }
 
 func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workload) {
-	workloadID := workload.GetMeta().GetId()
-	if workloadID == "" {
-		log.Printf("reconciler: workload missing id")
-		return
-	}
 	runnerCtx, err := runnerIdentityContext(ctx, workload.GetAgentId())
 	if err != nil {
-		log.Printf("reconciler: build runner identity for workload %s: %v", workloadID, err)
+		log.Printf("reconciler: build runner identity for workload %s: %v", workload.GetMeta().GetId(), err)
 		return
+	}
+	if err := r.stopWorkloadWithContext(runnerCtx, workload); err != nil {
+		log.Printf("reconciler: stop workload %s: %v", workload.GetMeta().GetId(), err)
+	}
+}
+
+func (r *Reconciler) stopWorkloadWithContext(runnerCtx context.Context, workload *runnersv1.Workload) error {
+	workloadID := workload.GetMeta().GetId()
+	if workloadID == "" {
+		return fmt.Errorf("workload missing id")
 	}
 	instanceID := normalizeRunnerWorkloadID(workload.GetInstanceId())
 	if instanceID == "" {
-		log.Printf("reconciler: workload %s missing instance id", workloadID)
 		r.markWorkloadFailed(runnerCtx, workloadID, nil, runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST, "missing instance id", nil)
-		return
+		return nil
 	}
 	runnerID := workload.GetRunnerId()
 	if runnerID == "" {
-		log.Printf("reconciler: workload %s missing runner id", workloadID)
-		return
+		return fmt.Errorf("workload %s missing runner id", workloadID)
 	}
-	runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
+	runnerClient, err := r.runnerDialer.Dial(runnerCtx, runnerID)
 	if err != nil {
 		if runnerdial.IsNoTerminators(err) {
 			if err := r.handleMissingRunnerWorkload(runnerCtx, workload); err != nil {
-				log.Printf("reconciler: handle missing workload %s after runner dial failure: %v", workloadID, err)
+				return fmt.Errorf("handle missing workload %s after runner dial failure: %w", workloadID, err)
 			}
-			return
+			return nil
 		}
-		log.Printf("reconciler: dial runner %s for workload %s: %v", runnerID, workloadID, err)
-		return
+		return fmt.Errorf("dial runner %s for workload %s: %w", runnerID, workloadID, err)
 	}
 	stoppingStatus := runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING
 	if _, err := r.runners.UpdateWorkload(runnersContext(runnerCtx), &runnersv1.UpdateWorkloadRequest{
 		Id:     workloadID,
 		Status: &stoppingStatus,
 	}); err != nil {
-		log.Printf("reconciler: update workload %s to stopping: %v", workloadID, err)
+		return fmt.Errorf("update workload %s to stopping: %w", workloadID, err)
 	}
 	workload.Status = stoppingStatus
 	if err := r.stopRunnerWorkload(runnerCtx, runnerClient, instanceID); err != nil {
 		if runnerdial.IsNoTerminators(err) {
 			if err := r.handleMissingRunnerWorkload(runnerCtx, workload); err != nil {
-				log.Printf("reconciler: handle missing workload %s after runner stop failure: %v", workloadID, err)
+				return fmt.Errorf("handle missing workload %s after runner stop failure: %w", workloadID, err)
 			}
-			return
+			return nil
 		}
-		log.Printf("reconciler: stop workload %s: %v", workloadID, err)
-		return
+		return fmt.Errorf("stop workload %s: %w", workloadID, err)
 	}
 	stoppedStatus := runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED
 	if _, err := r.runners.UpdateWorkload(runnersContext(runnerCtx), &runnersv1.UpdateWorkloadRequest{
@@ -407,13 +408,14 @@ func (r *Reconciler) stopWorkload(ctx context.Context, workload *runnersv1.Workl
 		Status:    &stoppedStatus,
 		RemovedAt: timestamppb.New(time.Now().UTC()),
 	}); err != nil {
-		log.Printf("reconciler: update workload %s to stopped: %v", workloadID, err)
+		return fmt.Errorf("update workload %s to stopped: %w", workloadID, err)
 	}
 	if r.zitiMgmt != nil && workload.GetZitiIdentityId() != "" {
-		if err := r.deleteIdentity(ctx, workload.GetZitiIdentityId()); err != nil {
-			log.Printf("reconciler: delete ziti identity %s after stopping workload %s: %v", workload.GetZitiIdentityId(), workloadID, err)
+		if err := r.deleteIdentity(runnerCtx, workload.GetZitiIdentityId()); err != nil {
+			return fmt.Errorf("delete ziti identity %s after stopping workload %s: %w", workload.GetZitiIdentityId(), workloadID, err)
 		}
 	}
+	return nil
 }
 
 func (r *Reconciler) stopRunnerWorkload(ctx context.Context, runnerClient runnerv1.RunnerServiceClient, instanceID string) error {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -25,58 +25,61 @@ const (
 )
 
 type Reconciler struct {
-	threads                   threadsv1.ThreadsServiceClient
-	agents                    agentsClient
-	runnerDialer              runnerdial.RunnerDialer
-	runners                   runnersClient
-	metering                  meteringv1.MeteringServiceClient
-	meteringSampleInterval    time.Duration
-	zitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
-	groups                    groupsClient
-	assembler                 *assembler.Assembler
-	wake                      <-chan struct{}
-	sandboxReconcileEnabled   bool
-	poll                      time.Duration
-	workloadReconcileInterval time.Duration
-	idle                      time.Duration
-	stopSec                   uint32
+	sandboxReconcileOrganizationIDs []string
+	threads                         threadsv1.ThreadsServiceClient
+	agents                          agentsClient
+	runnerDialer                    runnerdial.RunnerDialer
+	runners                         runnersClient
+	metering                        meteringv1.MeteringServiceClient
+	meteringSampleInterval          time.Duration
+	zitiMgmt                        zitimgmtv1.ZitiManagementServiceClient
+	groups                          groupsClient
+	assembler                       *assembler.Assembler
+	wake                            <-chan struct{}
+	sandboxReconcileEnabled         bool
+	poll                            time.Duration
+	workloadReconcileInterval       time.Duration
+	idle                            time.Duration
+	stopSec                         uint32
 }
 
 type Config struct {
-	Threads                   threadsv1.ThreadsServiceClient
-	Agents                    agentsClient
-	RunnerDialer              runnerdial.RunnerDialer
-	Runners                   runnersClient
-	Metering                  meteringv1.MeteringServiceClient
-	ZitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
-	Groups                    groupsClient
-	Assembler                 *assembler.Assembler
-	Wake                      <-chan struct{}
-	Poll                      time.Duration
-	WorkloadReconcileInterval time.Duration
-	Idle                      time.Duration
-	StopSec                   uint32
-	MeteringSampleInterval    time.Duration
-	SandboxReconcileEnabled   bool
+	SandboxReconcileOrganizationIDs []string
+	Threads                         threadsv1.ThreadsServiceClient
+	Agents                          agentsClient
+	RunnerDialer                    runnerdial.RunnerDialer
+	Runners                         runnersClient
+	Metering                        meteringv1.MeteringServiceClient
+	ZitiMgmt                        zitimgmtv1.ZitiManagementServiceClient
+	Groups                          groupsClient
+	Assembler                       *assembler.Assembler
+	Wake                            <-chan struct{}
+	Poll                            time.Duration
+	WorkloadReconcileInterval       time.Duration
+	Idle                            time.Duration
+	StopSec                         uint32
+	MeteringSampleInterval          time.Duration
+	SandboxReconcileEnabled         bool
 }
 
 func New(cfg Config) *Reconciler {
 	return &Reconciler{
-		threads:                   cfg.Threads,
-		agents:                    cfg.Agents,
-		runnerDialer:              cfg.RunnerDialer,
-		runners:                   cfg.Runners,
-		metering:                  cfg.Metering,
-		meteringSampleInterval:    cfg.MeteringSampleInterval,
-		sandboxReconcileEnabled:   cfg.SandboxReconcileEnabled,
-		zitiMgmt:                  cfg.ZitiMgmt,
-		groups:                    cfg.Groups,
-		assembler:                 cfg.Assembler,
-		wake:                      cfg.Wake,
-		poll:                      cfg.Poll,
-		workloadReconcileInterval: cfg.WorkloadReconcileInterval,
-		idle:                      cfg.Idle,
-		stopSec:                   cfg.StopSec,
+		sandboxReconcileOrganizationIDs: append([]string(nil), cfg.SandboxReconcileOrganizationIDs...),
+		threads:                         cfg.Threads,
+		agents:                          cfg.Agents,
+		runnerDialer:                    cfg.RunnerDialer,
+		runners:                         cfg.Runners,
+		metering:                        cfg.Metering,
+		meteringSampleInterval:          cfg.MeteringSampleInterval,
+		sandboxReconcileEnabled:         cfg.SandboxReconcileEnabled,
+		zitiMgmt:                        cfg.ZitiMgmt,
+		groups:                          cfg.Groups,
+		assembler:                       cfg.Assembler,
+		wake:                            cfg.Wake,
+		poll:                            cfg.Poll,
+		workloadReconcileInterval:       cfg.WorkloadReconcileInterval,
+		idle:                            cfg.Idle,
+		stopSec:                         cfg.StopSec,
 	}
 }
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -35,6 +35,7 @@ type Reconciler struct {
 	groups                    groupsClient
 	assembler                 *assembler.Assembler
 	wake                      <-chan struct{}
+	sandboxReconcileEnabled   bool
 	poll                      time.Duration
 	workloadReconcileInterval time.Duration
 	idle                      time.Duration
@@ -56,6 +57,7 @@ type Config struct {
 	Idle                      time.Duration
 	StopSec                   uint32
 	MeteringSampleInterval    time.Duration
+	SandboxReconcileEnabled   bool
 }
 
 func New(cfg Config) *Reconciler {
@@ -66,6 +68,7 @@ func New(cfg Config) *Reconciler {
 		runners:                   cfg.Runners,
 		metering:                  cfg.Metering,
 		meteringSampleInterval:    cfg.MeteringSampleInterval,
+		sandboxReconcileEnabled:   cfg.SandboxReconcileEnabled,
 		zitiMgmt:                  cfg.ZitiMgmt,
 		groups:                    cfg.Groups,
 		assembler:                 cfg.Assembler,
@@ -85,7 +88,9 @@ func (r *Reconciler) Run(ctx context.Context) error {
 		return fmt.Errorf("metering sample interval must be greater than 0")
 	}
 	go r.runWorkloadReconcileLoop(ctx)
-	go r.runSandboxReconcileLoop(ctx)
+	if r.sandboxReconcileEnabled {
+		go r.runSandboxReconcileLoop(ctx)
+	}
 	go r.runVolumeReconcileLoop(ctx)
 	go r.runMeteringSampleLoop(ctx)
 

--- a/internal/reconciler/sandbox_reconciler.go
+++ b/internal/reconciler/sandbox_reconciler.go
@@ -39,34 +39,23 @@ func (r *Reconciler) reconcileSandboxes(ctx context.Context) error {
 }
 
 func (r *Reconciler) listTrackedSandboxes(ctx context.Context) ([]*agentsv1.Sandbox, error) {
-	orgIdentities, err := r.agentIdentityByOrg(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if len(orgIdentities) == 0 {
-		return nil, nil
-	}
 	var sandboxes []*agentsv1.Sandbox
-	for orgID := range orgIdentities {
-		pageToken := ""
-		for {
-			resp, err := r.agents.ListSandboxes(ctx, &agentsv1.ListSandboxesRequest{
-				OrganizationId:    orgID,
-				IncludeTerminated: true,
-				PageSize:          sandboxPageSize,
-				PageToken:         pageToken,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("list sandboxes for org %s: %w", orgID, err)
-			}
-			sandboxes = append(sandboxes, resp.GetSandboxes()...)
-			pageToken = resp.GetNextPageToken()
-			if pageToken == "" {
-				break
-			}
+	pageToken := ""
+	for {
+		resp, err := r.agents.ListSandboxes(ctx, &agentsv1.ListSandboxesRequest{
+			IncludeTerminated: true,
+			PageSize:          sandboxPageSize,
+			PageToken:         pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list sandboxes: %w", err)
+		}
+		sandboxes = append(sandboxes, resp.GetSandboxes()...)
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return sandboxes, nil
 		}
 	}
-	return sandboxes, nil
 }
 
 func (r *Reconciler) reconcileSandbox(ctx context.Context, sandbox *agentsv1.Sandbox, now time.Time) error {
@@ -295,11 +284,16 @@ func (r *Reconciler) startSandboxWorkload(ctx context.Context, plan *sandboxWork
 		r.compensateIdentity(ctx, zitiIdentityID, "sandbox workload id mismatch")
 		return nil
 	}
-	_, err = r.runners.UpdateWorkload(runnersContext(runnerCtx), &runnersv1.UpdateWorkloadRequest{
+	updateReq := &runnersv1.UpdateWorkloadRequest{
 		Id:         workloadID,
 		InstanceId: stringPtr(instanceID),
 		Containers: containers,
-	})
+	}
+	if resp.GetStatus() == runnerv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+		status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING
+		updateReq.Status = &status
+	}
+	_, err = r.runners.UpdateWorkload(runnersContext(runnerCtx), updateReq)
 	return err
 }
 

--- a/internal/reconciler/sandbox_reconciler.go
+++ b/internal/reconciler/sandbox_reconciler.go
@@ -10,7 +10,6 @@ import (
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
-	zitimgmtv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/agents-orchestrator/internal/assembler"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 	"github.com/google/uuid"
@@ -341,37 +340,14 @@ func (r *Reconciler) createSandboxIdentity(ctx context.Context, sandboxID, envir
 	if r.zitiMgmt == nil {
 		return nil, nil
 	}
-	resp, err := r.zitiMgmt.CreateSandboxIdentity(ctx, &zitimgmtv1.CreateSandboxIdentityRequest{
-		SandboxId:      sandboxID.String(),
-		OwnerId:        ownerID.String(),
-		EnvironmentId:  environmentID.String(),
-		OrganizationId: organizationID,
-		WorkloadId:     workloadID.String(),
-		AdditionalRoleAttributes: []string{
-			"sandbox-environment-" + environmentID.String(),
-		},
-		Tags: map[string]string{
-			"agyn.sandbox.id":       sandboxID.String(),
-			"agyn.sandbox.owner_id": ownerID.String(),
-			"agyn.environment.id":   environmentID.String(),
-			"agyn.workload.id":      workloadID.String(),
-			"agyn.organization.id":  organizationID,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("create ziti identity for sandbox %s workload %s: %w", sandboxID.String(), workloadID.String(), err)
-	}
-	identityID := resp.GetZitiIdentityId()
-	enrollmentJWT := resp.GetEnrollmentJwt()
-	if identityID == "" || enrollmentJWT == "" {
-		var identityPtr *string
-		if identityID != "" {
-			identityPtr = &identityID
-		}
-		r.compensateIdentity(ctx, identityPtr, "missing sandbox identity fields")
-		return nil, fmt.Errorf("ziti identity response missing fields for sandbox %s workload %s", sandboxID.String(), workloadID.String())
-	}
-	return &identityInfo{id: identityID, enrollmentJWT: enrollmentJWT}, nil
+	return nil, fmt.Errorf(
+		"sandbox workload identity is blocked: agynio/api ziti_management.v1 has no CreateSandboxIdentity RPC for sandbox %s environment %s owner %s workload %s organization %s",
+		sandboxID.String(),
+		environmentID.String(),
+		ownerID.String(),
+		workloadID.String(),
+		organizationID,
+	)
 }
 
 func (r *Reconciler) stopSandboxWorkload(ctx context.Context, workload *runnersv1.Workload) error {

--- a/internal/reconciler/sandbox_reconciler.go
+++ b/internal/reconciler/sandbox_reconciler.go
@@ -10,6 +10,7 @@ import (
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	zitimgmtv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/agents-orchestrator/internal/assembler"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 	"github.com/google/uuid"
@@ -340,14 +341,37 @@ func (r *Reconciler) createSandboxIdentity(ctx context.Context, sandboxID, envir
 	if r.zitiMgmt == nil {
 		return nil, nil
 	}
-	return nil, fmt.Errorf(
-		"sandbox workload identity is blocked: agynio/api ziti_management.v1 has no CreateSandboxIdentity RPC for sandbox %s environment %s owner %s workload %s organization %s",
-		sandboxID.String(),
-		environmentID.String(),
-		ownerID.String(),
-		workloadID.String(),
-		organizationID,
-	)
+	resp, err := r.zitiMgmt.CreateSandboxIdentity(ctx, &zitimgmtv1.CreateSandboxIdentityRequest{
+		SandboxId:      sandboxID.String(),
+		OwnerId:        ownerID.String(),
+		EnvironmentId:  environmentID.String(),
+		OrganizationId: organizationID,
+		WorkloadId:     workloadID.String(),
+		AdditionalRoleAttributes: []string{
+			"sandbox-environment-" + environmentID.String(),
+		},
+		Tags: map[string]string{
+			"agyn.sandbox.id":       sandboxID.String(),
+			"agyn.sandbox.owner_id": ownerID.String(),
+			"agyn.environment.id":   environmentID.String(),
+			"agyn.workload.id":      workloadID.String(),
+			"agyn.organization.id":  organizationID,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create ziti identity for sandbox %s workload %s: %w", sandboxID.String(), workloadID.String(), err)
+	}
+	identityID := resp.GetZitiIdentityId()
+	enrollmentJWT := resp.GetEnrollmentJwt()
+	if identityID == "" || enrollmentJWT == "" {
+		var identityPtr *string
+		if identityID != "" {
+			identityPtr = &identityID
+		}
+		r.compensateIdentity(ctx, identityPtr, "missing sandbox identity fields")
+		return nil, fmt.Errorf("ziti identity response missing fields for sandbox %s workload %s", sandboxID.String(), workloadID.String())
+	}
+	return &identityInfo{id: identityID, enrollmentJWT: enrollmentJWT}, nil
 }
 
 func (r *Reconciler) stopSandboxWorkload(ctx context.Context, workload *runnersv1.Workload) error {

--- a/internal/reconciler/sandbox_reconciler.go
+++ b/internal/reconciler/sandbox_reconciler.go
@@ -1,0 +1,470 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agents-orchestrator/internal/assembler"
+	"github.com/agynio/agents-orchestrator/internal/uuidutil"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const sandboxPageSize int32 = 100
+
+type sandboxWorkloadPlan struct {
+	sandbox         *agentsv1.Sandbox
+	sandboxID       uuid.UUID
+	workspaceVolume *runnersv1.Volume
+	activeWorkload  *runnersv1.Workload
+}
+
+func (r *Reconciler) reconcileSandboxes(ctx context.Context) error {
+	sandboxes, err := r.listTrackedSandboxes(ctx)
+	if err != nil {
+		return err
+	}
+	for _, sandbox := range sandboxes {
+		if err := r.reconcileSandbox(ctx, sandbox, time.Now().UTC()); err != nil {
+			log.Printf("reconciler: sandbox %s failed: %v", sandbox.GetMeta().GetId(), err)
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) listTrackedSandboxes(ctx context.Context) ([]*agentsv1.Sandbox, error) {
+	orgIdentities, err := r.agentIdentityByOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(orgIdentities) == 0 {
+		return nil, nil
+	}
+	var sandboxes []*agentsv1.Sandbox
+	for orgID := range orgIdentities {
+		pageToken := ""
+		for {
+			resp, err := r.agents.ListSandboxes(ctx, &agentsv1.ListSandboxesRequest{
+				OrganizationId:    orgID,
+				IncludeTerminated: true,
+				PageSize:          sandboxPageSize,
+				PageToken:         pageToken,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("list sandboxes for org %s: %w", orgID, err)
+			}
+			sandboxes = append(sandboxes, resp.GetSandboxes()...)
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
+			}
+		}
+	}
+	return sandboxes, nil
+}
+
+func (r *Reconciler) reconcileSandbox(ctx context.Context, sandbox *agentsv1.Sandbox, now time.Time) error {
+	plan, err := r.loadSandboxWorkloadPlan(ctx, sandbox)
+	if err != nil {
+		return err
+	}
+	if ttlExpired(sandbox, now) && sandbox.GetStatus() != agentsv1.SandboxStatus_SANDBOX_STATUS_TERMINATED {
+		return r.terminateSandbox(ctx, plan)
+	}
+	switch sandbox.GetStatus() {
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_STARTING:
+		if plan.activeWorkload == nil {
+			return r.startSandboxWorkload(ctx, plan)
+		}
+		return nil
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING:
+		if plan.activeWorkload == nil {
+			return r.startSandboxWorkload(ctx, plan)
+		}
+		if sandboxIdle(sandbox, plan.activeWorkload, now) {
+			return r.stopSandboxWorkload(ctx, plan.activeWorkload)
+		}
+		return nil
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_STOPPED:
+		if plan.activeWorkload != nil && sandboxIdle(sandbox, plan.activeWorkload, now) {
+			return r.stopSandboxWorkload(ctx, plan.activeWorkload)
+		}
+		return nil
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_FAILED:
+		if plan.activeWorkload != nil {
+			return r.stopSandboxWorkload(ctx, plan.activeWorkload)
+		}
+		return nil
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_TERMINATED:
+		if plan.activeWorkload != nil {
+			if err := r.stopSandboxWorkload(ctx, plan.activeWorkload); err != nil {
+				return err
+			}
+		}
+		return r.deleteSandboxWorkspace(ctx, plan)
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_UNSPECIFIED:
+		return fmt.Errorf("sandbox %s status unspecified", plan.sandboxID.String())
+	default:
+		return fmt.Errorf("sandbox %s status %s unsupported", plan.sandboxID.String(), sandbox.GetStatus().String())
+	}
+}
+
+func (r *Reconciler) loadSandboxWorkloadPlan(ctx context.Context, sandbox *agentsv1.Sandbox) (*sandboxWorkloadPlan, error) {
+	if sandbox == nil || sandbox.GetMeta() == nil {
+		return nil, fmt.Errorf("sandbox meta missing")
+	}
+	sandboxID, err := uuidutil.ParseUUID(sandbox.GetMeta().GetId(), "sandbox.meta.id")
+	if err != nil {
+		return nil, err
+	}
+	workloads, err := r.listSandboxWorkloads(ctx, sandboxID.String())
+	if err != nil {
+		return nil, err
+	}
+	volumes, err := r.listSandboxVolumes(ctx, sandboxID.String())
+	if err != nil {
+		return nil, err
+	}
+	plan := &sandboxWorkloadPlan{sandbox: sandbox, sandboxID: sandboxID}
+	for _, workload := range workloads {
+		if isActiveWorkloadStatus(workload.GetStatus()) {
+			if plan.activeWorkload != nil {
+				if err := r.stopSandboxWorkload(ctx, workload); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			plan.activeWorkload = workload
+		}
+	}
+	for _, volume := range volumes {
+		if isPinnedVolumeStatus(volume.GetStatus()) {
+			if plan.workspaceVolume != nil {
+				return nil, fmt.Errorf("sandbox %s has multiple active workspace volumes", sandboxID.String())
+			}
+			plan.workspaceVolume = volume
+		}
+	}
+	return plan, nil
+}
+
+func (r *Reconciler) listSandboxWorkloads(ctx context.Context, sandboxID string) ([]*runnersv1.Workload, error) {
+	pageToken := ""
+	var workloads []*runnersv1.Workload
+	for {
+		resp, err := r.runners.ListWorkloads(runnersContext(ctx), &runnersv1.ListWorkloadsRequest{
+			PageSize:  activeWorkloadPageSize,
+			PageToken: pageToken,
+			Filter: &runnersv1.ListWorkloadsFilter{
+				OwnerKindIn: []runnersv1.RuntimeOwnerKind{runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX},
+				OwnerIdIn:   []string{sandboxID},
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list sandbox workloads %s: %w", sandboxID, err)
+		}
+		workloads = append(workloads, resp.GetWorkloads()...)
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return workloads, nil
+		}
+	}
+}
+
+func (r *Reconciler) listSandboxVolumes(ctx context.Context, sandboxID string) ([]*runnersv1.Volume, error) {
+	pageToken := ""
+	var volumes []*runnersv1.Volume
+	for {
+		resp, err := r.runners.ListVolumes(runnersContext(ctx), &runnersv1.ListVolumesRequest{
+			PageSize:  activeVolumePageSize,
+			PageToken: pageToken,
+			Filter: &runnersv1.ListVolumesFilter{
+				OwnerKindIn: []runnersv1.RuntimeOwnerKind{runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX},
+				OwnerIdIn:   []string{sandboxID},
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list sandbox volumes %s: %w", sandboxID, err)
+		}
+		volumes = append(volumes, resp.GetVolumes()...)
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return volumes, nil
+		}
+	}
+}
+
+func (r *Reconciler) startSandboxWorkload(ctx context.Context, plan *sandboxWorkloadPlan) error {
+	workspaceVolumeID := ""
+	if plan.workspaceVolume != nil {
+		workspaceVolumeID = plan.workspaceVolume.GetMeta().GetId()
+	} else {
+		workspaceVolumeID = uuid.NewString()
+	}
+	assembled, err := r.assembler.AssembleSandbox(ctx, plan.sandbox, workspaceVolumeID)
+	if err != nil {
+		return err
+	}
+	runnerID := strings.TrimSpace(assembled.RunnerID)
+	if runnerID == "" {
+		return fmt.Errorf("sandbox %s runner id missing", plan.sandboxID.String())
+	}
+	runner, enrolled, err := r.getRunnerIfEnrolled(ctx, runnerID)
+	if err != nil {
+		return err
+	}
+	if !enrolled {
+		return fmt.Errorf("sandbox %s runner %s is not enrolled", plan.sandboxID.String(), runnerID)
+	}
+	if runner.GetMeta().GetId() == "" {
+		return fmt.Errorf("sandbox %s runner meta missing", plan.sandboxID.String())
+	}
+	runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
+	if err != nil {
+		return fmt.Errorf("dial runner %s: %w", runnerID, err)
+	}
+	runnerCtx, err := runnerIdentityContext(ctx, assembled.OwnerID.String())
+	if err != nil {
+		return err
+	}
+	workloadID := uuid.NewString()
+	request := assembled.Request
+	request.WorkloadId = workloadID
+	request.Main.Env = append(request.Main.Env, &runnerv1.EnvVar{Name: "WORKLOAD_ID", Value: workloadID})
+	if request.AdditionalProperties == nil {
+		request.AdditionalProperties = map[string]string{}
+	}
+	request.AdditionalProperties[assembler.LabelKeyPrefix+assembler.LabelWorkloadKey] = workloadID
+	identity, err := r.createSandboxIdentity(ctx, plan.sandboxID, assembled.EnvironmentID, assembled.OwnerID, uuid.MustParse(workloadID), assembled.OrganizationID)
+	if err != nil {
+		return err
+	}
+	zitiIdentityID := identity.idPtr()
+	if identity != nil {
+		if err := attachZitiEnrollmentToken(request, identity.enrollmentJWT); err != nil {
+			r.compensateIdentity(ctx, zitiIdentityID, "missing ziti enroll container")
+			return err
+		}
+	}
+	if plan.workspaceVolume == nil {
+		if err := r.createSandboxWorkspaceRecord(runnerCtx, assembled, runnerID); err != nil {
+			r.compensateIdentity(ctx, zitiIdentityID, "sandbox workspace record failure")
+			return err
+		}
+	}
+	if err := r.createSandboxWorkloadRecord(runnerCtx, workloadID, runnerID, assembled, zitiIdentityID); err != nil {
+		r.markSandboxWorkspaceFailed(runnerCtx, plan.workspaceVolume, workspaceVolumeID)
+		r.compensateIdentity(ctx, zitiIdentityID, "sandbox workload record failure")
+		return err
+	}
+	resp, err := runnerClient.StartWorkload(runnerCtx, request)
+	if err != nil {
+		r.markWorkloadFailed(runnerCtx, workloadID, nil, runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, err.Error(), nil)
+		r.markSandboxWorkspaceFailed(runnerCtx, plan.workspaceVolume, workspaceVolumeID)
+		r.compensateIdentity(ctx, zitiIdentityID, "sandbox start failure")
+		return err
+	}
+	instanceID := normalizeRunnerWorkloadID(resp.GetId())
+	containers := buildContainers(request, resp)
+	if resp.GetStatus() == runnerv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
+		failureMessage := failureSummary(resp.GetFailure())
+		if instanceID != "" {
+			if err := r.stopRunnerWorkload(runnerCtx, runnerClient, instanceID); err != nil {
+				log.Printf("reconciler: stop sandbox workload %s after failure: %v", instanceID, err)
+			}
+		}
+		r.markWorkloadFailed(runnerCtx, workloadID, stringPtr(instanceID), runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, failureMessage, containers)
+		r.markSandboxWorkspaceFailed(runnerCtx, plan.workspaceVolume, workspaceVolumeID)
+		r.compensateIdentity(ctx, zitiIdentityID, "sandbox workload failure")
+		return nil
+	}
+	if resp.GetId() != workloadID {
+		if resp.GetId() != "" {
+			if err := r.stopRunnerWorkload(runnerCtx, runnerClient, resp.GetId()); err != nil {
+				log.Printf("reconciler: stop sandbox workload %s after id mismatch: %v", resp.GetId(), err)
+			}
+		}
+		r.markWorkloadFailed(runnerCtx, workloadID, stringPtr(instanceID), runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, "workload id mismatch", containers)
+		r.markSandboxWorkspaceFailed(runnerCtx, plan.workspaceVolume, workspaceVolumeID)
+		r.compensateIdentity(ctx, zitiIdentityID, "sandbox workload id mismatch")
+		return nil
+	}
+	_, err = r.runners.UpdateWorkload(runnersContext(runnerCtx), &runnersv1.UpdateWorkloadRequest{
+		Id:         workloadID,
+		InstanceId: stringPtr(instanceID),
+		Containers: containers,
+	})
+	return err
+}
+
+func (r *Reconciler) createSandboxWorkloadRecord(ctx context.Context, workloadID, runnerID string, assembled *assembler.SandboxAssembleResult, zitiIdentityID *string) error {
+	status := runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING
+	zitiIdentityValue := ""
+	if zitiIdentityID != nil {
+		zitiIdentityValue = *zitiIdentityID
+	}
+	_, err := r.runners.CreateWorkload(runnersContext(ctx), &runnersv1.CreateWorkloadRequest{
+		Id:                     workloadID,
+		RunnerId:               runnerID,
+		OrganizationId:         assembled.OrganizationID,
+		Status:                 status,
+		ZitiIdentityId:         zitiIdentityValue,
+		AllocatedCpuMillicores: assembled.AllocatedCPUMillicores,
+		AllocatedRamBytes:      assembled.AllocatedRAMBytes,
+		OwnerKind:              runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX,
+		OwnerId:                assembled.Request.GetAdditionalProperties()[assembler.LabelKeyPrefix+assembler.LabelSandboxID],
+	})
+	return err
+}
+
+func (r *Reconciler) createSandboxWorkspaceRecord(ctx context.Context, assembled *assembler.SandboxAssembleResult, runnerID string) error {
+	_, err := r.runners.CreateVolume(runnersContext(ctx), &runnersv1.CreateVolumeRequest{
+		Id:             assembled.WorkspaceVolumeID,
+		RunnerId:       runnerID,
+		OrganizationId: assembled.OrganizationID,
+		SizeGb:         assembled.WorkspaceSizeGB,
+		Status:         runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
+		OwnerKind:      runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX,
+		OwnerId:        assembled.Request.GetAdditionalProperties()[assembler.LabelKeyPrefix+assembler.LabelSandboxID],
+	})
+	return err
+}
+
+func (r *Reconciler) createSandboxIdentity(ctx context.Context, sandboxID, environmentID, ownerID, workloadID uuid.UUID, organizationID string) (*identityInfo, error) {
+	if r.zitiMgmt == nil {
+		return nil, nil
+	}
+	return nil, fmt.Errorf(
+		"sandbox workload identity is blocked: agynio/api ziti_management.v1 has no CreateSandboxIdentity RPC for sandbox %s environment %s owner %s workload %s organization %s",
+		sandboxID.String(),
+		environmentID.String(),
+		ownerID.String(),
+		workloadID.String(),
+		organizationID,
+	)
+}
+
+func (r *Reconciler) stopSandboxWorkload(ctx context.Context, workload *runnersv1.Workload) error {
+	if workload == nil || workload.GetMeta() == nil || workload.GetMeta().GetId() == "" {
+		return fmt.Errorf("sandbox workload meta missing")
+	}
+	ownerID := strings.TrimSpace(workload.GetOwnerId())
+	if ownerID == "" {
+		ownerID = strings.TrimSpace(workload.GetAgentId())
+	}
+	runnerCtx, err := runnerIdentityContext(ctx, ownerID)
+	if err != nil {
+		return err
+	}
+	if err := r.stopWorkloadWithContext(runnerCtx, workload); err != nil {
+		return err
+	}
+	return r.deleteIdentity(ctx, workload.GetZitiIdentityId())
+}
+
+func (r *Reconciler) terminateSandbox(ctx context.Context, plan *sandboxWorkloadPlan) error {
+	if plan.activeWorkload != nil {
+		if err := r.stopSandboxWorkload(ctx, plan.activeWorkload); err != nil {
+			return err
+		}
+	}
+	if err := r.deleteSandboxWorkspace(ctx, plan); err != nil {
+		return err
+	}
+	_, err := r.agents.DeleteSandbox(ctx, &agentsv1.DeleteSandboxRequest{Id: plan.sandboxID.String()})
+	return err
+}
+
+func (r *Reconciler) deleteSandboxWorkspace(ctx context.Context, plan *sandboxWorkloadPlan) error {
+	volume := plan.workspaceVolume
+	if volume == nil {
+		return nil
+	}
+	ownerID := strings.TrimSpace(volume.GetOwnerId())
+	if ownerID == "" {
+		ownerID = strings.TrimSpace(volume.GetAgentId())
+	}
+	runnerCtx, err := runnerIdentityContext(ctx, ownerID)
+	if err != nil {
+		return err
+	}
+	if volume.GetRunnerId() != "" {
+		runnerClient, err := r.runnerDialer.Dial(ctx, volume.GetRunnerId())
+		if err != nil {
+			return err
+		}
+		if _, err := runnerClient.RemoveVolume(runnerCtx, &runnerv1.RemoveVolumeRequest{VolumeName: volume.GetMeta().GetId(), Force: true}); err != nil {
+			return err
+		}
+	}
+	status := runnersv1.VolumeStatus_VOLUME_STATUS_DELETED
+	_, err = r.runners.UpdateVolume(runnersContext(runnerCtx), &runnersv1.UpdateVolumeRequest{
+		Id:        volume.GetMeta().GetId(),
+		Status:    &status,
+		RemovedAt: timestamppb.New(time.Now().UTC()),
+	})
+	return err
+}
+
+func (r *Reconciler) markSandboxWorkspaceFailed(ctx context.Context, existing *runnersv1.Volume, volumeID string) {
+	if existing != nil {
+		return
+	}
+	if volumeID == "" {
+		return
+	}
+	status := runnersv1.VolumeStatus_VOLUME_STATUS_FAILED
+	_, err := r.runners.UpdateVolume(runnersContext(ctx), &runnersv1.UpdateVolumeRequest{
+		Id:        volumeID,
+		Status:    &status,
+		RemovedAt: timestamppb.New(time.Now().UTC()),
+	})
+	if err != nil {
+		log.Printf("reconciler: update sandbox workspace %s to failed: %v", volumeID, err)
+	}
+}
+
+func ttlExpired(sandbox *agentsv1.Sandbox, now time.Time) bool {
+	meta := sandbox.GetMeta()
+	if meta == nil || meta.GetCreatedAt() == nil {
+		return false
+	}
+	ttl, err := time.ParseDuration(strings.TrimSpace(sandbox.GetTtl()))
+	if err != nil || ttl <= 0 {
+		return false
+	}
+	return !now.Before(meta.GetCreatedAt().AsTime().UTC().Add(ttl))
+}
+
+func sandboxIdle(sandbox *agentsv1.Sandbox, workload *runnersv1.Workload, now time.Time) bool {
+	idleTimeout, err := time.ParseDuration(strings.TrimSpace(sandbox.GetIdleTimeout()))
+	if err != nil || idleTimeout <= 0 {
+		return false
+	}
+	activityAt, err := workloadActivityAt(workload)
+	if err != nil {
+		return false
+	}
+	return now.Sub(activityAt) > idleTimeout
+}
+
+func isActiveWorkloadStatus(status runnersv1.WorkloadStatus) bool {
+	switch status {
+	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING:
+		return true
+	case runnersv1.WorkloadStatus_WORKLOAD_STATUS_UNSPECIFIED,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED:
+		return false
+	default:
+		return false
+	}
+}

--- a/internal/reconciler/sandbox_reconciler.go
+++ b/internal/reconciler/sandbox_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -39,23 +40,63 @@ func (r *Reconciler) reconcileSandboxes(ctx context.Context) error {
 }
 
 func (r *Reconciler) listTrackedSandboxes(ctx context.Context) ([]*agentsv1.Sandbox, error) {
+	orgIDs, err := r.listKnownSandboxOrgIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
 	var sandboxes []*agentsv1.Sandbox
-	pageToken := ""
-	for {
-		resp, err := r.agents.ListSandboxes(ctx, &agentsv1.ListSandboxesRequest{
-			IncludeTerminated: true,
-			PageSize:          sandboxPageSize,
-			PageToken:         pageToken,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("list sandboxes: %w", err)
-		}
-		sandboxes = append(sandboxes, resp.GetSandboxes()...)
-		pageToken = resp.GetNextPageToken()
-		if pageToken == "" {
-			return sandboxes, nil
+	for _, orgID := range orgIDs {
+		pageToken := ""
+		for {
+			resp, err := r.agents.ListSandboxes(ctx, &agentsv1.ListSandboxesRequest{
+				OrganizationId:    orgID,
+				IncludeTerminated: true,
+				PageSize:          sandboxPageSize,
+				PageToken:         pageToken,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("list sandboxes for org %s: %w", orgID, err)
+			}
+			sandboxes = append(sandboxes, resp.GetSandboxes()...)
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
+			}
 		}
 	}
+	return sandboxes, nil
+}
+
+func (r *Reconciler) listKnownSandboxOrgIDs(ctx context.Context) ([]string, error) {
+	return r.sandboxReconcileOrgIDs(ctx)
+}
+
+func (r *Reconciler) sandboxReconcileOrgIDs(ctx context.Context) ([]string, error) {
+	orgIDs := map[string]struct{}{}
+	for _, configuredOrgID := range r.sandboxReconcileOrganizationIDs {
+		parsedOrgID, err := uuidutil.ParseUUID(configuredOrgID, "sandbox_reconcile.organization_id")
+		if err != nil {
+			return nil, err
+		}
+		orgIDs[parsedOrgID.String()] = struct{}{}
+	}
+	agentOrgIDs, err := r.agentIdentityByOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for orgID := range agentOrgIDs {
+		parsedOrgID, err := uuidutil.ParseUUID(orgID, "agent.organization_id")
+		if err != nil {
+			return nil, err
+		}
+		orgIDs[parsedOrgID.String()] = struct{}{}
+	}
+	ordered := make([]string, 0, len(orgIDs))
+	for orgID := range orgIDs {
+		ordered = append(ordered, orgID)
+	}
+	sort.Strings(ordered)
+	return ordered, nil
 }
 
 func (r *Reconciler) reconcileSandbox(ctx context.Context, sandbox *agentsv1.Sandbox, now time.Time) error {
@@ -71,10 +112,16 @@ func (r *Reconciler) reconcileSandbox(ctx context.Context, sandbox *agentsv1.San
 		if plan.activeWorkload == nil {
 			return r.startSandboxWorkload(ctx, plan)
 		}
+		if err := r.reconcileActiveSandboxWorkload(ctx, plan); err != nil {
+			return err
+		}
 		return nil
 	case agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING:
 		if plan.activeWorkload == nil {
 			return r.startSandboxWorkload(ctx, plan)
+		}
+		if err := r.reconcileActiveSandboxWorkload(ctx, plan); err != nil {
+			return err
 		}
 		if sandboxIdle(sandbox, plan.activeWorkload, now) {
 			return r.stopSandboxWorkload(ctx, plan.activeWorkload)
@@ -187,6 +234,37 @@ func (r *Reconciler) listSandboxVolumes(ctx context.Context, sandboxID string) (
 			return volumes, nil
 		}
 	}
+}
+
+func (r *Reconciler) reconcileActiveSandboxWorkload(ctx context.Context, plan *sandboxWorkloadPlan) error {
+	workload := plan.activeWorkload
+	if workload == nil {
+		return nil
+	}
+	runnerID := strings.TrimSpace(workload.GetRunnerId())
+	if runnerID == "" {
+		return fmt.Errorf("sandbox workload %s runner id missing", workload.GetMeta().GetId())
+	}
+	ownerID := strings.TrimSpace(workload.GetOwnerId())
+	if ownerID == "" {
+		return fmt.Errorf("sandbox workload %s owner id missing", workload.GetMeta().GetId())
+	}
+	runnerCtx, err := runnerIdentityContext(ctx, ownerID)
+	if err != nil {
+		return err
+	}
+	runnerClient, err := r.runnerDialer.Dial(ctx, runnerID)
+	if err != nil {
+		return fmt.Errorf("dial runner %s for sandbox workload %s: %w", runnerID, workload.GetMeta().GetId(), err)
+	}
+	instanceID := normalizeRunnerWorkloadID(workload.GetInstanceId())
+	if instanceID == "" {
+		return nil
+	}
+	return r.handlePresentRunnerWorkload(runnerCtx, runnerClient, workload, &runnerv1.WorkloadListItem{
+		InstanceId:  instanceID,
+		WorkloadKey: workload.GetMeta().GetId(),
+	})
 }
 
 func (r *Reconciler) startSandboxWorkload(ctx context.Context, plan *sandboxWorkloadPlan) error {

--- a/internal/reconciler/volume_reconcile.go
+++ b/internal/reconciler/volume_reconcile.go
@@ -66,7 +66,7 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	tracked, err := r.listActiveVolumes(ctx, orgIdentities)
+	tracked, ignoredVolumeKeysByRunner, err := r.listActiveVolumes(ctx, orgIdentities)
 	if err != nil {
 		return err
 	}
@@ -205,6 +205,9 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 			}
 			runnerVolumes[volumeKey] = item
 		}
+		for volumeID := range ignoredVolumeKeysByRunner[runnerID] {
+			delete(runnerVolumes, volumeID)
+		}
 
 		for volumeID, volume := range trackedVolumes {
 			volumeCtx, err := runnerIdentityContext(ctx, volume.GetAgentId())
@@ -241,10 +244,11 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 	return nil
 }
 
-func (r *Reconciler) listActiveVolumes(ctx context.Context, orgIdentities map[string]string) ([]*runnersv1.Volume, error) {
+func (r *Reconciler) listActiveVolumes(ctx context.Context, orgIdentities map[string]string) ([]*runnersv1.Volume, map[string]map[string]struct{}, error) {
 	active := []*runnersv1.Volume{}
+	ignoredVolumeKeysByRunner := map[string]map[string]struct{}{}
 	if len(orgIdentities) == 0 {
-		return active, nil
+		return active, ignoredVolumeKeysByRunner, nil
 	}
 	pageToken := ""
 	statuses := []runnersv1.VolumeStatus{
@@ -261,26 +265,36 @@ func (r *Reconciler) listActiveVolumes(ctx context.Context, orgIdentities map[st
 			},
 		})
 		if err != nil {
-			return nil, fmt.Errorf("list volumes: %w", err)
+			return nil, nil, fmt.Errorf("list volumes: %w", err)
 		}
 		for _, volume := range resp.GetVolumes() {
 			if volume == nil {
-				return nil, fmt.Errorf("volume is nil")
+				return nil, nil, fmt.Errorf("volume is nil")
 			}
 			meta := volume.GetMeta()
 			if meta == nil {
-				return nil, fmt.Errorf("volume meta missing")
+				return nil, nil, fmt.Errorf("volume meta missing")
 			}
 			if meta.GetId() == "" {
-				return nil, fmt.Errorf("volume meta id missing")
+				return nil, nil, fmt.Errorf("volume meta id missing")
+			}
+			if volume.GetOwnerKind() == runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
+				runnerID := strings.TrimSpace(volume.GetRunnerId())
+				if runnerID != "" {
+					if ignoredVolumeKeysByRunner[runnerID] == nil {
+						ignoredVolumeKeysByRunner[runnerID] = map[string]struct{}{}
+					}
+					ignoredVolumeKeysByRunner[runnerID][meta.GetId()] = struct{}{}
+				}
+				continue
 			}
 			orgID := strings.TrimSpace(volume.GetOrganizationId())
 			if orgID == "" {
-				return nil, fmt.Errorf("volume %s organization id missing", meta.GetId())
+				return nil, nil, fmt.Errorf("volume %s organization id missing", meta.GetId())
 			}
 			parsedOrgID, err := uuidutil.ParseUUID(orgID, "volume.organization_id")
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if _, ok := orgIdentities[parsedOrgID.String()]; !ok {
 				continue
@@ -292,7 +306,7 @@ func (r *Reconciler) listActiveVolumes(ctx context.Context, orgIdentities map[st
 			break
 		}
 	}
-	return active, nil
+	return active, ignoredVolumeKeysByRunner, nil
 }
 
 func (r *Reconciler) handleMissingRunnerVolume(ctx context.Context, volume *runnersv1.Volume) error {

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -55,6 +55,9 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 	workloadsByRunner := make(map[string]map[string]*runnersv1.Workload)
 	runnerIdentities := map[string]string{}
 	for _, workload := range tracked {
+		if workload.GetOwnerKind() == runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
+			continue
+		}
 		runnerID := workload.GetRunnerId()
 		if runnerID == "" {
 			log.Printf("reconciler: warn: workload %s missing runner id", workload.GetMeta().GetId())

--- a/internal/subscriber/interfaces.go
+++ b/internal/subscriber/interfaces.go
@@ -1,0 +1,12 @@
+package subscriber
+
+import (
+	"context"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	"google.golang.org/grpc"
+)
+
+type agentsClient interface {
+	ListAgents(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error)
+}

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -34,12 +34,12 @@ type roomSubscription struct {
 
 type Subscriber struct {
 	client              notificationsv1.NotificationsServiceClient
-	agents              agentsv1.AgentsServiceClient
+	agents              agentsClient
 	wake                chan struct{}
 	roomRefreshInterval time.Duration
 }
 
-func New(client notificationsv1.NotificationsServiceClient, agents agentsv1.AgentsServiceClient) *Subscriber {
+func New(client notificationsv1.NotificationsServiceClient, agents agentsClient) *Subscriber {
 	return &Subscriber{
 		client:              client,
 		agents:              agents,

--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -13,6 +13,7 @@ var ErrNotImplemented = errors.New("not implemented")
 
 type FakeAgentsClient struct {
 	GetAgentFunc                       func(context.Context, *agentsv1.GetAgentRequest, ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+	GetEnvironmentFunc                 func(context.Context, *agentsv1.GetEnvironmentRequest, ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error)
 	ResolveAgentIdentityFunc           func(context.Context, *agentsv1.ResolveAgentIdentityRequest, ...grpc.CallOption) (*agentsv1.ResolveAgentIdentityResponse, error)
 	ListAgentsFunc                     func(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error)
 	ListSkillsFunc                     func(context.Context, *agentsv1.ListSkillsRequest, ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error)
@@ -334,5 +335,28 @@ func (f *FakeSecretsClient) ResolveSecretExists(ctx context.Context, req *secret
 	if f.ResolveSecretExistsFunc != nil {
 		return f.ResolveSecretExistsFunc(ctx, req, opts...)
 	}
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeAgentsClient) GetUnackedInboxItems(context.Context, *agentsv1.GetUnackedInboxItemsRequest, ...grpc.CallOption) (*agentsv1.GetUnackedInboxItemsResponse, error) {
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeAgentsClient) AckInboxItems(context.Context, *agentsv1.AckInboxItemsRequest, ...grpc.CallOption) (*agentsv1.AckInboxItemsResponse, error) {
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeAgentsClient) GetEnvironment(ctx context.Context, req *agentsv1.GetEnvironmentRequest, opts ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
+	if f.GetEnvironmentFunc != nil {
+		return f.GetEnvironmentFunc(ctx, req, opts...)
+	}
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeAgentsClient) ListSandboxes(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error) {
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeAgentsClient) DeleteSandbox(context.Context, *agentsv1.DeleteSandboxRequest, ...grpc.CallOption) (*agentsv1.DeleteSandboxResponse, error) {
 	return nil, ErrNotImplemented
 }

--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -24,6 +24,7 @@ type FakeAgentsClient struct {
 	ListMcpsFunc                       func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error)
 	ListHooksFunc                      func(context.Context, *agentsv1.ListHooksRequest, ...grpc.CallOption) (*agentsv1.ListHooksResponse, error)
 	GetVolumeFunc                      func(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
+	ListSandboxesFunc                  func(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error)
 }
 
 func (f *FakeAgentsClient) CreateAgent(context.Context, *agentsv1.CreateAgentRequest, ...grpc.CallOption) (*agentsv1.CreateAgentResponse, error) {
@@ -353,7 +354,10 @@ func (f *FakeAgentsClient) GetEnvironment(ctx context.Context, req *agentsv1.Get
 	return nil, ErrNotImplemented
 }
 
-func (f *FakeAgentsClient) ListSandboxes(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error) {
+func (f *FakeAgentsClient) ListSandboxes(ctx context.Context, req *agentsv1.ListSandboxesRequest, opts ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error) {
+	if f.ListSandboxesFunc != nil {
+		return f.ListSandboxesFunc(ctx, req, opts...)
+	}
 	return nil, ErrNotImplemented
 }
 

--- a/internal/zitimanager/manager_test.go
+++ b/internal/zitimanager/manager_test.go
@@ -431,6 +431,7 @@ func identityResponse(id string) *zitimgmtv1.RequestServiceIdentityResponse {
 
 type fakeZitiMgmtClient struct {
 	createAgentIdentity    func(context.Context, *zitimgmtv1.CreateAgentIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error)
+	createSandboxIdentity  func(context.Context, *zitimgmtv1.CreateSandboxIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error)
 	createAppIdentity      func(context.Context, *zitimgmtv1.CreateAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAppIdentityResponse, error)
 	createService          func(context.Context, *zitimgmtv1.CreateServiceRequest, ...grpc.CallOption) (*zitimgmtv1.CreateServiceResponse, error)
 	getService             func(context.Context, *zitimgmtv1.GetServiceRequest, ...grpc.CallOption) (*zitimgmtv1.GetServiceResponse, error)
@@ -454,6 +455,13 @@ type fakeZitiMgmtClient struct {
 func (f *fakeZitiMgmtClient) CreateAgentIdentity(ctx context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 	if f.createAgentIdentity != nil {
 		return f.createAgentIdentity(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) CreateSandboxIdentity(ctx context.Context, req *zitimgmtv1.CreateSandboxIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error) {
+	if f.createSandboxIdentity != nil {
+		return f.createSandboxIdentity(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }

--- a/internal/zitimanager/manager_test.go
+++ b/internal/zitimanager/manager_test.go
@@ -431,7 +431,6 @@ func identityResponse(id string) *zitimgmtv1.RequestServiceIdentityResponse {
 
 type fakeZitiMgmtClient struct {
 	createAgentIdentity    func(context.Context, *zitimgmtv1.CreateAgentIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error)
-	createSandboxIdentity  func(context.Context, *zitimgmtv1.CreateSandboxIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error)
 	createAppIdentity      func(context.Context, *zitimgmtv1.CreateAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAppIdentityResponse, error)
 	createService          func(context.Context, *zitimgmtv1.CreateServiceRequest, ...grpc.CallOption) (*zitimgmtv1.CreateServiceResponse, error)
 	getService             func(context.Context, *zitimgmtv1.GetServiceRequest, ...grpc.CallOption) (*zitimgmtv1.GetServiceResponse, error)
@@ -455,13 +454,6 @@ type fakeZitiMgmtClient struct {
 func (f *fakeZitiMgmtClient) CreateAgentIdentity(ctx context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 	if f.createAgentIdentity != nil {
 		return f.createAgentIdentity(ctx, req, opts...)
-	}
-	return nil, errNotImplemented
-}
-
-func (f *fakeZitiMgmtClient) CreateSandboxIdentity(ctx context.Context, req *zitimgmtv1.CreateSandboxIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error) {
-	if f.createSandboxIdentity != nil {
-		return f.createSandboxIdentity(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }


### PR DESCRIPTION
## Summary

- Adds the sandbox workload assembler path using environment image, environment flavor runner placement/resources, platform sandbox init image, `agynd` holder mode, `/workspace` runtime workspace volume, environment envs, image pull secrets, and Ziti sidecar/init wiring when enabled.
- Adds a sandbox reconciliation loop for sandbox-owned workloads/volumes: start-on-create/start-needed states, idle stop, TTL termination/delete cleanup, sandbox runtime workspace record lifecycle, and sandbox-specific workload/volume ownership metadata.
- Keeps sandbox workloads out of the existing agent inbox/workload loops, and extends orchestrator metering labels for `owner_kind=sandbox` compute/storage records.
- Wires sandbox init image/workspace size configuration into Helm values and orchestrator config.

Related architecture issue: agynio/architecture#162

## Blocker / contract gap

The sandbox workload identity path is intentionally blocked when Ziti is enabled because the current generated `agynio/api/ziti_management/v1` contract has no sandbox-specific identity RPC. Using `CreateAgentIdentity` or `CreateDeviceIdentity` would model sandbox workloads with the wrong authority.

Proposed contract resolution:

- Add `CreateSandboxIdentity` or equivalent to `agynio/api/ziti_management/v1`.
- Required request fields: `sandbox_id`, `owner_id`, `environment_id`, `organization_id`, `workload_id`, `additional_role_attributes`, and `tags`.
- Response fields: `ziti_identity_id` and `enrollment_jwt`.
- Base role attributes should include platform service dial attributes and `environment-<id>` / narrow sandbox attributes, not org-member, device, or agent attributes.

## Validation

- `CGO_ENABLED=0 go test -json ./...` -> tests passed=181 failed=0 skipped=0
- `CGO_ENABLED=0 go build ./...` -> passed
- `CGO_ENABLED=0 go vet ./...` -> passed with no findings
- `git diff --check` -> passed

Note: plain `go test ./...` in this local container requires a C compiler for cgo and fails before tests run because `gcc` is not installed; validation used `CGO_ENABLED=0`, matching the repository Docker build configuration.