### PR TITLE
feat(reconciler): create sandbox ziti identities

### DIFF
--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -1901,6 +1901,7 @@ func (f *fakeRunnerClient) CancelExecution(context.Context, *runnerv1.CancelExec
 
 type fakeZitiMgmtClient struct {
 	createAgentIdentity         func(context.Context, *zitimgmtv1.CreateAgentIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error)
+	createSandboxIdentity       func(context.Context, *zitimgmtv1.CreateSandboxIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error)
 	patchIdentityRoleAttributes func(context.Context, *zitimgmtv1.PatchIdentityRoleAttributesRequest, ...grpc.CallOption) (*zitimgmtv1.PatchIdentityRoleAttributesResponse, error)
 	createAppIdentity           func(context.Context, *zitimgmtv1.CreateAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAppIdentityResponse, error)
 	createService               func(context.Context, *zitimgmtv1.CreateServiceRequest, ...grpc.CallOption) (*zitimgmtv1.CreateServiceResponse, error)
@@ -1932,6 +1933,13 @@ type fakeZitiMgmtClient struct {
 func (f *fakeZitiMgmtClient) CreateAgentIdentity(ctx context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 	if f.createAgentIdentity != nil {
 		return f.createAgentIdentity(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) CreateSandboxIdentity(ctx context.Context, req *zitimgmtv1.CreateSandboxIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error) {
+	if f.createSandboxIdentity != nil {
+		return f.createSandboxIdentity(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -1473,6 +1473,9 @@ func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
 	var createWorkloadReq *runnersv1.CreateWorkloadRequest
 	var createVolumeReq *runnersv1.CreateVolumeRequest
 	var updateWorkloadReq *runnersv1.UpdateWorkloadRequest
+	var sandboxIdentityReq *zitimgmtv1.CreateSandboxIdentityRequest
+	var agentIdentityCalled bool
+	var deviceIdentityCalled bool
 	var startedWorkloadID string
 	agents := &testutil.FakeAgentsClient{
 		GetEnvironmentFunc: func(_ context.Context, req *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
@@ -1525,17 +1528,40 @@ func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
 		return runner, nil
 	}}
 	cfg := &config.Config{
-		AgentGatewayAddress:    "gateway:50051",
-		AgentLLMBaseURL:        "http://llm:8080/v1",
-		SandboxInitImage:       "sandbox-init-image",
-		SandboxWorkspaceSizeGB: "10",
+		AgentGatewayAddress:                 "gateway:50051",
+		AgentLLMBaseURL:                     "http://llm:8080/v1",
+		SandboxInitImage:                    "sandbox-init-image",
+		SandboxWorkspaceSizeGB:              "10",
+		ZitiEnabled:                         true,
+		ZitiSidecarImage:                    "ziti-sidecar-image",
+		WorkloadDNSUpstream:                 "10.43.0.10",
+		ZitiEnrollmentDNSUpstream:           "10.43.0.10",
+		ZitiEnrollmentControllerResolveHost: "ziti-controller-client.ziti.svc.cluster.local",
+		ZitiEnrollmentControllerPort:        "2496",
+		ZitiRuntimeControllerResolveHost:    "istio-ingressgateway.istio-gateway.svc.cluster.local",
+		ZitiRuntimeControllerPort:           "443",
 	}
 	sandboxAssembler := assembler.NewWithRunners(agents, runners, &testutil.FakeSecretsClient{}, cfg)
+	zitiMgmt := &fakeZitiMgmtClient{
+		createSandboxIdentity: func(_ context.Context, req *zitimgmtv1.CreateSandboxIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error) {
+			sandboxIdentityReq = req
+			return &zitimgmtv1.CreateSandboxIdentityResponse{ZitiIdentityId: "sandbox-ziti-id", EnrollmentJwt: "sandbox-jwt"}, nil
+		},
+		createAgentIdentity: func(context.Context, *zitimgmtv1.CreateAgentIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
+			agentIdentityCalled = true
+			return nil, errors.New("agent identity must not be used for sandbox")
+		},
+		createDeviceIdentity: func(context.Context, *zitimgmtv1.CreateDeviceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateDeviceIdentityResponse, error) {
+			deviceIdentityCalled = true
+			return nil, errors.New("device identity must not be used for sandbox")
+		},
+	}
 	reconciler := newTestReconciler(Config{
 		RunnerDialer: runnerDialer,
 		Runners:      runners,
 		Agents:       agents,
 		Assembler:    sandboxAssembler,
+		ZitiMgmt:     zitiMgmt,
 	})
 	plan := &sandboxWorkloadPlan{sandboxID: uuid.MustParse(sandboxID), sandbox: &agentsv1.Sandbox{Meta: &agentsv1.EntityMeta{Id: sandboxID}, OrganizationId: testOrganizationID, Name: "sandbox", EnvironmentId: environmentID, OwnerId: ownerID, Status: agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING}}
 
@@ -1556,6 +1582,39 @@ func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
 	}
 	if createWorkloadReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING {
 		t.Fatalf("unexpected create workload status: %v", createWorkloadReq.GetStatus())
+	}
+	if createWorkloadReq.GetZitiIdentityId() != "sandbox-ziti-id" {
+		t.Fatalf("unexpected ziti identity id: %q", createWorkloadReq.GetZitiIdentityId())
+	}
+	if sandboxIdentityReq == nil {
+		t.Fatal("expected sandbox identity create")
+	}
+	if sandboxIdentityReq.GetSandboxId() != sandboxID {
+		t.Fatalf("unexpected sandbox id: %q", sandboxIdentityReq.GetSandboxId())
+	}
+	if sandboxIdentityReq.GetOwnerId() != ownerID {
+		t.Fatalf("unexpected owner id: %q", sandboxIdentityReq.GetOwnerId())
+	}
+	if sandboxIdentityReq.GetEnvironmentId() != environmentID {
+		t.Fatalf("unexpected environment id: %q", sandboxIdentityReq.GetEnvironmentId())
+	}
+	if sandboxIdentityReq.GetOrganizationId() != testOrganizationID {
+		t.Fatalf("unexpected organization id: %q", sandboxIdentityReq.GetOrganizationId())
+	}
+	if sandboxIdentityReq.GetWorkloadId() != startedWorkloadID {
+		t.Fatalf("unexpected workload id: %q started %q", sandboxIdentityReq.GetWorkloadId(), startedWorkloadID)
+	}
+	if len(sandboxIdentityReq.GetAdditionalRoleAttributes()) != 1 || sandboxIdentityReq.GetAdditionalRoleAttributes()[0] != "sandbox-environment-"+environmentID {
+		t.Fatalf("unexpected sandbox role attributes: %v", sandboxIdentityReq.GetAdditionalRoleAttributes())
+	}
+	if sandboxIdentityReq.GetTags()["agyn.sandbox.id"] != sandboxID || sandboxIdentityReq.GetTags()["agyn.workload.id"] != startedWorkloadID {
+		t.Fatalf("unexpected sandbox tags: %v", sandboxIdentityReq.GetTags())
+	}
+	if agentIdentityCalled {
+		t.Fatal("CreateAgentIdentity must not be used for sandbox workloads")
+	}
+	if deviceIdentityCalled {
+		t.Fatal("CreateDeviceIdentity must not be used for sandbox workloads")
 	}
 	if updateWorkloadReq == nil {
 		t.Fatal("expected workload update")

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -1604,7 +1604,7 @@ func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
 	if sandboxIdentityReq.GetWorkloadId() != startedWorkloadID {
 		t.Fatalf("unexpected workload id: %q started %q", sandboxIdentityReq.GetWorkloadId(), startedWorkloadID)
 	}
-	if len(sandboxIdentityReq.GetAdditionalRoleAttributes()) != 1 || sandboxIdentityReq.GetAdditionalRoleAttributes()[0] != "sandbox-environment-"+environmentID {
+	if len(sandboxIdentityReq.GetAdditionalRoleAttributes()) != 0 {
 		t.Fatalf("unexpected sandbox role attributes: %v", sandboxIdentityReq.GetAdditionalRoleAttributes())
 	}
 	if sandboxIdentityReq.GetTags()["agyn.sandbox.id"] != sandboxID || sandboxIdentityReq.GetTags()["agyn.workload.id"] != startedWorkloadID {

--- a/internal/reconciler/sandbox_reconciler.go
+++ b/internal/reconciler/sandbox_reconciler.go
@@ -11,6 +11,7 @@ import (
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	zitimgmtv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/agents-orchestrator/internal/assembler"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 	"github.com/google/uuid"
@@ -412,14 +413,37 @@ func (r *Reconciler) createSandboxIdentity(ctx context.Context, sandboxID, envir
 	if r.zitiMgmt == nil {
 		return nil, nil
 	}
-	return nil, fmt.Errorf(
-		"sandbox workload identity is blocked: agynio/api ziti_management.v1 has no CreateSandboxIdentity RPC for sandbox %s environment %s owner %s workload %s organization %s",
-		sandboxID.String(),
-		environmentID.String(),
-		ownerID.String(),
-		workloadID.String(),
-		organizationID,
-	)
+	resp, err := r.zitiMgmt.CreateSandboxIdentity(ctx, &zitimgmtv1.CreateSandboxIdentityRequest{
+		SandboxId:      sandboxID.String(),
+		OwnerId:        ownerID.String(),
+		EnvironmentId:  environmentID.String(),
+		OrganizationId: organizationID,
+		WorkloadId:     workloadID.String(),
+		AdditionalRoleAttributes: []string{
+			"sandbox-environment-" + environmentID.String(),
+		},
+		Tags: map[string]string{
+			"agyn.sandbox.id":       sandboxID.String(),
+			"agyn.sandbox.owner_id": ownerID.String(),
+			"agyn.environment.id":   environmentID.String(),
+			"agyn.workload.id":      workloadID.String(),
+			"agyn.organization.id":  organizationID,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create ziti identity for sandbox %s workload %s: %w", sandboxID.String(), workloadID.String(), err)
+	}
+	identityID := resp.GetZitiIdentityId()
+	enrollmentJWT := resp.GetEnrollmentJwt()
+	if identityID == "" || enrollmentJWT == "" {
+		var identityPtr *string
+		if identityID != "" {
+			identityPtr = &identityID
+		}
+		r.compensateIdentity(ctx, identityPtr, "missing sandbox identity fields")
+		return nil, fmt.Errorf("ziti identity response missing fields for sandbox %s workload %s", sandboxID.String(), workloadID.String())
+	}
+	return &identityInfo{id: identityID, enrollmentJWT: enrollmentJWT}, nil
 }
 
 func (r *Reconciler) stopSandboxWorkload(ctx context.Context, workload *runnersv1.Workload) error {

--- a/internal/reconciler/sandbox_reconciler.go
+++ b/internal/reconciler/sandbox_reconciler.go
@@ -419,9 +419,6 @@ func (r *Reconciler) createSandboxIdentity(ctx context.Context, sandboxID, envir
 		EnvironmentId:  environmentID.String(),
 		OrganizationId: organizationID,
 		WorkloadId:     workloadID.String(),
-		AdditionalRoleAttributes: []string{
-			"sandbox-environment-" + environmentID.String(),
-		},
 		Tags: map[string]string{
 			"agyn.sandbox.id":       sandboxID.String(),
 			"agyn.sandbox.owner_id": ownerID.String(),

--- a/internal/zitimanager/manager_test.go
+++ b/internal/zitimanager/manager_test.go
@@ -431,6 +431,7 @@ func identityResponse(id string) *zitimgmtv1.RequestServiceIdentityResponse {
 
 type fakeZitiMgmtClient struct {
 	createAgentIdentity    func(context.Context, *zitimgmtv1.CreateAgentIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error)
+	createSandboxIdentity  func(context.Context, *zitimgmtv1.CreateSandboxIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error)
 	createAppIdentity      func(context.Context, *zitimgmtv1.CreateAppIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.CreateAppIdentityResponse, error)
 	createService          func(context.Context, *zitimgmtv1.CreateServiceRequest, ...grpc.CallOption) (*zitimgmtv1.CreateServiceResponse, error)
 	getService             func(context.Context, *zitimgmtv1.GetServiceRequest, ...grpc.CallOption) (*zitimgmtv1.GetServiceResponse, error)
@@ -454,6 +455,13 @@ type fakeZitiMgmtClient struct {
 func (f *fakeZitiMgmtClient) CreateAgentIdentity(ctx context.Context, req *zitimgmtv1.CreateAgentIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateAgentIdentityResponse, error) {
 	if f.createAgentIdentity != nil {
 		return f.createAgentIdentity(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func (f *fakeZitiMgmtClient) CreateSandboxIdentity(ctx context.Context, req *zitimgmtv1.CreateSandboxIdentityRequest, opts ...grpc.CallOption) (*zitimgmtv1.CreateSandboxIdentityResponse, error) {
+	if f.createSandboxIdentity != nil {
+		return f.createSandboxIdentity(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }


### PR DESCRIPTION
## Summary
- Follows merged agynio/api#161 for the sandbox workload identity contract.
- Replaces the intentional sandbox identity blocker with `CreateSandboxIdentity` on the generated ziti-management client path.
- Keeps the merged sandbox reconciler fixes from #224 and verifies sandbox workloads do not use agent/device identity RPCs.

References agynio/architecture#162.

## Validation
- `CGO_ENABLED=0 go test ./...`
  - packages: passed=7 failed=0 skipped=5
  - tests: passed=189 failed=0 skipped=0
- `CGO_ENABLED=0 go build ./...`
  - passed
- `CGO_ENABLED=0 go vet ./...`
  - passed with no errors
- `git diff --check`
  - passed