### PR TITLE
feat: reconcile sandboxes and resolve flavors against the runner's catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .env
 .DS_Store
 .gen/
+
+# DevSpace writes caches and logs here during a source run.
+.devspace/

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -127,8 +127,6 @@ env:
     value: "ghcr.io/agynio/agent-init-codex:latest"
   - name: SANDBOX_WORKSPACE_SIZE_GB
     value: "10"
-  - name: SANDBOX_RECONCILE_ENABLED
-    value: "false"
   - name: SANDBOX_RECONCILE_ORGANIZATION_IDS
     value: ""
   - name: POLL_INTERVAL

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -179,7 +179,6 @@ func run() error {
 		StopSec:                         cfg.StopTimeoutSec,
 		MeteringSampleInterval:          cfg.MeteringSampleInterval,
 		SandboxReconcileOrganizationIDs: append([]string(nil), cfg.SandboxReconcileOrganizationIDs...),
-		SandboxReconcileEnabled:         cfg.SandboxReconcileEnabled,
 	})
 
 	start := func(leadCtx context.Context) {

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -144,7 +144,7 @@ func run() error {
 		defer closeConn(groupsConn)
 		groupsClient = groupsv1.NewGroupsServiceClient(groupsConn)
 	}
-	subscriber := subscriber.New(notificationsClient, agentsClient)
+	subscriber := subscriber.NewWithSandboxOrganizations(notificationsClient, agentsClient, cfg.SandboxReconcileOrganizationIDs)
 	egressCANamespace, err := k8sclient.ResolveNamespace(cfg.EgressCANamespace, "egress CA")
 	if err != nil {
 		return err
@@ -172,6 +172,7 @@ func run() error {
 		Metering:                        meteringClient,
 		Assembler:                       assembler,
 		Wake:                            subscriber.Wake(),
+		SandboxWake:                     subscriber.SandboxWake(),
 		Poll:                            cfg.PollInterval,
 		WorkloadReconcileInterval:       cfg.WorkloadReconcileInterval,
 		Idle:                            cfg.IdleTimeout,

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -114,6 +114,11 @@ func run() error {
 		if err != nil {
 			return err
 		}
+		go func() {
+			if err := <-manager.IdentityLost(); err != nil {
+				log.Fatalf("terminating: %v", err)
+			}
+		}()
 		go manager.RunLeaseRenewal(ctx)
 		runnerDialer = runnerdial.NewDialer(manager)
 	} else {

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -181,7 +181,7 @@ functions:
 
     echo "Waiting for orchestrator source sync and process start..."
     ELAPSED=0
-    LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator,app.kubernetes.io/instance=agents-orchestrator"
+    LABEL_SELECTOR="app.kubernetes.io/name=agents-orchestrator"
     until kubectl logs -n ${ORCHESTRATOR_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 2>/dev/null | \
       grep -q "orchestrator: ready"; do
       sleep 5
@@ -245,7 +245,6 @@ dev:
     namespace: ${ORCHESTRATOR_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: agents-orchestrator
-      app.kubernetes.io/instance: agents-orchestrator
     containers:
       agents-orchestrator:
         container: agents-orchestrator
@@ -278,7 +277,6 @@ dev:
     namespace: ${ORCHESTRATOR_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: agents-orchestrator
-      app.kubernetes.io/instance: agents-orchestrator
     containers:
       agents-orchestrator:
         container: agents-orchestrator

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -150,9 +150,13 @@ functions:
                 - name: go-mod-cache
                   mountPath: /tmp/go-mod-cache
               resources:
+                # Requests are reservations held for the pod's whole life, but a
+                # dev container only needs its build peak briefly and then idles
+                # near 100Mi. Keeping them low lets several services run from
+                # source on one node; the limits still allow a full build.
                 requests:
-                  cpu: 500m
-                  memory: 1Gi
+                  cpu: 100m
+                  memory: 256Mi
                 limits:
                   cpu: "2"
                   memory: 4Gi

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -747,11 +747,12 @@ func (a *Assembler) listEnvs(ctx context.Context, req *agentsv1.ListEnvsRequest)
 	for {
 		rctx, cancel := context.WithTimeout(ctx, rpcTimeout)
 		page, err := a.agents.ListEnvs(rctx, &agentsv1.ListEnvsRequest{
-			AgentId:   req.GetAgentId(),
-			McpId:     req.GetMcpId(),
-			HookId:    req.GetHookId(),
-			PageSize:  listPageSize,
-			PageToken: token,
+			AgentId:       req.GetAgentId(),
+			McpId:         req.GetMcpId(),
+			HookId:        req.GetHookId(),
+			EnvironmentId: req.GetEnvironmentId(),
+			PageSize:      listPageSize,
+			PageToken:     token,
 		})
 		cancel()
 		if err != nil {
@@ -800,6 +801,7 @@ func (a *Assembler) listImagePullSecretAttachments(ctx context.Context, req *age
 			AgentId:           req.GetAgentId(),
 			McpId:             req.GetMcpId(),
 			HookId:            req.GetHookId(),
+			EnvironmentId:     req.GetEnvironmentId(),
 			PageSize:          listPageSize,
 			PageToken:         token,
 		})

--- a/internal/assembler/interfaces.go
+++ b/internal/assembler/interfaces.go
@@ -20,5 +20,5 @@ type agentsClient interface {
 }
 
 type runnersClient interface {
-	GetFlavor(context.Context, *runnersv1.GetFlavorRequest, ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error)
+	ListFlavors(context.Context, *runnersv1.ListFlavorsRequest, ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error)
 }

--- a/internal/assembler/sandbox.go
+++ b/internal/assembler/sandbox.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 
+	"google.golang.org/protobuf/proto"
+
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
@@ -55,7 +57,7 @@ func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandb
 	if err != nil {
 		return nil, err
 	}
-	flavor, err := a.fetchFlavor(ctx, environment.GetFlavorId())
+	flavor, err := a.resolveFlavor(ctx, environment.GetRunnerId(), environment.GetFlavor())
 	if err != nil {
 		return nil, err
 	}
@@ -229,31 +231,55 @@ func (a *Assembler) fetchEnvironment(ctx context.Context, environmentID uuid.UUI
 	if environment.GetImage() == "" {
 		return nil, fmt.Errorf("environment %s image is required", environmentID.String())
 	}
-	if environment.GetFlavorId() == "" {
-		return nil, fmt.Errorf("environment %s flavor_id is required", environmentID.String())
+	if environment.GetRunnerId() == "" {
+		return nil, fmt.Errorf("environment %s runner_id is required", environmentID.String())
 	}
 	return environment, nil
 }
 
-func (a *Assembler) fetchFlavor(ctx context.Context, flavorID string) (*runnersv1.Flavor, error) {
-	flavorID = strings.TrimSpace(flavorID)
-	if flavorID == "" {
-		return nil, fmt.Errorf("flavor id missing")
+// resolveFlavor looks the environment's flavor name up in the runner's reported
+// catalog. The name is late-bound by design, so a name that is not in the
+// catalog is a scheduling failure the standard retry policy covers rather than
+// a permanent error — the runner may report it on its next startup.
+func (a *Assembler) resolveFlavor(ctx context.Context, runnerID, flavorName string) (*runnersv1.Flavor, error) {
+	runnerID = strings.TrimSpace(runnerID)
+	if runnerID == "" {
+		return nil, fmt.Errorf("runner id missing")
 	}
 	rctx, cancel := context.WithTimeout(ctx, rpcTimeout)
-	resp, err := a.runners.GetFlavor(rctx, &runnersv1.GetFlavorRequest{Id: flavorID})
+	resp, err := a.runners.ListFlavors(rctx, &runnersv1.ListFlavorsRequest{
+		RunnerId: &runnerID,
+		// A deprecated entry still resolves and schedules; the flag only steers
+		// new references away from it.
+		IncludeDeprecated: proto.Bool(true),
+	})
 	cancel()
 	if err != nil {
-		return nil, fmt.Errorf("get flavor %s: %w", flavorID, err)
+		return nil, fmt.Errorf("list flavors for runner %s: %w", runnerID, err)
 	}
-	flavor := resp.GetFlavor()
-	if flavor == nil {
-		return nil, fmt.Errorf("flavor %s missing", flavorID)
+
+	flavorName = strings.TrimSpace(flavorName)
+	var defaultFlavor *runnersv1.Flavor
+	for _, flavor := range resp.GetFlavors() {
+		if flavor == nil {
+			continue
+		}
+		if flavorName != "" && flavor.GetName() == flavorName {
+			return flavor, nil
+		}
+		if flavor.GetDefault() {
+			defaultFlavor = flavor
+		}
 	}
-	if flavor.GetRunnerId() == "" {
-		return nil, fmt.Errorf("flavor %s runner_id is required", flavorID)
+
+	// An environment naming no flavor takes the runner's default.
+	if flavorName == "" {
+		if defaultFlavor == nil {
+			return nil, fmt.Errorf("runner %s reports no default flavor", runnerID)
+		}
+		return defaultFlavor, nil
 	}
-	return flavor, nil
+	return nil, fmt.Errorf("runner %s reports no flavor named %q", runnerID, flavorName)
 }
 
 func flavorAllocatedResources(flavor *runnersv1.Flavor) (int32, int64, error) {

--- a/internal/assembler/sandbox_test.go
+++ b/internal/assembler/sandbox_test.go
@@ -1,0 +1,350 @@
+package assembler
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	secretsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/secrets/v1"
+	"github.com/agynio/agents-orchestrator/internal/config"
+	"github.com/agynio/agents-orchestrator/internal/testutil"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+const (
+	testSandboxImage      = "sandbox-image"
+	testSandboxInitImage  = "sandbox-init-image"
+	testSandboxFlavorID   = "flavor-1"
+	testSandboxRunnerID   = "runner-1"
+	testSandboxSizeGB     = "10"
+	testSandboxEnvName    = "sandbox-env"
+	testSandboxWorkspace  = "/workspace"
+	testSandboxGatewayURL = "gateway:50051"
+)
+
+type fakeRunnersClient struct {
+	getFlavor func(context.Context, *runnersv1.GetFlavorRequest, ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error)
+}
+
+func (f *fakeRunnersClient) GetFlavor(ctx context.Context, req *runnersv1.GetFlavorRequest, opts ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
+	if f.getFlavor != nil {
+		return f.getFlavor(ctx, req, opts...)
+	}
+	return nil, errors.New("not implemented")
+}
+
+type sandboxFixture struct {
+	sandbox           *agentsv1.Sandbox
+	sandboxID         uuid.UUID
+	environmentID     uuid.UUID
+	ownerID           uuid.UUID
+	workspaceVolumeID string
+	agents            *testutil.FakeAgentsClient
+	runners           *fakeRunnersClient
+	secrets           *testutil.FakeSecretsClient
+	cfg               *config.Config
+	egressCACert      []byte
+}
+
+func newSandboxFixture() *sandboxFixture {
+	sandboxID := uuid.New()
+	environmentID := uuid.New()
+	ownerID := uuid.New()
+	fixture := &sandboxFixture{
+		sandboxID:         sandboxID,
+		environmentID:     environmentID,
+		ownerID:           ownerID,
+		workspaceVolumeID: uuid.NewString(),
+		secrets:           &testutil.FakeSecretsClient{},
+		cfg: &config.Config{
+			AgentGatewayAddress:    testSandboxGatewayURL,
+			AgentLLMBaseURL:        "http://llm:8080/v1",
+			AgentTracingAddress:    "tracing:50051",
+			SandboxInitImage:       testSandboxInitImage,
+			SandboxWorkspaceSizeGB: testSandboxSizeGB,
+		},
+	}
+	fixture.sandbox = &agentsv1.Sandbox{
+		Meta:          &agentsv1.EntityMeta{Id: sandboxID.String()},
+		Name:          "brave-otter",
+		EnvironmentId: environmentID.String(),
+		OwnerId:       ownerID.String(),
+		Status:        agentsv1.SandboxStatus_SANDBOX_STATUS_STARTING,
+
+		OrganizationId: "org-1",
+	}
+	fixture.agents = &testutil.FakeAgentsClient{
+		GetEnvironmentFunc: func(_ context.Context, req *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
+			if req.GetId() != environmentID.String() {
+				return nil, errors.New("unexpected environment id")
+			}
+			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{
+				Meta:           &agentsv1.EntityMeta{Id: environmentID.String()},
+				OrganizationId: "org-1",
+				Name:           testSandboxEnvName,
+				Image:          testSandboxImage,
+				FlavorId:       testSandboxFlavorID,
+			}}, nil
+		},
+		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
+			return &agentsv1.ListEnvsResponse{}, nil
+		},
+		ListImagePullSecretAttachmentsFunc: func(context.Context, *agentsv1.ListImagePullSecretAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error) {
+			return &agentsv1.ListImagePullSecretAttachmentsResponse{}, nil
+		},
+	}
+	fixture.runners = &fakeRunnersClient{
+		getFlavor: func(_ context.Context, req *runnersv1.GetFlavorRequest, _ ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
+			if req.GetId() != testSandboxFlavorID {
+				return nil, errors.New("unexpected flavor id")
+			}
+			return &runnersv1.GetFlavorResponse{Flavor: &runnersv1.Flavor{
+				Meta:      &runnersv1.EntityMeta{Id: testSandboxFlavorID},
+				RunnerId:  testSandboxRunnerID,
+				Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"},
+			}}, nil
+		},
+	}
+	return fixture
+}
+
+func (f *sandboxFixture) assemble(t *testing.T) *SandboxAssembleResult {
+	t.Helper()
+	assembler := NewWithRunnersAndEgressCA(f.agents, f.runners, f.secrets, f.cfg, f.egressCACert)
+	result, err := assembler.AssembleSandbox(context.Background(), f.sandbox, f.workspaceVolumeID)
+	if err != nil {
+		t.Fatalf("assemble sandbox: %v", err)
+	}
+	return result
+}
+
+func TestAssembleSandboxUsesEnvironmentImageAndFlavor(t *testing.T) {
+	fixture := newSandboxFixture()
+	result := fixture.assemble(t)
+
+	if result.RunnerID != testSandboxRunnerID {
+		t.Fatalf("expected runner %q, got %q", testSandboxRunnerID, result.RunnerID)
+	}
+	if result.OrganizationID != "org-1" {
+		t.Fatalf("unexpected organization id %q", result.OrganizationID)
+	}
+	if result.EnvironmentID != fixture.environmentID {
+		t.Fatalf("unexpected environment id %s", result.EnvironmentID)
+	}
+	if result.OwnerID != fixture.ownerID {
+		t.Fatalf("unexpected owner id %s", result.OwnerID)
+	}
+	if result.WorkspaceVolumeID != fixture.workspaceVolumeID {
+		t.Fatalf("unexpected workspace volume id %q", result.WorkspaceVolumeID)
+	}
+	if result.WorkspaceSizeGB != testSandboxSizeGB {
+		t.Fatalf("unexpected workspace size %q", result.WorkspaceSizeGB)
+	}
+	if result.AllocatedCPUMillicores != 500 {
+		t.Fatalf("unexpected allocated cpu %d", result.AllocatedCPUMillicores)
+	}
+	if result.AllocatedRAMBytes != 1<<30 {
+		t.Fatalf("unexpected allocated ram %d", result.AllocatedRAMBytes)
+	}
+	main := result.Request.GetMain()
+	if main == nil {
+		t.Fatal("expected main container")
+	}
+	if main.GetImage() != testSandboxImage {
+		t.Fatalf("expected environment image %q, got %q", testSandboxImage, main.GetImage())
+	}
+	expectedName := "sandbox-" + fixture.sandboxID.String()[:8]
+	if main.GetName() != expectedName {
+		t.Fatalf("expected main name %q, got %q", expectedName, main.GetName())
+	}
+	properties := result.Request.GetAdditionalProperties()
+	if properties[LabelKeyPrefix+LabelSandboxID] != fixture.sandboxID.String() {
+		t.Fatalf("unexpected sandbox id label: %v", properties)
+	}
+	if properties[LabelKeyPrefix+LabelSandboxOwnerID] != fixture.ownerID.String() {
+		t.Fatalf("unexpected sandbox owner label: %v", properties)
+	}
+	if properties[LabelKeyPrefix+LabelEnvironmentID] != fixture.environmentID.String() {
+		t.Fatalf("unexpected environment label: %v", properties)
+	}
+}
+
+func TestAssembleSandboxRunsInitContainerAndHolderCommand(t *testing.T) {
+	fixture := newSandboxFixture()
+	result := fixture.assemble(t)
+
+	initContainers := result.Request.GetInitContainers()
+	if len(initContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(initContainers))
+	}
+	initContainer := initContainers[0]
+	if initContainer.GetImage() != testSandboxInitImage {
+		t.Fatalf("expected init image %q, got %q", testSandboxInitImage, initContainer.GetImage())
+	}
+	initMount := findVolumeMount(initContainer, agynBinVolumeName)
+	if initMount == nil || initMount.GetMountPath() != agynBinMountPath {
+		t.Fatalf("expected agyn-bin mount on the init container, got %v", initContainer.GetMounts())
+	}
+	if findVolumeSpec(result.Request.GetVolumes(), agynBinVolumeName) == nil {
+		t.Fatalf("expected agyn-bin volume, got %v", result.Request.GetVolumes())
+	}
+	main := result.Request.GetMain()
+	if !equalStringSlice(main.GetCmd(), []string{agynBinBinaryPath}) {
+		t.Fatalf("unexpected main cmd %v", main.GetCmd())
+	}
+	mainBinMount := findVolumeMount(main, agynBinVolumeName)
+	if mainBinMount == nil || mainBinMount.GetMountPath() != agynBinMountPath {
+		t.Fatalf("expected agyn-bin mount on the main container, got %v", main.GetMounts())
+	}
+}
+
+func TestAssembleSandboxSetsHolderMode(t *testing.T) {
+	fixture := newSandboxFixture()
+	result := fixture.assemble(t)
+
+	envs := envMap(result.Request.GetMain().GetEnv())
+	assertEnv(t, envs, "AGYND_MODE", SandboxHolderMode)
+	assertEnv(t, envs, "SANDBOX_ID", fixture.sandboxID.String())
+	assertEnv(t, envs, "SANDBOX_NAME", "brave-otter")
+	assertEnv(t, envs, "SANDBOX_OWNER_ID", fixture.ownerID.String())
+	assertEnv(t, envs, "ENVIRONMENT_ID", fixture.environmentID.String())
+	assertEnv(t, envs, "ENVIRONMENT_NAME", testSandboxEnvName)
+	assertEnv(t, envs, "WORKSPACE_DIR", testSandboxWorkspace)
+}
+
+func TestAssembleSandboxSetsNoAgentPlatformEnv(t *testing.T) {
+	fixture := newSandboxFixture()
+	result := fixture.assemble(t)
+
+	for name := range envMap(result.Request.GetMain().GetEnv()) {
+		if strings.HasPrefix(name, "AGENT_") {
+			t.Fatalf("unexpected agent platform env %s on a sandbox workload", name)
+		}
+	}
+}
+
+func TestAssembleSandboxMountsPersistentWorkspace(t *testing.T) {
+	fixture := newSandboxFixture()
+	result := fixture.assemble(t)
+
+	main := result.Request.GetMain()
+	if main.GetWorkingDir() != SandboxWorkspaceMountPath {
+		t.Fatalf("expected working dir %q, got %q", SandboxWorkspaceMountPath, main.GetWorkingDir())
+	}
+	workspaceMount := findVolumeMount(main, sandboxWorkspaceVolumeName)
+	if workspaceMount == nil {
+		t.Fatalf("expected workspace mount, got %v", main.GetMounts())
+	}
+	if workspaceMount.GetMountPath() != SandboxWorkspaceMountPath {
+		t.Fatalf("expected workspace mount path %q, got %q", SandboxWorkspaceMountPath, workspaceMount.GetMountPath())
+	}
+	workspaceVolume := findVolumeSpec(result.Request.GetVolumes(), sandboxWorkspaceVolumeName)
+	if workspaceVolume == nil {
+		t.Fatalf("expected workspace volume, got %v", result.Request.GetVolumes())
+	}
+	if workspaceVolume.GetKind() != runnerv1.VolumeKind_VOLUME_KIND_NAMED {
+		t.Fatalf("expected a named workspace volume, got %v", workspaceVolume.GetKind())
+	}
+	// The deterministic persistent name is what lets the workspace survive idle
+	// stops and reconnects.
+	expectedPersistentName := "sandbox-ws-" + fixture.sandboxID.String()
+	if workspaceVolume.GetPersistentName() != expectedPersistentName {
+		t.Fatalf("expected persistent name %q, got %q", expectedPersistentName, workspaceVolume.GetPersistentName())
+	}
+	labels := workspaceVolume.GetLabels()
+	if labels[LabelSandboxID] != fixture.sandboxID.String() {
+		t.Fatalf("unexpected workspace sandbox label: %v", labels)
+	}
+	if labels[LabelSandboxOwnerID] != fixture.ownerID.String() {
+		t.Fatalf("unexpected workspace owner label: %v", labels)
+	}
+	if labels[LabelVolumeKey] != fixture.workspaceVolumeID {
+		t.Fatalf("unexpected workspace volume key label: %v", labels)
+	}
+}
+
+func TestAssembleSandboxInjectsEnvironmentEnvsAndSecrets(t *testing.T) {
+	fixture := newSandboxFixture()
+	secretID := uuid.NewString()
+	fixture.agents.ListEnvsFunc = func(_ context.Context, req *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
+		if req.GetEnvironmentId() != fixture.environmentID.String() {
+			return nil, errors.New("expected environment-scoped env listing")
+		}
+		return &agentsv1.ListEnvsResponse{Envs: []*agentsv1.Env{
+			{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "PLAIN_ENV", Source: &agentsv1.Env_Value{Value: "plain"}},
+			{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "SECRET_ENV", Source: &agentsv1.Env_SecretId{SecretId: secretID}},
+		}}, nil
+	}
+	fixture.secrets.ResolveSecretFunc = func(_ context.Context, req *secretsv1.ResolveSecretRequest, _ ...grpc.CallOption) (*secretsv1.ResolveSecretResponse, error) {
+		if req.GetId() != secretID {
+			return nil, errors.New("unexpected secret id")
+		}
+		return &secretsv1.ResolveSecretResponse{Value: "resolved-secret"}, nil
+	}
+
+	result := fixture.assemble(t)
+	envs := envMap(result.Request.GetMain().GetEnv())
+	assertEnv(t, envs, "PLAIN_ENV", "plain")
+	assertEnv(t, envs, "SECRET_ENV", "resolved-secret")
+}
+
+func TestAssembleSandboxResolvesImagePullSecrets(t *testing.T) {
+	fixture := newSandboxFixture()
+	imagePullSecretID := uuid.NewString()
+	fixture.agents.ListImagePullSecretAttachmentsFunc = func(_ context.Context, req *agentsv1.ListImagePullSecretAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error) {
+		if req.GetEnvironmentId() != fixture.environmentID.String() {
+			return nil, errors.New("expected environment-scoped image pull secret listing")
+		}
+		return &agentsv1.ListImagePullSecretAttachmentsResponse{ImagePullSecretAttachments: []*agentsv1.ImagePullSecretAttachment{
+			{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, ImagePullSecretId: imagePullSecretID},
+		}}, nil
+	}
+	fixture.secrets.ResolveImagePullSecretFunc = func(_ context.Context, req *secretsv1.ResolveImagePullSecretRequest, _ ...grpc.CallOption) (*secretsv1.ResolveImagePullSecretResponse, error) {
+		if req.GetId() != imagePullSecretID {
+			return nil, errors.New("unexpected image pull secret id")
+		}
+		return &secretsv1.ResolveImagePullSecretResponse{Registry: "registry.example.com", Username: "robot", Password: "token"}, nil
+	}
+
+	result := fixture.assemble(t)
+	credentials := result.Request.GetImagePullCredentials()
+	if len(credentials) != 1 {
+		t.Fatalf("expected 1 image pull credential, got %d", len(credentials))
+	}
+	if credentials[0].GetRegistry() != "registry.example.com" || credentials[0].GetUsername() != "robot" || credentials[0].GetPassword() != "token" {
+		t.Fatalf("unexpected image pull credential: %v", credentials[0])
+	}
+}
+
+func TestAssembleSandboxDistributesEgressCA(t *testing.T) {
+	fixture := newSandboxFixture()
+	fixture.egressCACert = []byte("egress-ca-cert")
+	result := fixture.assemble(t)
+
+	inlineFiles := result.Request.GetInlineFiles()
+	if string(inlineFiles[egressCACertPath]) != "egress-ca-cert" {
+		t.Fatalf("expected the egress CA inline file, got %v", inlineFiles)
+	}
+	main := result.Request.GetMain()
+	if len(main.GetInlineFileMounts()) != 1 || main.GetInlineFileMounts()[0].GetPath() != egressCACertPath {
+		t.Fatalf("expected the egress CA mounted into the main container, got %v", main.GetInlineFileMounts())
+	}
+	envs := envMap(main.GetEnv())
+	assertEnv(t, envs, "SSL_CERT_FILE", egressCACertPath)
+	assertEnv(t, envs, "REQUESTS_CA_BUNDLE", egressCACertPath)
+	assertEnv(t, envs, "NODE_EXTRA_CA_CERTS", egressCACertPath)
+	assertEnv(t, envs, "CURL_CA_BUNDLE", egressCACertPath)
+	assertEnv(t, envs, "SSL_CERT_DIR", egressCACertDir)
+
+	initContainer := result.Request.GetInitContainers()[0]
+	if len(initContainer.GetInlineFileMounts()) != 1 || initContainer.GetInlineFileMounts()[0].GetPath() != egressCACertPath {
+		t.Fatalf("expected the egress CA mounted into the init container, got %v", initContainer.GetInlineFileMounts())
+	}
+	initEnvs := envMap(initContainer.GetEnv())
+	assertEnv(t, initEnvs, "SSL_CERT_FILE", egressCACertPath)
+}

--- a/internal/assembler/sandbox_test.go
+++ b/internal/assembler/sandbox_test.go
@@ -19,7 +19,7 @@ import (
 const (
 	testSandboxImage      = "sandbox-image"
 	testSandboxInitImage  = "sandbox-init-image"
-	testSandboxFlavorID   = "flavor-1"
+	testSandboxFlavor     = "ram-2gb"
 	testSandboxRunnerID   = "runner-1"
 	testSandboxSizeGB     = "10"
 	testSandboxEnvName    = "sandbox-env"
@@ -28,12 +28,12 @@ const (
 )
 
 type fakeRunnersClient struct {
-	getFlavor func(context.Context, *runnersv1.GetFlavorRequest, ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error)
+	listFlavors func(context.Context, *runnersv1.ListFlavorsRequest, ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error)
 }
 
-func (f *fakeRunnersClient) GetFlavor(ctx context.Context, req *runnersv1.GetFlavorRequest, opts ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
-	if f.getFlavor != nil {
-		return f.getFlavor(ctx, req, opts...)
+func (f *fakeRunnersClient) ListFlavors(ctx context.Context, req *runnersv1.ListFlavorsRequest, opts ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+	if f.listFlavors != nil {
+		return f.listFlavors(ctx, req, opts...)
 	}
 	return nil, errors.New("not implemented")
 }
@@ -88,7 +88,8 @@ func newSandboxFixture() *sandboxFixture {
 				OrganizationId: "org-1",
 				Name:           testSandboxEnvName,
 				Image:          testSandboxImage,
-				FlavorId:       testSandboxFlavorID,
+				RunnerId:       testSandboxRunnerID,
+				Flavor:         testSandboxFlavor,
 			}}, nil
 		},
 		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
@@ -99,14 +100,22 @@ func newSandboxFixture() *sandboxFixture {
 		},
 	}
 	fixture.runners = &fakeRunnersClient{
-		getFlavor: func(_ context.Context, req *runnersv1.GetFlavorRequest, _ ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
-			if req.GetId() != testSandboxFlavorID {
-				return nil, errors.New("unexpected flavor id")
+		listFlavors: func(_ context.Context, req *runnersv1.ListFlavorsRequest, _ ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			if req.GetRunnerId() != testSandboxRunnerID {
+				return nil, errors.New("unexpected runner id")
 			}
-			return &runnersv1.GetFlavorResponse{Flavor: &runnersv1.Flavor{
-				Meta:      &runnersv1.EntityMeta{Id: testSandboxFlavorID},
-				RunnerId:  testSandboxRunnerID,
-				Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"},
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{
+				{
+					RunnerId:  testSandboxRunnerID,
+					Name:      "other",
+					Default:   true,
+					Resources: &runnersv1.ComputeResources{RequestsCpu: "100m", RequestsMemory: "256Mi"},
+				},
+				{
+					RunnerId:  testSandboxRunnerID,
+					Name:      testSandboxFlavor,
+					Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"},
+				},
 			}}, nil
 		},
 	}
@@ -347,4 +356,56 @@ func TestAssembleSandboxDistributesEgressCA(t *testing.T) {
 	}
 	initEnvs := envMap(initContainer.GetEnv())
 	assertEnv(t, initEnvs, "SSL_CERT_FILE", egressCACertPath)
+}
+
+func TestResolveFlavorFallsBackToRunnerDefault(t *testing.T) {
+	// An environment naming no flavor takes whatever the runner marks default.
+	assembler := &Assembler{runners: &fakeRunnersClient{
+		listFlavors: func(_ context.Context, _ *runnersv1.ListFlavorsRequest, _ ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{
+				{RunnerId: testSandboxRunnerID, Name: "ram-4gb"},
+				{RunnerId: testSandboxRunnerID, Name: "ram-2gb", Default: true},
+			}}, nil
+		},
+	}}
+
+	flavor, err := assembler.resolveFlavor(context.Background(), testSandboxRunnerID, "")
+	if err != nil {
+		t.Fatalf("resolve flavor: %v", err)
+	}
+	if flavor.GetName() != "ram-2gb" {
+		t.Fatalf("expected the default flavor, got %q", flavor.GetName())
+	}
+}
+
+func TestResolveFlavorFailsWhenNameIsNotReported(t *testing.T) {
+	// Late binding means an unknown name is a scheduling failure the retry
+	// policy covers, not a silent fallback to some other size.
+	assembler := &Assembler{runners: &fakeRunnersClient{
+		listFlavors: func(_ context.Context, _ *runnersv1.ListFlavorsRequest, _ ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{
+				{RunnerId: testSandboxRunnerID, Name: "ram-2gb", Default: true},
+			}}, nil
+		},
+	}}
+
+	_, err := assembler.resolveFlavor(context.Background(), testSandboxRunnerID, "ram-64gb")
+	if err == nil || !strings.Contains(err.Error(), "ram-64gb") {
+		t.Fatalf("expected the unknown name to be reported, got %v", err)
+	}
+}
+
+func TestResolveFlavorFailsWhenRunnerHasNoDefault(t *testing.T) {
+	assembler := &Assembler{runners: &fakeRunnersClient{
+		listFlavors: func(_ context.Context, _ *runnersv1.ListFlavorsRequest, _ ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{
+				{RunnerId: testSandboxRunnerID, Name: "ram-2gb"},
+			}}, nil
+		},
+	}}
+
+	_, err := assembler.resolveFlavor(context.Background(), testSandboxRunnerID, "")
+	if err == nil || !strings.Contains(err.Error(), "no default flavor") {
+		t.Fatalf("expected a missing default to be reported, got %v", err)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,6 @@ type Config struct {
 	MeteringServiceAddress              string
 	MeteringSampleInterval              time.Duration
 	ZitiEnabled                         bool
-	SandboxReconcileEnabled             bool
 	SandboxReconcileOrganizationIDs     []string
 	ZitiManagementAddress               string
 	GroupsAddress                       string
@@ -134,14 +133,6 @@ func FromEnv() (Config, error) {
 	}
 	if _, err := strconv.ParseFloat(cfg.SandboxWorkspaceSizeGB, 64); err != nil {
 		return Config{}, fmt.Errorf("parse SANDBOX_WORKSPACE_SIZE_GB: %w", err)
-	}
-	sandboxReconcileEnabled := os.Getenv("SANDBOX_RECONCILE_ENABLED")
-	if sandboxReconcileEnabled != "" {
-		parsed, err := strconv.ParseBool(sandboxReconcileEnabled)
-		if err != nil {
-			return Config{}, fmt.Errorf("parse SANDBOX_RECONCILE_ENABLED: %w", err)
-		}
-		cfg.SandboxReconcileEnabled = parsed
 	}
 	var err error
 	cfg.SandboxReconcileOrganizationIDs, err = parseUUIDList(os.Getenv("SANDBOX_RECONCILE_ORGANIZATION_IDS"), "SANDBOX_RECONCILE_ORGANIZATION_IDS")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,9 +47,6 @@ func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	if cfg.GroupSyncEnabled {
 		t.Fatal("expected group sync to be disabled")
 	}
-	if cfg.SandboxReconcileEnabled {
-		t.Fatal("expected sandbox reconciliation to be disabled")
-	}
 	if cfg.GroupsAddress != "groups:50051" {
 		t.Fatalf("expected groups address %q, got %q", "groups:50051", cfg.GroupsAddress)
 	}
@@ -301,7 +298,6 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("AGENT_LLM_BASE_URL", "")
 	t.Setenv("SANDBOX_INIT_IMAGE", "")
 	t.Setenv("SANDBOX_WORKSPACE_SIZE_GB", "")
-	t.Setenv("SANDBOX_RECONCILE_ENABLED", "")
 	t.Setenv("SANDBOX_RECONCILE_ORGANIZATION_IDS", "")
 	t.Setenv("POLL_INTERVAL", "")
 	t.Setenv("WORKLOAD_RECONCILE_INTERVAL", "")
@@ -310,29 +306,6 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("LEASE_NAME", "")
 	t.Setenv("LEASE_NAMESPACE", "")
 	t.Setenv("EGRESS_CA_NAMESPACE", "")
-}
-
-func TestFromEnvSandboxReconcileEnabled(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("SANDBOX_RECONCILE_ENABLED", "true")
-
-	cfg, err := FromEnv()
-	if err != nil {
-		t.Fatalf("FromEnv: %v", err)
-	}
-	if !cfg.SandboxReconcileEnabled {
-		t.Fatal("expected sandbox reconciliation to be enabled")
-	}
-}
-
-func TestFromEnvSandboxReconcileEnabledInvalid(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("SANDBOX_RECONCILE_ENABLED", "not-bool")
-
-	_, err := FromEnv()
-	if err == nil {
-		t.Fatal("expected SANDBOX_RECONCILE_ENABLED parse error")
-	}
 }
 
 func TestFromEnvGroupSyncConfig(t *testing.T) {

--- a/internal/reconciler/interfaces.go
+++ b/internal/reconciler/interfaces.go
@@ -11,6 +11,7 @@ import (
 type agentsClient interface {
 	ListAgents(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error)
 	GetVolume(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
+	GetSandbox(context.Context, *agentsv1.GetSandboxRequest, ...grpc.CallOption) (*agentsv1.GetSandboxResponse, error)
 	ListSandboxes(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error)
 	UpdateSandboxRuntimeState(context.Context, *agentsv1.UpdateSandboxRuntimeStateRequest, ...grpc.CallOption) (*agentsv1.UpdateSandboxRuntimeStateResponse, error)
 	DeleteSandbox(context.Context, *agentsv1.DeleteSandboxRequest, ...grpc.CallOption) (*agentsv1.DeleteSandboxResponse, error)

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -1646,7 +1646,7 @@ func (f *fakeRunnerDialer) Close() {}
 type fakeRunnersClient struct {
 	createWorkload        func(context.Context, *runnersv1.CreateWorkloadRequest, ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error)
 	createVolume          func(context.Context, *runnersv1.CreateVolumeRequest, ...grpc.CallOption) (*runnersv1.CreateVolumeResponse, error)
-	getFlavor             func(context.Context, *runnersv1.GetFlavorRequest, ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error)
+	listFlavors           func(context.Context, *runnersv1.ListFlavorsRequest, ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error)
 	deleteWorkload        func(context.Context, *runnersv1.DeleteWorkloadRequest, ...grpc.CallOption) (*runnersv1.DeleteWorkloadResponse, error)
 	getRunner             func(context.Context, *runnersv1.GetRunnerRequest, ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error)
 	listWorkloads         func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error)
@@ -1674,9 +1674,9 @@ func (f *fakeRunnersClient) GetRunner(ctx context.Context, req *runnersv1.GetRun
 	return nil, errNotImplemented
 }
 
-func (f *fakeRunnersClient) GetFlavor(ctx context.Context, req *runnersv1.GetFlavorRequest, opts ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
-	if f.getFlavor != nil {
-		return f.getFlavor(ctx, req, opts...)
+func (f *fakeRunnersClient) ListFlavors(ctx context.Context, req *runnersv1.ListFlavorsRequest, opts ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+	if f.listFlavors != nil {
+		return f.listFlavors(ctx, req, opts...)
 	}
 	return nil, errNotImplemented
 }

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -1220,15 +1220,21 @@ func TestReconcileOrphanIdentitiesDeletesOrphans(t *testing.T) {
 	deleteCalls := []string{}
 	zitiMgmt := &fakeZitiMgmtClient{
 		listManagedIdentities: func(_ context.Context, req *zitimgmtv1.ListManagedIdentitiesRequest, _ ...grpc.CallOption) (*zitimgmtv1.ListManagedIdentitiesResponse, error) {
-			if req.GetIdentityType() != identityv1.IdentityType_IDENTITY_TYPE_AGENT {
+			// The sweep covers agent and sandbox identities in the same pass;
+			// this case exercises the agent half and has no sandbox identities.
+			switch req.GetIdentityType() {
+			case identityv1.IdentityType_IDENTITY_TYPE_AGENT:
+				return &zitimgmtv1.ListManagedIdentitiesResponse{
+					Identities: []*zitimgmtv1.ManagedIdentity{
+						{ZitiIdentityId: activeID},
+						{ZitiIdentityId: orphanID},
+					},
+				}, nil
+			case identityv1.IdentityType_IDENTITY_TYPE_SANDBOX:
+				return &zitimgmtv1.ListManagedIdentitiesResponse{}, nil
+			default:
 				return nil, errors.New("unexpected identity type")
 			}
-			return &zitimgmtv1.ListManagedIdentitiesResponse{
-				Identities: []*zitimgmtv1.ManagedIdentity{
-					{ZitiIdentityId: activeID},
-					{ZitiIdentityId: orphanID},
-				},
-			}, nil
 		},
 		deleteIdentity: func(_ context.Context, req *zitimgmtv1.DeleteIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.DeleteIdentityResponse, error) {
 			deleteCalls = append(deleteCalls, req.GetZitiIdentityId())

--- a/internal/reconciler/metering_sample.go
+++ b/internal/reconciler/metering_sample.go
@@ -6,10 +6,12 @@ import (
 	"log"
 	"math"
 	"math/big"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	meteringv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/metering/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
@@ -25,6 +27,7 @@ const (
 	labelThreadID                = "thread_id"
 	labelAgentID                 = "agent_id"
 	labelSandboxID               = "sandbox_id"
+	labelSandboxOwnerID          = "sandbox_owner_id"
 	labelOwnerKind               = "owner_kind"
 	labelRunnerID                = "runner_id"
 	labelIdentityID              = "identity_id"
@@ -78,12 +81,14 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 		return nil
 	}
 
+	sandboxOwners := r.sandboxOwnerIDs(ctx, workloads, volumes)
+
 	records := make([]*meteringv1.UsageRecord, 0, len(workloads)*2+len(volumes))
 	workloadUpdates := make([]*runnersv1.SampledAtEntry, 0, len(workloads))
 	volumeUpdates := make([]*runnersv1.SampledAtEntry, 0, len(volumes))
 
 	for _, workload := range workloads {
-		workloadRecords, update, err := sampleWorkloadMetering(workload, now)
+		workloadRecords, update, err := sampleWorkloadMetering(workload, now, sandboxOwners)
 		if err != nil {
 			return err
 		}
@@ -93,7 +98,7 @@ func (r *Reconciler) sampleMetering(ctx context.Context, now time.Time) error {
 		records = append(records, workloadRecords...)
 	}
 	for _, volume := range volumes {
-		volumeRecord, update, err := sampleVolumeMetering(volume, now)
+		volumeRecord, update, err := sampleVolumeMetering(volume, now, sandboxOwners)
 		if err != nil {
 			return err
 		}
@@ -221,7 +226,55 @@ func (r *Reconciler) listPendingSampleVolumes(ctx context.Context, orgIdentities
 	return volumes, nil
 }
 
-func sampleWorkloadMetering(workload *runnersv1.Workload, now time.Time) ([]*meteringv1.UsageRecord, *runnersv1.SampledAtEntry, error) {
+// sandboxOwnerIDs resolves the owning user of every sandbox with pending
+// samples. Metering records for sandbox workloads are attributed to the
+// organization and labelled with the sandbox and its owner; a sandbox that can
+// no longer be resolved is metered without the owner label rather than losing
+// the whole sample cycle.
+func (r *Reconciler) sandboxOwnerIDs(ctx context.Context, workloads []*runnersv1.Workload, volumes []*runnersv1.Volume) map[string]string {
+	pending := map[string]struct{}{}
+	for _, workload := range workloads {
+		if workload.GetOwnerKind() != runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
+			continue
+		}
+		if sandboxID := strings.TrimSpace(workload.GetOwnerId()); sandboxID != "" {
+			pending[sandboxID] = struct{}{}
+		}
+	}
+	for _, volume := range volumes {
+		if volume.GetOwnerKind() != runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
+			continue
+		}
+		if sandboxID := strings.TrimSpace(volume.GetOwnerId()); sandboxID != "" {
+			pending[sandboxID] = struct{}{}
+		}
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	sandboxIDs := make([]string, 0, len(pending))
+	for sandboxID := range pending {
+		sandboxIDs = append(sandboxIDs, sandboxID)
+	}
+	sort.Strings(sandboxIDs)
+	owners := make(map[string]string, len(sandboxIDs))
+	for _, sandboxID := range sandboxIDs {
+		resp, err := r.agents.GetSandbox(ctx, &agentsv1.GetSandboxRequest{Ref: &agentsv1.GetSandboxRequest_Id{Id: sandboxID}})
+		if err != nil {
+			log.Printf("reconciler: warn: get sandbox %s for metering labels: %v", sandboxID, err)
+			continue
+		}
+		ownerID := strings.TrimSpace(resp.GetSandbox().GetOwnerId())
+		if ownerID == "" {
+			log.Printf("reconciler: warn: sandbox %s owner id missing for metering labels", sandboxID)
+			continue
+		}
+		owners[sandboxID] = ownerID
+	}
+	return owners
+}
+
+func sampleWorkloadMetering(workload *runnersv1.Workload, now time.Time, sandboxOwners map[string]string) ([]*meteringv1.UsageRecord, *runnersv1.SampledAtEntry, error) {
 	meta := workload.GetMeta()
 	if meta == nil || meta.GetId() == "" {
 		return nil, nil, fmt.Errorf("workload meta missing")
@@ -242,7 +295,7 @@ func sampleWorkloadMetering(workload *runnersv1.Workload, now time.Time) ([]*met
 	if orgID == "" {
 		return nil, nil, fmt.Errorf("workload %s organization id missing", workloadID)
 	}
-	baseLabels, err := workloadLabels(workload, workloadID)
+	baseLabels, err := workloadLabels(workload, workloadID, sandboxOwners)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -295,7 +348,7 @@ func sampleWorkloadMetering(workload *runnersv1.Workload, now time.Time) ([]*met
 	return records, update, nil
 }
 
-func sampleVolumeMetering(volume *runnersv1.Volume, now time.Time) (*meteringv1.UsageRecord, *runnersv1.SampledAtEntry, error) {
+func sampleVolumeMetering(volume *runnersv1.Volume, now time.Time, sandboxOwners map[string]string) (*meteringv1.UsageRecord, *runnersv1.SampledAtEntry, error) {
 	meta := volume.GetMeta()
 	if meta == nil || meta.GetId() == "" {
 		return nil, nil, fmt.Errorf("volume meta missing")
@@ -316,7 +369,7 @@ func sampleVolumeMetering(volume *runnersv1.Volume, now time.Time) (*meteringv1.
 	if orgID == "" {
 		return nil, nil, fmt.Errorf("volume %s organization id missing", volumeID)
 	}
-	labels, err := volumeLabels(volume, volumeID)
+	labels, err := volumeLabels(volume, volumeID, sandboxOwners)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -354,7 +407,7 @@ func sampleWindow(kind, id string, createdAt, lastSampledAt, removedAt *timestam
 	return start.AsTime().UTC(), end, nil
 }
 
-func workloadLabels(workload *runnersv1.Workload, workloadID string) (map[string]string, error) {
+func workloadLabels(workload *runnersv1.Workload, workloadID string, sandboxOwners map[string]string) (map[string]string, error) {
 	runnerID := strings.TrimSpace(workload.GetRunnerId())
 	if runnerID == "" {
 		return nil, fmt.Errorf("workload %s runner id missing", workloadID)
@@ -364,13 +417,13 @@ func workloadLabels(workload *runnersv1.Workload, workloadID string) (map[string
 		labelResourceID: workloadID,
 		labelRunnerID:   runnerID,
 	}
-	if err := applyOwnerLabels(labels, workloadID, workload.GetOwnerKind(), workload.GetOwnerId(), workload.GetAgentId(), workload.GetThreadId()); err != nil {
+	if err := applyOwnerLabels(labels, workloadID, workload.GetOwnerKind(), workload.GetOwnerId(), workload.GetAgentId(), workload.GetThreadId(), sandboxOwners); err != nil {
 		return nil, err
 	}
 	return labels, nil
 }
 
-func volumeLabels(volume *runnersv1.Volume, volumeID string) (map[string]string, error) {
+func volumeLabels(volume *runnersv1.Volume, volumeID string, sandboxOwners map[string]string) (map[string]string, error) {
 	runnerID := strings.TrimSpace(volume.GetRunnerId())
 	if runnerID == "" {
 		return nil, fmt.Errorf("volume %s runner id missing", volumeID)
@@ -380,13 +433,13 @@ func volumeLabels(volume *runnersv1.Volume, volumeID string) (map[string]string,
 		labelResourceID: volumeID,
 		labelRunnerID:   runnerID,
 	}
-	if err := applyOwnerLabels(labels, volumeID, volume.GetOwnerKind(), volume.GetOwnerId(), volume.GetAgentId(), volume.GetThreadId()); err != nil {
+	if err := applyOwnerLabels(labels, volumeID, volume.GetOwnerKind(), volume.GetOwnerId(), volume.GetAgentId(), volume.GetThreadId(), sandboxOwners); err != nil {
 		return nil, err
 	}
 	return labels, nil
 }
 
-func applyOwnerLabels(labels map[string]string, resourceID string, ownerKind runnersv1.RuntimeOwnerKind, ownerID, agentID, threadID string) error {
+func applyOwnerLabels(labels map[string]string, resourceID string, ownerKind runnersv1.RuntimeOwnerKind, ownerID, agentID, threadID string, sandboxOwners map[string]string) error {
 	switch ownerKind {
 	case runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX:
 		sandboxID := strings.TrimSpace(ownerID)
@@ -396,6 +449,9 @@ func applyOwnerLabels(labels map[string]string, resourceID string, ownerKind run
 		labels[labelOwnerKind] = "sandbox"
 		labels[labelSandboxID] = sandboxID
 		labels[labelIdentityID] = sandboxID
+		if sandboxOwnerID := strings.TrimSpace(sandboxOwners[sandboxID]); sandboxOwnerID != "" {
+			labels[labelSandboxOwnerID] = sandboxOwnerID
+		}
 	case runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_UNSPECIFIED,
 		runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_AGENT_INSTANCE:
 		cleanAgentID := strings.TrimSpace(agentID)

--- a/internal/reconciler/metering_sample_test.go
+++ b/internal/reconciler/metering_sample_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	meteringv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/metering/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agents-orchestrator/internal/testutil"
+	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -235,4 +238,136 @@ func assertSampledAt(t *testing.T, entries []*runnersv1.SampledAtEntry, id strin
 		}
 	}
 	t.Fatalf("missing sampled_at entry for %s", id)
+}
+
+func TestSampleMeteringLabelsSandboxOwner(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	sandboxID := uuid.NewString()
+	ownerID := uuid.NewString()
+
+	workload := &runnersv1.Workload{
+		Meta:                   &runnersv1.EntityMeta{Id: "workload-sandbox", CreatedAt: timestamppb.New(now.Add(-time.Minute))},
+		RunnerId:               "runner-1",
+		OrganizationId:         testOrganizationID,
+		AllocatedCpuMillicores: 500,
+		OwnerKind:              runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX,
+		OwnerId:                sandboxID,
+	}
+	volume := &runnersv1.Volume{
+		Meta:           &runnersv1.EntityMeta{Id: "volume-sandbox", CreatedAt: timestamppb.New(now.Add(-time.Minute))},
+		RunnerId:       "runner-1",
+		OrganizationId: testOrganizationID,
+		SizeGb:         "10",
+		OwnerKind:      runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX,
+		OwnerId:        sandboxID,
+	}
+
+	var recorded []*meteringv1.UsageRecord
+	metering := &fakeMeteringClient{record: func(_ context.Context, req *meteringv1.RecordRequest, _ ...grpc.CallOption) (*meteringv1.RecordResponse, error) {
+		recorded = req.GetRecords()
+		return &meteringv1.RecordResponse{}, nil
+	}}
+	runners := &fakeRunnersClient{
+		listWorkloads: func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{workload}}, nil
+		},
+		listVolumes: func(context.Context, *runnersv1.ListVolumesRequest, ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{volume}}, nil
+		},
+		batchUpdateWorkload: func(context.Context, *runnersv1.BatchUpdateWorkloadSampledAtRequest, ...grpc.CallOption) (*runnersv1.BatchUpdateWorkloadSampledAtResponse, error) {
+			return &runnersv1.BatchUpdateWorkloadSampledAtResponse{}, nil
+		},
+	}
+	getSandboxCalls := 0
+	agents := &testutil.FakeAgentsClient{
+		ListAgentsFunc: defaultListAgentsFunc(),
+		GetSandboxFunc: func(_ context.Context, req *agentsv1.GetSandboxRequest, _ ...grpc.CallOption) (*agentsv1.GetSandboxResponse, error) {
+			getSandboxCalls++
+			if req.GetId() != sandboxID {
+				return nil, errors.New("unexpected sandbox id")
+			}
+			return &agentsv1.GetSandboxResponse{Sandbox: &agentsv1.Sandbox{
+				Meta:           &agentsv1.EntityMeta{Id: sandboxID},
+				OrganizationId: testOrganizationID,
+				OwnerId:        ownerID,
+			}}, nil
+		},
+	}
+
+	reconciler := New(Config{
+		Runners:                runners,
+		Metering:               metering,
+		Agents:                 agents,
+		MeteringSampleInterval: time.Minute,
+	})
+	if err := reconciler.sampleMetering(ctx, now); err != nil {
+		t.Fatalf("sample metering: %v", err)
+	}
+	if getSandboxCalls != 1 {
+		t.Fatalf("expected one sandbox lookup per cycle, got %d", getSandboxCalls)
+	}
+	if len(recorded) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(recorded))
+	}
+	for _, record := range recorded {
+		assertLabelValue(t, record.GetLabels(), labelOwnerKind, "sandbox")
+		assertLabelValue(t, record.GetLabels(), labelSandboxID, sandboxID)
+		assertLabelValue(t, record.GetLabels(), labelSandboxOwnerID, ownerID)
+	}
+}
+
+func TestSampleMeteringKeepsSandboxRecordsWhenOwnerUnresolved(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	sandboxID := uuid.NewString()
+
+	workload := &runnersv1.Workload{
+		Meta:                   &runnersv1.EntityMeta{Id: "workload-sandbox", CreatedAt: timestamppb.New(now.Add(-time.Minute))},
+		RunnerId:               "runner-1",
+		OrganizationId:         testOrganizationID,
+		AllocatedCpuMillicores: 500,
+		OwnerKind:              runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX,
+		OwnerId:                sandboxID,
+	}
+
+	var recorded []*meteringv1.UsageRecord
+	metering := &fakeMeteringClient{record: func(_ context.Context, req *meteringv1.RecordRequest, _ ...grpc.CallOption) (*meteringv1.RecordResponse, error) {
+		recorded = req.GetRecords()
+		return &meteringv1.RecordResponse{}, nil
+	}}
+	runners := &fakeRunnersClient{
+		listWorkloads: func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{workload}}, nil
+		},
+		listVolumes: func(context.Context, *runnersv1.ListVolumesRequest, ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{}, nil
+		},
+		batchUpdateWorkload: func(context.Context, *runnersv1.BatchUpdateWorkloadSampledAtRequest, ...grpc.CallOption) (*runnersv1.BatchUpdateWorkloadSampledAtResponse, error) {
+			return &runnersv1.BatchUpdateWorkloadSampledAtResponse{}, nil
+		},
+	}
+	agents := &testutil.FakeAgentsClient{
+		ListAgentsFunc: defaultListAgentsFunc(),
+		GetSandboxFunc: func(context.Context, *agentsv1.GetSandboxRequest, ...grpc.CallOption) (*agentsv1.GetSandboxResponse, error) {
+			return nil, errors.New("sandbox gone")
+		},
+	}
+
+	reconciler := New(Config{
+		Runners:                runners,
+		Metering:               metering,
+		Agents:                 agents,
+		MeteringSampleInterval: time.Minute,
+	})
+	if err := reconciler.sampleMetering(ctx, now); err != nil {
+		t.Fatalf("sample metering: %v", err)
+	}
+	if len(recorded) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recorded))
+	}
+	if _, ok := recorded[0].GetLabels()[labelSandboxOwnerID]; ok {
+		t.Fatal("expected no sandbox owner label when the sandbox cannot be resolved")
+	}
+	assertLabelValue(t, recorded[0].GetLabels(), labelSandboxID, sandboxID)
 }

--- a/internal/reconciler/orphan.go
+++ b/internal/reconciler/orphan.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	zitimgmtv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/ziti_management/v1"
 )
 
 // managedIdentityPageSize bounds each list call to keep pagination reasonable.
 const managedIdentityPageSize int32 = 100
+
+// identityCreateGracePeriod protects identities that were just minted for a
+// workload whose record does not exist yet: the identity is created before the
+// workload row, so a sweep in that window would reclaim a live identity.
+const identityCreateGracePeriod = time.Minute
 
 func (r *Reconciler) reconcileOrphanIdentities(ctx context.Context) error {
 	orgIdentities, err := r.agentIdentityByOrg(ctx)
@@ -21,20 +28,76 @@ func (r *Reconciler) reconcileOrphanIdentities(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	active := make(map[string]struct{}, len(tracked))
-	for _, workload := range tracked {
+	active := activeZitiIdentities(tracked)
+
+	now := time.Now().UTC()
+	if err := r.sweepOrphanIdentities(ctx, identityv1.IdentityType_IDENTITY_TYPE_AGENT, active, now); err != nil {
+		return err
+	}
+	if !r.sandboxReconcileEnabled {
+		return nil
+	}
+	sandboxWorkloads, err := r.listActiveSandboxWorkloads(ctx)
+	if err != nil {
+		return err
+	}
+	return r.sweepOrphanIdentities(ctx, identityv1.IdentityType_IDENTITY_TYPE_SANDBOX, activeZitiIdentities(sandboxWorkloads), now)
+}
+
+func activeZitiIdentities(workloads []*runnersv1.Workload) map[string]struct{} {
+	active := make(map[string]struct{}, len(workloads))
+	for _, workload := range workloads {
 		zitiIdentityID := workload.GetZitiIdentityId()
 		if zitiIdentityID == "" {
 			continue
 		}
 		active[zitiIdentityID] = struct{}{}
 	}
+	return active
+}
 
+// listActiveSandboxWorkloads lists every non-terminal sandbox workload. Unlike
+// the agent listing it is not scoped by agent organizations: a sandbox may run
+// in an organization that has no agent at all.
+func (r *Reconciler) listActiveSandboxWorkloads(ctx context.Context) ([]*runnersv1.Workload, error) {
+	statuses := []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STARTING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING,
+	}
+	pageToken := ""
+	var workloads []*runnersv1.Workload
+	for {
+		resp, err := r.runners.ListWorkloads(runnersContext(ctx), &runnersv1.ListWorkloadsRequest{
+			PageSize:  activeWorkloadPageSize,
+			PageToken: pageToken,
+			Filter: &runnersv1.ListWorkloadsFilter{
+				StatusIn:    statuses,
+				OwnerKindIn: []runnersv1.RuntimeOwnerKind{runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX},
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list sandbox workloads: %w", err)
+		}
+		for _, workload := range resp.GetWorkloads() {
+			if workload == nil {
+				return nil, fmt.Errorf("workload is nil")
+			}
+			workloads = append(workloads, workload)
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return workloads, nil
+		}
+	}
+}
+
+func (r *Reconciler) sweepOrphanIdentities(ctx context.Context, identityType identityv1.IdentityType, active map[string]struct{}, now time.Time) error {
 	pageToken := ""
 	var deleteErr error
 	for {
 		resp, err := r.zitiMgmt.ListManagedIdentities(ctx, &zitimgmtv1.ListManagedIdentitiesRequest{
-			IdentityType: identityv1.IdentityType_IDENTITY_TYPE_AGENT,
+			IdentityType: identityType,
 			PageSize:     managedIdentityPageSize,
 			PageToken:    pageToken,
 		})
@@ -52,6 +115,9 @@ func (r *Reconciler) reconcileOrphanIdentities(ctx context.Context) error {
 			if _, ok := active[identityID]; ok {
 				continue
 			}
+			if identityWithinCreateGrace(identity, now) {
+				continue
+			}
 			if err := r.deleteIdentity(ctx, identityID); err != nil {
 				log.Printf("reconciler: delete orphan ziti identity %s: %v", identityID, err)
 				if deleteErr == nil {
@@ -65,4 +131,12 @@ func (r *Reconciler) reconcileOrphanIdentities(ctx context.Context) error {
 		}
 	}
 	return deleteErr
+}
+
+func identityWithinCreateGrace(identity *zitimgmtv1.ManagedIdentity, now time.Time) bool {
+	createdAt := identity.GetCreatedAt()
+	if createdAt == nil {
+		return false
+	}
+	return now.Sub(createdAt.AsTime().UTC()) < identityCreateGracePeriod
 }

--- a/internal/reconciler/orphan.go
+++ b/internal/reconciler/orphan.go
@@ -34,9 +34,6 @@ func (r *Reconciler) reconcileOrphanIdentities(ctx context.Context) error {
 	if err := r.sweepOrphanIdentities(ctx, identityv1.IdentityType_IDENTITY_TYPE_AGENT, active, now); err != nil {
 		return err
 	}
-	if !r.sandboxReconcileEnabled {
-		return nil
-	}
 	sandboxWorkloads, err := r.listActiveSandboxWorkloads(ctx)
 	if err != nil {
 		return err

--- a/internal/reconciler/reconcile_loops.go
+++ b/internal/reconciler/reconcile_loops.go
@@ -28,6 +28,8 @@ func (r *Reconciler) runSandboxReconcileLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-r.sandboxWake:
+			r.runSandboxReconcileCycle(ctx)
 		case <-ticker.C:
 			r.runSandboxReconcileCycle(ctx)
 		}

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -2288,11 +2288,10 @@ func TestReconcileVolumesActivatesSandboxWorkspaceVolume(t *testing.T) {
 		},
 	}
 	reconciler := newTestReconciler(Config{
-		RunnerDialer:            &fakeRunnerDialer{dial: func(context.Context, string) (runnerv1.RunnerServiceClient, error) { return runner, nil }},
-		Runners:                 runners,
-		Agents:                  &testutil.FakeAgentsClient{},
-		Assembler:               newTestAssembler(uuid.New(), false),
-		SandboxReconcileEnabled: true,
+		RunnerDialer: &fakeRunnerDialer{dial: func(context.Context, string) (runnerv1.RunnerServiceClient, error) { return runner, nil }},
+		Runners:      runners,
+		Agents:       &testutil.FakeAgentsClient{},
+		Assembler:    newTestAssembler(uuid.New(), false),
 	})
 
 	if err := reconciler.reconcileVolumes(ctx); err != nil {
@@ -2348,8 +2347,7 @@ func TestReconcileVolumesKeepsActiveSandboxWorkspaceVolume(t *testing.T) {
 		Agents: &testutil.FakeAgentsClient{UpdateSandboxRuntimeStateFunc: func(context.Context, *agentsv1.UpdateSandboxRuntimeStateRequest, ...grpc.CallOption) (*agentsv1.UpdateSandboxRuntimeStateResponse, error) {
 			return nil, errors.New("sandbox must not be failed while its workspace exists")
 		}},
-		Assembler:               newTestAssembler(uuid.New(), false),
-		SandboxReconcileEnabled: true,
+		Assembler: newTestAssembler(uuid.New(), false),
 	})
 
 	if err := reconciler.reconcileVolumes(ctx); err != nil {
@@ -2391,8 +2389,7 @@ func TestReconcileVolumesFailsSandboxWhenWorkspaceVolumeLost(t *testing.T) {
 			runtimeReq = req
 			return &agentsv1.UpdateSandboxRuntimeStateResponse{}, nil
 		}},
-		Assembler:               newTestAssembler(uuid.New(), false),
-		SandboxReconcileEnabled: true,
+		Assembler: newTestAssembler(uuid.New(), false),
 	})
 
 	if err := reconciler.reconcileVolumes(ctx); err != nil {
@@ -2455,40 +2452,6 @@ func TestReconcileOrphanIdentitiesSweepsSandboxIdentities(t *testing.T) {
 	}
 
 	reconciler := newTestReconciler(Config{
-		RunnerDialer:            &fakeRunnerDialer{},
-		ZitiMgmt:                zitiMgmt,
-		Runners:                 runners,
-		Assembler:               newTestAssembler(uuid.New(), true),
-		SandboxReconcileEnabled: true,
-	})
-	if err := reconciler.reconcileOrphanIdentities(ctx); err != nil {
-		t.Fatalf("reconcile orphan identities: %v", err)
-	}
-	if !reflect.DeepEqual(deleteCalls, []string{orphanSandboxID}) {
-		t.Fatalf("unexpected delete calls: %v", deleteCalls)
-	}
-}
-
-func TestReconcileOrphanIdentitiesSkipsSandboxSweepWhenDisabled(t *testing.T) {
-	ctx := context.Background()
-	runners := &fakeRunnersClient{
-		listWorkloads: func(_ context.Context, req *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
-			if len(req.GetFilter().GetOwnerKindIn()) != 0 {
-				return nil, errors.New("sandbox workloads must not be listed while sandbox reconcile is disabled")
-			}
-			return &runnersv1.ListWorkloadsResponse{}, nil
-		},
-	}
-	zitiMgmt := &fakeZitiMgmtClient{
-		listManagedIdentities: func(_ context.Context, req *zitimgmtv1.ListManagedIdentitiesRequest, _ ...grpc.CallOption) (*zitimgmtv1.ListManagedIdentitiesResponse, error) {
-			if req.GetIdentityType() != identityv1.IdentityType_IDENTITY_TYPE_AGENT {
-				return nil, errors.New("unexpected identity type")
-			}
-			return &zitimgmtv1.ListManagedIdentitiesResponse{}, nil
-		},
-	}
-
-	reconciler := newTestReconciler(Config{
 		RunnerDialer: &fakeRunnerDialer{},
 		ZitiMgmt:     zitiMgmt,
 		Runners:      runners,
@@ -2496,6 +2459,9 @@ func TestReconcileOrphanIdentitiesSkipsSandboxSweepWhenDisabled(t *testing.T) {
 	})
 	if err := reconciler.reconcileOrphanIdentities(ctx); err != nil {
 		t.Fatalf("reconcile orphan identities: %v", err)
+	}
+	if !reflect.DeepEqual(deleteCalls, []string{orphanSandboxID}) {
+		t.Fatalf("unexpected delete calls: %v", deleteCalls)
 	}
 }
 
@@ -2515,7 +2481,6 @@ func TestSandboxReconcileLoopRunsOnWake(t *testing.T) {
 		SandboxReconcileOrganizationIDs: []string{testOrganizationID},
 		Agents:                          agents,
 		SandboxWake:                     wake,
-		SandboxReconcileEnabled:         true,
 		// Long enough that only the wake can trigger the second cycle.
 		WorkloadReconcileInterval: time.Hour,
 	})

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -3,10 +3,13 @@ package reconciler
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
@@ -2174,5 +2177,360 @@ func TestReconcileSandboxTTLDoesNotDeleteWhenRuntimeClearFails(t *testing.T) {
 	}
 	if deleteCalled {
 		t.Fatal("delete must not run after runtime clear failure")
+	}
+}
+
+func TestReconcileSandboxStoppedStopsActiveWorkloadWhenNotIdle(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	sandboxID := uuid.NewString()
+	ownerID := uuid.NewString()
+	workloadID := uuid.NewString()
+	runtimeWorkloadID := workloadID
+	// An attached session keeps the workload far from its idle timeout.
+	activeAt := timestamppb.New(time.Now().Add(-time.Second))
+	var runtimeReq *agentsv1.UpdateSandboxRuntimeStateRequest
+	var workloadStatuses []runnersv1.WorkloadStatus
+	stoppedInstanceID := ""
+	runners := &fakeRunnersClient{
+		listWorkloads: func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{{
+				Meta:           &runnersv1.EntityMeta{Id: workloadID},
+				RunnerId:       runnerID,
+				OrganizationId: testOrganizationID,
+				Status:         runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+				InstanceId:     stringPtr(workloadID),
+				LastActivityAt: activeAt,
+				OwnerKind:      runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX,
+				OwnerId:        sandboxID,
+			}}}, nil
+		},
+		listVolumes: func(context.Context, *runnersv1.ListVolumesRequest, ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			if req.Status != nil {
+				workloadStatuses = append(workloadStatuses, req.GetStatus())
+			}
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+	runner := &fakeRunnerClient{stopWorkload: func(_ context.Context, req *runnerv1.StopWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StopWorkloadResponse, error) {
+		stoppedInstanceID = req.GetWorkloadId()
+		return &runnerv1.StopWorkloadResponse{}, nil
+	}}
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: &fakeRunnerDialer{dial: func(context.Context, string) (runnerv1.RunnerServiceClient, error) { return runner, nil }},
+		Runners:      runners,
+		Agents: &testutil.FakeAgentsClient{UpdateSandboxRuntimeStateFunc: func(_ context.Context, req *agentsv1.UpdateSandboxRuntimeStateRequest, _ ...grpc.CallOption) (*agentsv1.UpdateSandboxRuntimeStateResponse, error) {
+			runtimeReq = req
+			return &agentsv1.UpdateSandboxRuntimeStateResponse{}, nil
+		}},
+		Assembler: newTestAssembler(uuid.New(), false),
+	})
+	sandbox := &agentsv1.Sandbox{
+		Meta:           &agentsv1.EntityMeta{Id: sandboxID},
+		OrganizationId: testOrganizationID,
+		OwnerId:        ownerID,
+		Status:         agentsv1.SandboxStatus_SANDBOX_STATUS_STOPPED,
+		IdleTimeout:    "1h",
+		WorkloadId:     &runtimeWorkloadID,
+	}
+
+	if err := reconciler.reconcileSandbox(ctx, sandbox, time.Now().UTC()); err != nil {
+		t.Fatalf("reconcile sandbox: %v", err)
+	}
+	if stoppedInstanceID != workloadID {
+		t.Fatalf("expected sandbox workload stop on runner, got %q", stoppedInstanceID)
+	}
+	expectedStatuses := []runnersv1.WorkloadStatus{
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPING,
+		runnersv1.WorkloadStatus_WORKLOAD_STATUS_STOPPED,
+	}
+	if !reflect.DeepEqual(workloadStatuses, expectedStatuses) {
+		t.Fatalf("unexpected workload status transitions: %v", workloadStatuses)
+	}
+	if runtimeReq == nil || runtimeReq.GetStatus() != agentsv1.SandboxStatus_SANDBOX_STATUS_STOPPED || !runtimeReq.GetClearWorkloadId() {
+		t.Fatalf("unexpected runtime update: %v", runtimeReq)
+	}
+}
+
+func TestReconcileVolumesActivatesSandboxWorkspaceVolume(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	sandboxVolumeKey := uuid.NewString()
+	sandboxID := uuid.NewString()
+	instanceID := "sandbox-volume-instance"
+
+	var updateReq *runnersv1.UpdateVolumeRequest
+	runners := &fakeRunnersClient{
+		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
+				{Meta: &runnersv1.EntityMeta{Id: sandboxVolumeKey}, RunnerId: runnerID, OrganizationId: testOrganizationID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING, OwnerKind: runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX, OwnerId: sandboxID},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateVolume: func(_ context.Context, req *runnersv1.UpdateVolumeRequest, _ ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateVolumeResponse{}, nil
+		},
+	}
+	runner := &fakeRunnerClient{
+		listVolumes: func(_ context.Context, _ *runnerv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnerv1.ListVolumesResponse, error) {
+			return &runnerv1.ListVolumesResponse{Volumes: []*runnerv1.VolumeListItem{
+				{VolumeKey: sandboxVolumeKey, InstanceId: instanceID},
+			}}, nil
+		},
+		removeVolume: func(_ context.Context, _ *runnerv1.RemoveVolumeRequest, _ ...grpc.CallOption) (*runnerv1.RemoveVolumeResponse, error) {
+			return nil, errors.New("sandbox workspace volume must not be removed")
+		},
+	}
+	reconciler := newTestReconciler(Config{
+		RunnerDialer:            &fakeRunnerDialer{dial: func(context.Context, string) (runnerv1.RunnerServiceClient, error) { return runner, nil }},
+		Runners:                 runners,
+		Agents:                  &testutil.FakeAgentsClient{},
+		Assembler:               newTestAssembler(uuid.New(), false),
+		SandboxReconcileEnabled: true,
+	})
+
+	if err := reconciler.reconcileVolumes(ctx); err != nil {
+		t.Fatalf("reconcile volumes: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected sandbox workspace volume update")
+	}
+	if updateReq.GetId() != sandboxVolumeKey {
+		t.Fatalf("unexpected volume update id: %q", updateReq.GetId())
+	}
+	if updateReq.GetStatus() != runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE {
+		t.Fatalf("unexpected status: %v", updateReq.GetStatus())
+	}
+	if updateReq.GetInstanceId() != instanceID {
+		t.Fatalf("unexpected instance id: %q", updateReq.GetInstanceId())
+	}
+}
+
+func TestReconcileVolumesKeepsActiveSandboxWorkspaceVolume(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	sandboxVolumeKey := uuid.NewString()
+	sandboxID := uuid.NewString()
+	instanceID := "sandbox-volume-instance"
+
+	runners := &fakeRunnersClient{
+		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
+				{Meta: &runnersv1.EntityMeta{Id: sandboxVolumeKey}, RunnerId: runnerID, OrganizationId: testOrganizationID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, InstanceId: stringPtr(instanceID), OwnerKind: runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX, OwnerId: sandboxID},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateVolume: func(_ context.Context, req *runnersv1.UpdateVolumeRequest, _ ...grpc.CallOption) (*runnersv1.UpdateVolumeResponse, error) {
+			return nil, fmt.Errorf("unexpected volume update: %v", req)
+		},
+	}
+	runner := &fakeRunnerClient{
+		listVolumes: func(_ context.Context, _ *runnerv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnerv1.ListVolumesResponse, error) {
+			return &runnerv1.ListVolumesResponse{Volumes: []*runnerv1.VolumeListItem{
+				{VolumeKey: sandboxVolumeKey, InstanceId: instanceID},
+			}}, nil
+		},
+		removeVolume: func(_ context.Context, _ *runnerv1.RemoveVolumeRequest, _ ...grpc.CallOption) (*runnerv1.RemoveVolumeResponse, error) {
+			return nil, errors.New("sandbox workspace volume must survive idle stops")
+		},
+	}
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: &fakeRunnerDialer{dial: func(context.Context, string) (runnerv1.RunnerServiceClient, error) { return runner, nil }},
+		Runners:      runners,
+		Agents: &testutil.FakeAgentsClient{UpdateSandboxRuntimeStateFunc: func(context.Context, *agentsv1.UpdateSandboxRuntimeStateRequest, ...grpc.CallOption) (*agentsv1.UpdateSandboxRuntimeStateResponse, error) {
+			return nil, errors.New("sandbox must not be failed while its workspace exists")
+		}},
+		Assembler:               newTestAssembler(uuid.New(), false),
+		SandboxReconcileEnabled: true,
+	})
+
+	if err := reconciler.reconcileVolumes(ctx); err != nil {
+		t.Fatalf("reconcile volumes: %v", err)
+	}
+}
+
+func TestReconcileVolumesFailsSandboxWhenWorkspaceVolumeLost(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	sandboxVolumeKey := uuid.NewString()
+	sandboxID := uuid.NewString()
+
+	var runtimeReq *agentsv1.UpdateSandboxRuntimeStateRequest
+	runners := &fakeRunnersClient{
+		listVolumes: func(_ context.Context, _ *runnersv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
+			return &runnersv1.ListVolumesResponse{Volumes: []*runnersv1.Volume{
+				{Meta: &runnersv1.EntityMeta{Id: sandboxVolumeKey}, RunnerId: runnerID, OrganizationId: testOrganizationID, Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE, OwnerKind: runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX, OwnerId: sandboxID},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+	}
+	runner := &fakeRunnerClient{
+		listVolumes: func(_ context.Context, _ *runnerv1.ListVolumesRequest, _ ...grpc.CallOption) (*runnerv1.ListVolumesResponse, error) {
+			return &runnerv1.ListVolumesResponse{}, nil
+		},
+	}
+	degradeCalled := false
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: &fakeRunnerDialer{dial: func(context.Context, string) (runnerv1.RunnerServiceClient, error) { return runner, nil }},
+		Runners:      runners,
+		Threads: &fakeThreadsClient{degradeThread: func(context.Context, *threadsv1.DegradeThreadRequest, ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error) {
+			degradeCalled = true
+			return &threadsv1.DegradeThreadResponse{}, nil
+		}},
+		Agents: &testutil.FakeAgentsClient{UpdateSandboxRuntimeStateFunc: func(_ context.Context, req *agentsv1.UpdateSandboxRuntimeStateRequest, _ ...grpc.CallOption) (*agentsv1.UpdateSandboxRuntimeStateResponse, error) {
+			runtimeReq = req
+			return &agentsv1.UpdateSandboxRuntimeStateResponse{}, nil
+		}},
+		Assembler:               newTestAssembler(uuid.New(), false),
+		SandboxReconcileEnabled: true,
+	})
+
+	if err := reconciler.reconcileVolumes(ctx); err != nil {
+		t.Fatalf("reconcile volumes: %v", err)
+	}
+	if runtimeReq == nil {
+		t.Fatal("expected sandbox runtime state update")
+	}
+	if runtimeReq.GetId() != sandboxID || runtimeReq.GetStatus() != agentsv1.SandboxStatus_SANDBOX_STATUS_FAILED || !runtimeReq.GetClearWorkloadId() {
+		t.Fatalf("unexpected runtime update: %v", runtimeReq)
+	}
+	if degradeCalled {
+		t.Fatal("sandbox volumes must not degrade a thread")
+	}
+}
+
+func TestReconcileOrphanIdentitiesSweepsSandboxIdentities(t *testing.T) {
+	ctx := context.Background()
+	activeAgentID := "active-agent-identity"
+	activeSandboxID := "active-sandbox-identity"
+	orphanSandboxID := "orphan-sandbox-identity"
+	startingSandboxID := "starting-sandbox-identity"
+
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, req *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			if len(req.GetFilter().GetOwnerKindIn()) == 1 && req.GetFilter().GetOwnerKindIn()[0] == runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
+				return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+					{Meta: &runnersv1.EntityMeta{Id: "sandbox-workload-1"}, OrganizationId: testOrganizationID, ZitiIdentityId: activeSandboxID, OwnerKind: runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX, OwnerId: uuid.NewString()},
+				}}, nil
+			}
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{Meta: &runnersv1.EntityMeta{Id: "workload-1"}, OrganizationId: testOrganizationID, ZitiIdentityId: activeAgentID},
+			}}, nil
+		},
+	}
+
+	deleteCalls := []string{}
+	zitiMgmt := &fakeZitiMgmtClient{
+		listManagedIdentities: func(_ context.Context, req *zitimgmtv1.ListManagedIdentitiesRequest, _ ...grpc.CallOption) (*zitimgmtv1.ListManagedIdentitiesResponse, error) {
+			switch req.GetIdentityType() {
+			case identityv1.IdentityType_IDENTITY_TYPE_AGENT:
+				return &zitimgmtv1.ListManagedIdentitiesResponse{Identities: []*zitimgmtv1.ManagedIdentity{
+					{ZitiIdentityId: activeAgentID},
+				}}, nil
+			case identityv1.IdentityType_IDENTITY_TYPE_SANDBOX:
+				return &zitimgmtv1.ListManagedIdentitiesResponse{Identities: []*zitimgmtv1.ManagedIdentity{
+					{ZitiIdentityId: activeSandboxID},
+					{ZitiIdentityId: orphanSandboxID, CreatedAt: timestamppb.New(time.Now().Add(-time.Hour))},
+					// Minted moments ago for a workload whose record is not written yet.
+					{ZitiIdentityId: startingSandboxID, CreatedAt: timestamppb.New(time.Now())},
+				}}, nil
+			default:
+				return nil, errors.New("unexpected identity type")
+			}
+		},
+		deleteIdentity: func(_ context.Context, req *zitimgmtv1.DeleteIdentityRequest, _ ...grpc.CallOption) (*zitimgmtv1.DeleteIdentityResponse, error) {
+			deleteCalls = append(deleteCalls, req.GetZitiIdentityId())
+			return &zitimgmtv1.DeleteIdentityResponse{}, nil
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer:            &fakeRunnerDialer{},
+		ZitiMgmt:                zitiMgmt,
+		Runners:                 runners,
+		Assembler:               newTestAssembler(uuid.New(), true),
+		SandboxReconcileEnabled: true,
+	})
+	if err := reconciler.reconcileOrphanIdentities(ctx); err != nil {
+		t.Fatalf("reconcile orphan identities: %v", err)
+	}
+	if !reflect.DeepEqual(deleteCalls, []string{orphanSandboxID}) {
+		t.Fatalf("unexpected delete calls: %v", deleteCalls)
+	}
+}
+
+func TestReconcileOrphanIdentitiesSkipsSandboxSweepWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, req *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			if len(req.GetFilter().GetOwnerKindIn()) != 0 {
+				return nil, errors.New("sandbox workloads must not be listed while sandbox reconcile is disabled")
+			}
+			return &runnersv1.ListWorkloadsResponse{}, nil
+		},
+	}
+	zitiMgmt := &fakeZitiMgmtClient{
+		listManagedIdentities: func(_ context.Context, req *zitimgmtv1.ListManagedIdentitiesRequest, _ ...grpc.CallOption) (*zitimgmtv1.ListManagedIdentitiesResponse, error) {
+			if req.GetIdentityType() != identityv1.IdentityType_IDENTITY_TYPE_AGENT {
+				return nil, errors.New("unexpected identity type")
+			}
+			return &zitimgmtv1.ListManagedIdentitiesResponse{}, nil
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: &fakeRunnerDialer{},
+		ZitiMgmt:     zitiMgmt,
+		Runners:      runners,
+		Assembler:    newTestAssembler(uuid.New(), true),
+	})
+	if err := reconciler.reconcileOrphanIdentities(ctx); err != nil {
+		t.Fatalf("reconcile orphan identities: %v", err)
+	}
+}
+
+func TestSandboxReconcileLoopRunsOnWake(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cycles := make(chan struct{}, 4)
+	agents := &testutil.FakeAgentsClient{
+		ListSandboxesFunc: func(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error) {
+			cycles <- struct{}{}
+			return &agentsv1.ListSandboxesResponse{}, nil
+		},
+	}
+	wake := make(chan struct{}, 1)
+	reconciler := newTestReconciler(Config{
+		SandboxReconcileOrganizationIDs: []string{testOrganizationID},
+		Agents:                          agents,
+		SandboxWake:                     wake,
+		SandboxReconcileEnabled:         true,
+		// Long enough that only the wake can trigger the second cycle.
+		WorkloadReconcileInterval: time.Hour,
+	})
+	go reconciler.runSandboxReconcileLoop(ctx)
+
+	waitForSandboxCycle(t, cycles)
+	wake <- struct{}{}
+	waitForSandboxCycle(t, cycles)
+}
+
+func waitForSandboxCycle(t *testing.T, cycles <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-cycles:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for sandbox reconcile cycle")
 	}
 }

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -1526,7 +1526,7 @@ func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
 	environmentID := uuid.NewString()
 	ownerID := uuid.NewString()
 	sandboxID := uuid.NewString()
-	flavorID := "flavor-1"
+	flavorName := "ram-2gb"
 	var createWorkloadReq *runnersv1.CreateWorkloadRequest
 	var createVolumeReq *runnersv1.CreateVolumeRequest
 	var updateWorkloadReq *runnersv1.UpdateWorkloadRequest
@@ -1540,7 +1540,7 @@ func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
 			if req.GetId() != environmentID {
 				return nil, errors.New("unexpected environment id")
 			}
-			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{Meta: &agentsv1.EntityMeta{Id: environmentID}, OrganizationId: testOrganizationID, Name: "sandbox-env", FlavorId: flavorID, Image: "sandbox-image"}}, nil
+			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{Meta: &agentsv1.EntityMeta{Id: environmentID}, OrganizationId: testOrganizationID, Name: "sandbox-env", RunnerId: runnerID, Flavor: flavorName, Image: "sandbox-image"}}, nil
 		},
 		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			return &agentsv1.ListEnvsResponse{}, nil
@@ -1554,11 +1554,13 @@ func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
 		},
 	}
 	runners := &fakeRunnersClient{
-		getFlavor: func(_ context.Context, req *runnersv1.GetFlavorRequest, _ ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
-			if req.GetId() != flavorID {
-				return nil, errors.New("unexpected flavor id")
+		listFlavors: func(_ context.Context, req *runnersv1.ListFlavorsRequest, _ ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			if req.GetRunnerId() != runnerID {
+				return nil, errors.New("unexpected runner id")
 			}
-			return &runnersv1.GetFlavorResponse{Flavor: &runnersv1.Flavor{Meta: &runnersv1.EntityMeta{Id: flavorID}, RunnerId: runnerID, Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"}}}, nil
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{
+				{RunnerId: runnerID, Name: flavorName, Default: true, Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"}},
+			}}, nil
 		},
 		getRunner: func(_ context.Context, req *runnersv1.GetRunnerRequest, _ ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
 			if req.GetId() != runnerID {
@@ -1775,14 +1777,14 @@ func TestStartSandboxWorkloadWritesRuntimeRunning(t *testing.T) {
 	environmentID := uuid.NewString()
 	ownerID := uuid.NewString()
 	sandboxID := uuid.NewString()
-	flavorID := "flavor-1"
+	flavorName := "ram-2gb"
 	var runtimeReq *agentsv1.UpdateSandboxRuntimeStateRequest
 	agents := &testutil.FakeAgentsClient{
 		GetEnvironmentFunc: func(_ context.Context, req *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
 			if req.GetId() != environmentID {
 				return nil, errors.New("unexpected environment id")
 			}
-			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{Meta: &agentsv1.EntityMeta{Id: environmentID}, OrganizationId: testOrganizationID, Name: "sandbox-env", FlavorId: flavorID, Image: "sandbox-image"}}, nil
+			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{Meta: &agentsv1.EntityMeta{Id: environmentID}, OrganizationId: testOrganizationID, Name: "sandbox-env", RunnerId: runnerID, Flavor: flavorName, Image: "sandbox-image"}}, nil
 		},
 		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			return &agentsv1.ListEnvsResponse{}, nil
@@ -1796,11 +1798,13 @@ func TestStartSandboxWorkloadWritesRuntimeRunning(t *testing.T) {
 		},
 	}
 	runners := &fakeRunnersClient{
-		getFlavor: func(_ context.Context, req *runnersv1.GetFlavorRequest, _ ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
-			if req.GetId() != flavorID {
-				return nil, errors.New("unexpected flavor id")
+		listFlavors: func(_ context.Context, req *runnersv1.ListFlavorsRequest, _ ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			if req.GetRunnerId() != runnerID {
+				return nil, errors.New("unexpected runner id")
 			}
-			return &runnersv1.GetFlavorResponse{Flavor: &runnersv1.Flavor{Meta: &runnersv1.EntityMeta{Id: flavorID}, RunnerId: runnerID, Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"}}}, nil
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{
+				{RunnerId: runnerID, Name: flavorName, Default: true, Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"}},
+			}}, nil
 		},
 		getRunner: func(_ context.Context, req *runnersv1.GetRunnerRequest, _ ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
 			if req.GetId() != runnerID {
@@ -1900,12 +1904,12 @@ func TestStartSandboxWorkloadFailureWritesRuntimeFailed(t *testing.T) {
 	environmentID := uuid.NewString()
 	ownerID := uuid.NewString()
 	sandboxID := uuid.NewString()
-	flavorID := "flavor-1"
+	flavorName := "ram-2gb"
 	runtimeWorkloadID := uuid.NewString()
 	var runtimeReq *agentsv1.UpdateSandboxRuntimeStateRequest
 	agents := &testutil.FakeAgentsClient{
 		GetEnvironmentFunc: func(context.Context, *agentsv1.GetEnvironmentRequest, ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
-			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{Meta: &agentsv1.EntityMeta{Id: environmentID}, OrganizationId: testOrganizationID, Name: "sandbox-env", FlavorId: flavorID, Image: "sandbox-image"}}, nil
+			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{Meta: &agentsv1.EntityMeta{Id: environmentID}, OrganizationId: testOrganizationID, Name: "sandbox-env", RunnerId: runnerID, Flavor: flavorName, Image: "sandbox-image"}}, nil
 		},
 		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			return &agentsv1.ListEnvsResponse{}, nil
@@ -1919,8 +1923,10 @@ func TestStartSandboxWorkloadFailureWritesRuntimeFailed(t *testing.T) {
 		},
 	}
 	runners := &fakeRunnersClient{
-		getFlavor: func(context.Context, *runnersv1.GetFlavorRequest, ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
-			return &runnersv1.GetFlavorResponse{Flavor: &runnersv1.Flavor{Meta: &runnersv1.EntityMeta{Id: flavorID}, RunnerId: runnerID, Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"}}}, nil
+		listFlavors: func(context.Context, *runnersv1.ListFlavorsRequest, ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{
+				{RunnerId: runnerID, Name: flavorName, Default: true, Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"}},
+			}}, nil
 		},
 		getRunner: func(context.Context, *runnersv1.GetRunnerRequest, ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
 			return &runnersv1.GetRunnerResponse{Runner: buildRunner(runnerID)}, nil
@@ -1968,12 +1974,12 @@ func TestReconcileSandboxStartsFromStartingRuntimeState(t *testing.T) {
 	environmentID := uuid.NewString()
 	ownerID := uuid.NewString()
 	sandboxID := uuid.NewString()
-	flavorID := "flavor-1"
+	flavorName := "ram-2gb"
 	var runtimeReq *agentsv1.UpdateSandboxRuntimeStateRequest
 	var startReq *runnerv1.StartWorkloadRequest
 	agents := &testutil.FakeAgentsClient{
 		GetEnvironmentFunc: func(context.Context, *agentsv1.GetEnvironmentRequest, ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
-			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{Meta: &agentsv1.EntityMeta{Id: environmentID}, OrganizationId: testOrganizationID, Name: "sandbox-env", FlavorId: flavorID, Image: "sandbox-image"}}, nil
+			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{Meta: &agentsv1.EntityMeta{Id: environmentID}, OrganizationId: testOrganizationID, Name: "sandbox-env", RunnerId: runnerID, Flavor: flavorName, Image: "sandbox-image"}}, nil
 		},
 		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			return &agentsv1.ListEnvsResponse{}, nil
@@ -1993,8 +1999,10 @@ func TestReconcileSandboxStartsFromStartingRuntimeState(t *testing.T) {
 		listVolumes: func(context.Context, *runnersv1.ListVolumesRequest, ...grpc.CallOption) (*runnersv1.ListVolumesResponse, error) {
 			return &runnersv1.ListVolumesResponse{}, nil
 		},
-		getFlavor: func(context.Context, *runnersv1.GetFlavorRequest, ...grpc.CallOption) (*runnersv1.GetFlavorResponse, error) {
-			return &runnersv1.GetFlavorResponse{Flavor: &runnersv1.Flavor{Meta: &runnersv1.EntityMeta{Id: flavorID}, RunnerId: runnerID, Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"}}}, nil
+		listFlavors: func(context.Context, *runnersv1.ListFlavorsRequest, ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{
+				{RunnerId: runnerID, Name: flavorName, Default: true, Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"}},
+			}}, nil
 		},
 		getRunner: func(context.Context, *runnersv1.GetRunnerRequest, ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
 			return &runnersv1.GetRunnerResponse{Runner: buildRunner(runnerID)}, nil

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -36,6 +36,7 @@ type Reconciler struct {
 	groups                          groupsClient
 	assembler                       *assembler.Assembler
 	wake                            <-chan struct{}
+	sandboxWake                     <-chan struct{}
 	sandboxReconcileEnabled         bool
 	poll                            time.Duration
 	workloadReconcileInterval       time.Duration
@@ -54,6 +55,7 @@ type Config struct {
 	Groups                          groupsClient
 	Assembler                       *assembler.Assembler
 	Wake                            <-chan struct{}
+	SandboxWake                     <-chan struct{}
 	Poll                            time.Duration
 	WorkloadReconcileInterval       time.Duration
 	Idle                            time.Duration
@@ -76,6 +78,7 @@ func New(cfg Config) *Reconciler {
 		groups:                          cfg.Groups,
 		assembler:                       cfg.Assembler,
 		wake:                            cfg.Wake,
+		sandboxWake:                     cfg.SandboxWake,
 		poll:                            cfg.Poll,
 		workloadReconcileInterval:       cfg.WorkloadReconcileInterval,
 		idle:                            cfg.Idle,

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -37,7 +37,6 @@ type Reconciler struct {
 	assembler                       *assembler.Assembler
 	wake                            <-chan struct{}
 	sandboxWake                     <-chan struct{}
-	sandboxReconcileEnabled         bool
 	poll                            time.Duration
 	workloadReconcileInterval       time.Duration
 	idle                            time.Duration
@@ -61,7 +60,6 @@ type Config struct {
 	Idle                            time.Duration
 	StopSec                         uint32
 	MeteringSampleInterval          time.Duration
-	SandboxReconcileEnabled         bool
 }
 
 func New(cfg Config) *Reconciler {
@@ -73,7 +71,6 @@ func New(cfg Config) *Reconciler {
 		runners:                         cfg.Runners,
 		metering:                        cfg.Metering,
 		meteringSampleInterval:          cfg.MeteringSampleInterval,
-		sandboxReconcileEnabled:         cfg.SandboxReconcileEnabled,
 		zitiMgmt:                        cfg.ZitiMgmt,
 		groups:                          cfg.Groups,
 		assembler:                       cfg.Assembler,
@@ -94,9 +91,7 @@ func (r *Reconciler) Run(ctx context.Context) error {
 		return fmt.Errorf("metering sample interval must be greater than 0")
 	}
 	go r.runWorkloadReconcileLoop(ctx)
-	if r.sandboxReconcileEnabled {
-		go r.runSandboxReconcileLoop(ctx)
-	}
+	go r.runSandboxReconcileLoop(ctx)
 	go r.runVolumeReconcileLoop(ctx)
 	go r.runMeteringSampleLoop(ctx)
 

--- a/internal/reconciler/sandbox_reconciler.go
+++ b/internal/reconciler/sandbox_reconciler.go
@@ -135,13 +135,16 @@ func (r *Reconciler) reconcileSandbox(ctx context.Context, sandbox *agentsv1.San
 		}
 		return nil
 	case agentsv1.SandboxStatus_SANDBOX_STATUS_STOPPED:
-		if plan.activeWorkload != nil && sandboxIdle(sandbox, plan.activeWorkload, now) {
+		// A stopped sandbox must always converge to no running workload, whether it
+		// was stopped explicitly or by the idle timeout. Idleness is irrelevant here:
+		// an attached session does not keep an explicitly stopped sandbox alive.
+		if plan.activeWorkload != nil {
 			if err := r.stopSandboxWorkload(ctx, plan.activeWorkload); err != nil {
 				return err
 			}
 			return r.updateSandboxRuntimeState(ctx, plan.sandbox, agentsv1.SandboxStatus_SANDBOX_STATUS_STOPPED, "", true)
 		}
-		if plan.activeWorkload == nil && plan.sandbox.WorkloadId != nil {
+		if plan.sandbox.WorkloadId != nil {
 			return r.updateSandboxRuntimeState(ctx, plan.sandbox, agentsv1.SandboxStatus_SANDBOX_STATUS_STOPPED, "", true)
 		}
 		return nil
@@ -441,6 +444,25 @@ func (r *Reconciler) updateSandboxRuntimeState(ctx context.Context, sandbox *age
 	}
 	if _, err := r.agents.UpdateSandboxRuntimeState(ctx, req); err != nil {
 		return fmt.Errorf("update sandbox %s runtime state: %w", sandboxID, err)
+	}
+	return nil
+}
+
+// markSandboxFailed transitions a sandbox to failed when only its id is known.
+// Sandboxes have no agent instance to pause, so a lost runtime resource fails
+// the sandbox itself and clears the workload reference.
+func (r *Reconciler) markSandboxFailed(ctx context.Context, sandboxID string) error {
+	parsedSandboxID, err := uuidutil.ParseUUID(strings.TrimSpace(sandboxID), "sandbox.id")
+	if err != nil {
+		return err
+	}
+	status := agentsv1.SandboxStatus_SANDBOX_STATUS_FAILED
+	if _, err := r.agents.UpdateSandboxRuntimeState(ctx, &agentsv1.UpdateSandboxRuntimeStateRequest{
+		Id:               parsedSandboxID.String(),
+		Status:           &status,
+		WorkloadIdUpdate: &agentsv1.UpdateSandboxRuntimeStateRequest_ClearWorkloadId{ClearWorkloadId: true},
+	}); err != nil {
+		return fmt.Errorf("update sandbox %s runtime state: %w", parsedSandboxID.String(), err)
 	}
 	return nil
 }

--- a/internal/reconciler/volume_reconcile.go
+++ b/internal/reconciler/volume_reconcile.go
@@ -287,18 +287,6 @@ func (r *Reconciler) listActiveVolumes(ctx context.Context, orgIdentities map[st
 			if meta.GetId() == "" {
 				return nil, nil, fmt.Errorf("volume meta id missing")
 			}
-			if isSandboxVolume(volume) && !r.sandboxReconcileEnabled {
-				// Sandbox reconciliation is off: keep the workspace volume out of the
-				// orphan sweep instead of reconciling it.
-				runnerID := strings.TrimSpace(volume.GetRunnerId())
-				if runnerID != "" {
-					if ignoredVolumeKeysByRunner[runnerID] == nil {
-						ignoredVolumeKeysByRunner[runnerID] = map[string]struct{}{}
-					}
-					ignoredVolumeKeysByRunner[runnerID][meta.GetId()] = struct{}{}
-				}
-				continue
-			}
 			orgID := strings.TrimSpace(volume.GetOrganizationId())
 			if orgID == "" {
 				return nil, nil, fmt.Errorf("volume %s organization id missing", meta.GetId())

--- a/internal/reconciler/volume_reconcile.go
+++ b/internal/reconciler/volume_reconcile.go
@@ -29,6 +29,20 @@ type volumeTTLInfo struct {
 	ttl        *time.Duration
 }
 
+// volumeIdentityID resolves the identity used to talk to the runner about a
+// volume. Sandbox-owned volumes carry no agent id; they are addressed by the
+// sandbox that owns them, matching the sandbox workload path.
+func volumeIdentityID(volume *runnersv1.Volume) string {
+	if volume.GetOwnerKind() == runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
+		return strings.TrimSpace(volume.GetOwnerId())
+	}
+	return strings.TrimSpace(volume.GetAgentId())
+}
+
+func isSandboxVolume(volume *runnersv1.Volume) bool {
+	return volume.GetOwnerKind() == runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX
+}
+
 func runnerIdentityForVolumes(runnerID string, runnerOrganizationID string, orgIdentities map[string]string, volumes map[string]*runnersv1.Volume) (string, error) {
 	orgID := strings.TrimSpace(runnerOrganizationID)
 	if orgID != "" {
@@ -43,9 +57,9 @@ func runnerIdentityForVolumes(runnerID string, runnerOrganizationID string, orgI
 	}
 	var identityID string
 	for volumeID, volume := range volumes {
-		volumeIdentityID := strings.TrimSpace(volume.GetAgentId())
+		volumeIdentityID := volumeIdentityID(volume)
 		if volumeIdentityID == "" {
-			return "", fmt.Errorf("volume %s missing agent id", volumeID)
+			return "", fmt.Errorf("volume %s missing owner identity", volumeID)
 		}
 		if identityID == "" {
 			identityID = volumeIdentityID
@@ -79,9 +93,9 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 			log.Printf("reconciler: warn: volume %s missing runner id", volume.GetMeta().GetId())
 			continue
 		}
-		identityID := strings.TrimSpace(volume.GetAgentId())
+		identityID := volumeIdentityID(volume)
 		if identityID == "" {
-			return fmt.Errorf("volume %s missing agent id", volume.GetMeta().GetId())
+			return fmt.Errorf("volume %s missing owner identity", volume.GetMeta().GetId())
 		}
 		volumeID := volume.GetMeta().GetId()
 		if volumeID == "" {
@@ -140,12 +154,15 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 		}
 		if _, ok := enrolledRunnerIDs[runnerID]; !ok {
 			for volumeID, volume := range trackedVolumes {
-				volumeCtx, err := runnerIdentityContext(ctx, volume.GetAgentId())
+				volumeCtx, err := runnerIdentityContext(ctx, volumeIdentityID(volume))
 				if err != nil {
 					return err
 				}
 				if err := r.handleMissingRunnerVolume(volumeCtx, volume); err != nil {
 					log.Printf("reconciler: warn: handle missing volume %s on unenrolled runner: %v", volumeID, err)
+				}
+				if isSandboxVolume(volume) {
+					continue
 				}
 				r.degradeThread(volumeCtx, volume.GetThreadId(), degradeReasonRunnerDeprovisioned, degraded)
 			}
@@ -194,7 +211,7 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 		}
 
 		for volumeID, volume := range trackedVolumes {
-			volumeCtx, err := runnerIdentityContext(ctx, volume.GetAgentId())
+			volumeCtx, err := runnerIdentityContext(ctx, volumeIdentityID(volume))
 			if err != nil {
 				return err
 			}
@@ -204,7 +221,15 @@ func (r *Reconciler) reconcileVolumes(ctx context.Context) error {
 					log.Printf("reconciler: warn: handle missing volume %s: %v", volumeID, err)
 				}
 				if volume.GetStatus() == runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE {
-					r.degradeThread(volumeCtx, volume.GetThreadId(), degradeReasonVolumeLost, degraded)
+					if isSandboxVolume(volume) {
+						// No agent instance stands behind a sandbox: a lost workspace
+						// PVC fails the sandbox itself.
+						if err := r.markSandboxFailed(ctx, volume.GetOwnerId()); err != nil {
+							log.Printf("reconciler: warn: fail sandbox %s after lost workspace volume %s: %v", volume.GetOwnerId(), volumeID, err)
+						}
+					} else {
+						r.degradeThread(volumeCtx, volume.GetThreadId(), degradeReasonVolumeLost, degraded)
+					}
 				}
 				continue
 			}
@@ -262,7 +287,9 @@ func (r *Reconciler) listActiveVolumes(ctx context.Context, orgIdentities map[st
 			if meta.GetId() == "" {
 				return nil, nil, fmt.Errorf("volume meta id missing")
 			}
-			if volume.GetOwnerKind() == runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
+			if isSandboxVolume(volume) && !r.sandboxReconcileEnabled {
+				// Sandbox reconciliation is off: keep the workspace volume out of the
+				// orphan sweep instead of reconciling it.
 				runnerID := strings.TrimSpace(volume.GetRunnerId())
 				if runnerID != "" {
 					if ignoredVolumeKeysByRunner[runnerID] == nil {
@@ -342,6 +369,11 @@ func (r *Reconciler) handlePresentRunnerVolume(ctx context.Context, runnerClient
 			}); err != nil {
 				return err
 			}
+		}
+		if isSandboxVolume(volume) {
+			// The workspace volume lives and dies with its sandbox: it must survive
+			// idle stops and reconnects, so it has no independent TTL.
+			return nil
 		}
 		expired, err := r.volumeTTLExpired(ctx, volume, volumeInfoCache, threadCache)
 		if err != nil {

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -20,8 +20,10 @@ import (
 const (
 	messageCreatedEvent               = "message.created"
 	agentUpdatedEvent                 = "agent.updated"
+	sandboxUpdatedEvent               = "sandbox.updated"
 	agentRoomPrefix                   = "agent:"
 	threadParticipantRoomPrefix       = "thread_participant:"
+	sandboxOrgRoomPrefix              = "sandbox_org:"
 	identityMetadataKey               = "x-identity-id"
 	listAgentsPageSize          int32 = 100
 	defaultRoomRefreshInterval        = 30 * time.Second
@@ -36,14 +38,24 @@ type Subscriber struct {
 	client              notificationsv1.NotificationsServiceClient
 	agents              agentsClient
 	wake                chan struct{}
+	sandboxWake         chan struct{}
+	sandboxOrgIDs       []string
 	roomRefreshInterval time.Duration
 }
 
 func New(client notificationsv1.NotificationsServiceClient, agents agentsClient) *Subscriber {
+	return NewWithSandboxOrganizations(client, agents, nil)
+}
+
+// NewWithSandboxOrganizations additionally watches the org-level sandbox rooms
+// of organizations that carry no agent, which the agent listing cannot surface.
+func NewWithSandboxOrganizations(client notificationsv1.NotificationsServiceClient, agents agentsClient, sandboxOrganizationIDs []string) *Subscriber {
 	return &Subscriber{
 		client:              client,
 		agents:              agents,
 		wake:                make(chan struct{}, 1),
+		sandboxWake:         make(chan struct{}, 1),
+		sandboxOrgIDs:       append([]string(nil), sandboxOrganizationIDs...),
 		roomRefreshInterval: defaultRoomRefreshInterval,
 	}
 }
@@ -147,6 +159,11 @@ func (s *Subscriber) runSubscription(ctx context.Context, subscription roomSubsc
 			case s.wake <- struct{}{}:
 			default:
 			}
+		case sandboxUpdatedEvent:
+			select {
+			case s.sandboxWake <- struct{}{}:
+			default:
+			}
 		}
 	}
 }
@@ -156,6 +173,7 @@ func (s *Subscriber) buildRoomSubscriptions(ctx context.Context) ([]roomSubscrip
 		return nil, "", errors.New("agents client not configured")
 	}
 	roomsByIdentity := map[uuid.UUID]map[string]struct{}{}
+	sandboxOrgIdentities := map[string]uuid.UUID{}
 	pageToken := ""
 	for {
 		resp, err := s.agents.ListAgents(ctx, &agentsv1.ListAgentsRequest{
@@ -186,6 +204,17 @@ func (s *Subscriber) buildRoomSubscriptions(ctx context.Context) ([]roomSubscrip
 			agentID = parsedAgentID.String()
 			rooms[agentRoomPrefix+agentID] = struct{}{}
 			rooms[threadParticipantRoomPrefix+agentID] = struct{}{}
+			orgID := strings.TrimSpace(agent.GetOrganizationId())
+			if orgID == "" {
+				continue
+			}
+			parsedOrgID, err := uuidutil.ParseUUID(orgID, "agent.organization_id")
+			if err != nil {
+				return nil, "", err
+			}
+			if _, ok := sandboxOrgIdentities[parsedOrgID.String()]; !ok {
+				sandboxOrgIdentities[parsedOrgID.String()] = parsedAgentID
+			}
 		}
 		pageToken = resp.GetNextPageToken()
 		if pageToken == "" {
@@ -194,6 +223,9 @@ func (s *Subscriber) buildRoomSubscriptions(ctx context.Context) ([]roomSubscrip
 	}
 	if len(roomsByIdentity) == 0 {
 		return nil, "", fmt.Errorf("no agent rooms available")
+	}
+	if err := s.applySandboxOrgRooms(roomsByIdentity, sandboxOrgIdentities); err != nil {
+		return nil, "", err
 	}
 
 	identityIDs := make([]uuid.UUID, 0, len(roomsByIdentity))
@@ -214,6 +246,42 @@ func (s *Subscriber) buildRoomSubscriptions(ctx context.Context) ([]roomSubscrip
 		fingerprints = append(fingerprints, fingerprint)
 	}
 	return subscriptions, strings.Join(fingerprints, "|"), nil
+}
+
+// applySandboxOrgRooms attaches the org-level sandbox room of every organization
+// the reconciler covers to one subscription per organization, so sandbox status
+// changes wake the sandbox loop without waiting for the next poll tick.
+func (s *Subscriber) applySandboxOrgRooms(roomsByIdentity map[uuid.UUID]map[string]struct{}, sandboxOrgIdentities map[string]uuid.UUID) error {
+	for _, configuredOrgID := range s.sandboxOrgIDs {
+		parsedOrgID, err := uuidutil.ParseUUID(strings.TrimSpace(configuredOrgID), "sandbox_reconcile.organization_id")
+		if err != nil {
+			return err
+		}
+		if _, ok := sandboxOrgIdentities[parsedOrgID.String()]; ok {
+			continue
+		}
+		// The organization has no agent to borrow an identity from; the org-level
+		// sandbox room is not identity-scoped, so any known identity can watch it.
+		sandboxOrgIdentities[parsedOrgID.String()] = lowestIdentity(roomsByIdentity)
+	}
+	for orgID, identityID := range sandboxOrgIdentities {
+		rooms, ok := roomsByIdentity[identityID]
+		if !ok {
+			continue
+		}
+		rooms[sandboxOrgRoomPrefix+orgID] = struct{}{}
+	}
+	return nil
+}
+
+func lowestIdentity(roomsByIdentity map[uuid.UUID]map[string]struct{}) uuid.UUID {
+	var lowest uuid.UUID
+	for identityID := range roomsByIdentity {
+		if lowest == uuid.Nil || identityID.String() < lowest.String() {
+			lowest = identityID
+		}
+	}
+	return lowest
 }
 
 func sortedRooms(rooms map[string]struct{}) []string {
@@ -252,6 +320,12 @@ func (s *Subscriber) watchRooms(ctx context.Context, fingerprint string, updated
 
 func (s *Subscriber) Wake() <-chan struct{} {
 	return s.wake
+}
+
+// SandboxWake signals sandbox.updated events so the sandbox reconcile loop can
+// react to connect/stop/delete without waiting for its poll interval.
+func (s *Subscriber) SandboxWake() <-chan struct{} {
+	return s.sandboxWake
 }
 
 func waitWithBackoff(ctx context.Context, delay time.Duration) error {

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -162,6 +162,11 @@ func TestSubscriberResubscribesOnAgentChange(t *testing.T) {
 
 func newSubscriberHarness(t *testing.T, responses chan *notificationsv1.SubscribeResponse, ack chan struct{}, initialAgents []*agentsv1.Agent, refreshInterval time.Duration) *subscriberHarness {
 	t.Helper()
+	return newSubscriberHarnessWithSandboxOrgs(t, responses, ack, initialAgents, refreshInterval, nil)
+}
+
+func newSubscriberHarnessWithSandboxOrgs(t *testing.T, responses chan *notificationsv1.SubscribeResponse, ack chan struct{}, initialAgents []*agentsv1.Agent, refreshInterval time.Duration, sandboxOrgIDs []string) *subscriberHarness {
+	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	store := &agentStore{agents: initialAgents}
 	agentsClient := &testutil.FakeAgentsClient{ListAgentsFunc: func(ctx context.Context, req *agentsv1.ListAgentsRequest, opts ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
@@ -183,7 +188,7 @@ func newSubscriberHarness(t *testing.T, responses chan *notificationsv1.Subscrib
 			ack:              ack,
 		}, nil
 	}}
-	subscriber := New(client, agentsClient)
+	subscriber := NewWithSandboxOrganizations(client, agentsClient, sandboxOrgIDs)
 	subscriber.roomRefreshInterval = refreshInterval
 	done := make(chan error, 1)
 	go func() {
@@ -337,4 +342,62 @@ type subscriberHarness struct {
 
 func agentFixture(id string) *agentsv1.Agent {
 	return &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: id}}
+}
+
+func TestSubscriberWakesSandboxOnSandboxUpdated(t *testing.T) {
+	responses := make(chan *notificationsv1.SubscribeResponse, 1)
+	ack := make(chan struct{}, 1)
+	agentID := "88888888-8888-8888-8888-888888888888"
+	orgID := "99999999-9999-9999-9999-999999999999"
+	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.Agent{agentInOrgFixture(agentID, orgID)}, time.Hour)
+	defer harness.cancel()
+
+	req := waitForSubscribe(t, harness.subscribeReqs, 1)
+	expected := []string{"agent:" + agentID, "sandbox_org:" + orgID, "thread_participant:" + agentID}
+	if !reflect.DeepEqual(req.req.GetRooms(), expected) {
+		t.Fatalf("expected rooms %v, got %v", expected, req.req.GetRooms())
+	}
+
+	responses <- messageEnvelope("sandbox.updated")
+	waitForAck(t, ack, 1)
+
+	select {
+	case <-harness.subscriber.SandboxWake():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected sandbox wake signal")
+	}
+	select {
+	case <-harness.subscriber.Wake():
+		t.Fatal("sandbox.updated must not wake the agent loop")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	harness.cancel()
+	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected run error: %v", err)
+	}
+}
+
+func TestSubscriberSubscribesConfiguredSandboxOrganizations(t *testing.T) {
+	responses := make(chan *notificationsv1.SubscribeResponse, 1)
+	ack := make(chan struct{}, 1)
+	agentID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	configuredOrgID := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	harness := newSubscriberHarnessWithSandboxOrgs(t, responses, ack, []*agentsv1.Agent{agentFixture(agentID)}, time.Hour, []string{configuredOrgID})
+	defer harness.cancel()
+
+	req := waitForSubscribe(t, harness.subscribeReqs, 1)
+	expected := []string{"agent:" + agentID, "sandbox_org:" + configuredOrgID, "thread_participant:" + agentID}
+	if !reflect.DeepEqual(req.req.GetRooms(), expected) {
+		t.Fatalf("expected rooms %v, got %v", expected, req.req.GetRooms())
+	}
+
+	harness.cancel()
+	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected run error: %v", err)
+	}
+}
+
+func agentInOrgFixture(id, organizationID string) *agentsv1.Agent {
+	return &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: id}, OrganizationId: organizationID}
 }

--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -24,6 +24,7 @@ type FakeAgentsClient struct {
 	ListMcpsFunc                       func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error)
 	ListHooksFunc                      func(context.Context, *agentsv1.ListHooksRequest, ...grpc.CallOption) (*agentsv1.ListHooksResponse, error)
 	GetVolumeFunc                      func(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
+	GetSandboxFunc                     func(context.Context, *agentsv1.GetSandboxRequest, ...grpc.CallOption) (*agentsv1.GetSandboxResponse, error)
 	ListSandboxesFunc                  func(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error)
 	UpdateSandboxRuntimeStateFunc      func(context.Context, *agentsv1.UpdateSandboxRuntimeStateRequest, ...grpc.CallOption) (*agentsv1.UpdateSandboxRuntimeStateResponse, error)
 	DeleteSandboxFunc                  func(context.Context, *agentsv1.DeleteSandboxRequest, ...grpc.CallOption) (*agentsv1.DeleteSandboxResponse, error)
@@ -352,6 +353,13 @@ func (f *FakeAgentsClient) AckInboxItems(context.Context, *agentsv1.AckInboxItem
 func (f *FakeAgentsClient) GetEnvironment(ctx context.Context, req *agentsv1.GetEnvironmentRequest, opts ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
 	if f.GetEnvironmentFunc != nil {
 		return f.GetEnvironmentFunc(ctx, req, opts...)
+	}
+	return nil, ErrNotImplemented
+}
+
+func (f *FakeAgentsClient) GetSandbox(ctx context.Context, req *agentsv1.GetSandboxRequest, opts ...grpc.CallOption) (*agentsv1.GetSandboxResponse, error) {
+	if f.GetSandboxFunc != nil {
+		return f.GetSandboxFunc(ctx, req, opts...)
 	}
 	return nil, ErrNotImplemented
 }

--- a/internal/zitimanager/manager.go
+++ b/internal/zitimanager/manager.go
@@ -20,11 +20,15 @@ var (
 	retryInitialBackoff = 1 * time.Second
 	retryMaxBackoff     = 15 * time.Second
 	leaseRetryBackoff   = []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
-	reEnrollCooldown    = 200 * time.Millisecond
 
 	newZitiContext       = ziti.NewContext
 	configureZitiContext = configureZitiClientContext
 )
+
+// ErrIdentityLost reports that the orchestrator's OpenZiti identity no longer
+// exists (garbage-collected while the pod was running). Recovery is a pod
+// restart: a fresh pod enrolls a fresh identity.
+var ErrIdentityLost = errors.New("ziti identity lost")
 
 type ZitiManager struct {
 	mu              sync.RWMutex
@@ -33,13 +37,9 @@ type ZitiManager struct {
 	mgmtClient      zitimgmtv1.ZitiManagementServiceClient
 	renewalInterval time.Duration
 	enrollTimeout   time.Duration
-	parentCtx       context.Context
 
-	reEnrollMu sync.Mutex
-	reEnrollCh chan error
-
-	lastReEnrollAt  time.Time
-	lastReEnrollErr error
+	lostOnce sync.Once
+	lostCh   chan error
 }
 
 func New(ctx context.Context, client zitimgmtv1.ZitiManagementServiceClient, enrollTimeout, renewalInterval time.Duration) (*ZitiManager, error) {
@@ -59,7 +59,7 @@ func New(ctx context.Context, client zitimgmtv1.ZitiManagementServiceClient, enr
 		mgmtClient:      client,
 		renewalInterval: renewalInterval,
 		enrollTimeout:   enrollTimeout,
-		parentCtx:       ctx,
+		lostCh:          make(chan error, 1),
 	}
 	enrollCtx, cancel := context.WithTimeout(ctx, enrollTimeout)
 	defer cancel()
@@ -72,6 +72,21 @@ func New(ctx context.Context, client zitimgmtv1.ZitiManagementServiceClient, enr
 	return manager, nil
 }
 
+// IdentityLost is signalled once, with an error wrapping ErrIdentityLost, when
+// the orchestrator's identity is found to be gone (definitive NOT_FOUND from
+// the lease extension, or an auth failure confirmed to be identity loss). The
+// caller must log the error and terminate so the pod restart path enrolls a
+// fresh identity.
+func (m *ZitiManager) IdentityLost() <-chan error {
+	return m.lostCh
+}
+
+func (m *ZitiManager) signalIdentityLost(err error) {
+	m.lostOnce.Do(func() {
+		m.lostCh <- err
+	})
+}
+
 func (m *ZitiManager) DialContext(ctx context.Context, service string) (edge.Conn, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -81,10 +96,21 @@ func (m *ZitiManager) DialContext(ctx context.Context, service string) (edge.Con
 	return m.zitiCtx.DialContext(ctx, service)
 }
 
+// NotifyAuthFailure is called by the dial path when a dial is rejected for
+// authentication reasons. It confirms whether the identity is truly gone by
+// attempting a lease extension; a definitive NOT_FOUND signals identity loss.
+// A transient auth failure (identity still present) is logged and ignored.
 func (m *ZitiManager) NotifyAuthFailure(ctx context.Context) {
-	waitCtx := m.effectiveContext(ctx)
-	if err := m.triggerReEnroll(waitCtx); err != nil && waitCtx.Err() == nil {
-		log.Printf("ziti re-enroll after auth failure failed: %v", err)
+	err := m.extendLeaseWithRetry(ctx)
+	if err == nil {
+		return
+	}
+	if isNotFoundGrpcError(err) {
+		m.signalIdentityLost(fmt.Errorf("%w: identity %s no longer exists (auth failure): %v", ErrIdentityLost, m.currentIdentityID(), err))
+		return
+	}
+	if ctx.Err() == nil {
+		log.Printf("ziti auth failure check for identity %s: %v", m.currentIdentityID(), err)
 	}
 }
 
@@ -103,15 +129,14 @@ func (m *ZitiManager) RunLeaseRenewal(ctx context.Context) {
 			if err == nil {
 				continue
 			}
+			if ctx.Err() != nil {
+				return
+			}
 			if isNotFoundGrpcError(err) {
-				if err := m.triggerReEnroll(ctx); err != nil && ctx.Err() == nil {
-					log.Printf("ziti lease renewal re-enroll failed: %v", err)
-				}
-				continue
+				m.signalIdentityLost(fmt.Errorf("%w: identity %s no longer exists: %v", ErrIdentityLost, m.currentIdentityID(), err))
+				return
 			}
-			if ctx.Err() == nil {
-				log.Printf("failed to extend ziti lease: %v", err)
-			}
+			log.Printf("failed to extend ziti lease for identity %s: %v", m.currentIdentityID(), err)
 		}
 	}
 }
@@ -148,74 +173,6 @@ func (m *ZitiManager) currentIdentityID() string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.identityID
-}
-
-func (m *ZitiManager) triggerReEnroll(ctx context.Context) error {
-	waitCtx := m.effectiveContext(ctx)
-	enrollCtx := m.parentCtx
-	if enrollCtx == nil {
-		enrollCtx = waitCtx
-	}
-	ch, started := m.startReEnroll()
-	if !started {
-		return waitForReEnroll(waitCtx, ch)
-	}
-	err := m.reEnroll(enrollCtx)
-	m.finishReEnroll(ch, err)
-	return err
-}
-
-func (m *ZitiManager) startReEnroll() (chan error, bool) {
-	m.reEnrollMu.Lock()
-	defer m.reEnrollMu.Unlock()
-	if m.reEnrollCh != nil {
-		return m.reEnrollCh, false
-	}
-	if m.lastReEnrollErr == nil && !m.lastReEnrollAt.IsZero() {
-		if time.Since(m.lastReEnrollAt) < reEnrollCooldown {
-			ch := make(chan error, 1)
-			ch <- m.lastReEnrollErr
-			close(ch)
-			return ch, false
-		}
-	}
-	ch := make(chan error, 1)
-	m.reEnrollCh = ch
-	return ch, true
-}
-
-func (m *ZitiManager) finishReEnroll(ch chan error, err error) {
-	m.reEnrollMu.Lock()
-	if m.reEnrollCh == ch {
-		m.reEnrollCh = nil
-		m.lastReEnrollAt = time.Now()
-		m.lastReEnrollErr = err
-	}
-	m.reEnrollMu.Unlock()
-	if ch != nil {
-		ch <- err
-		close(ch)
-	}
-}
-
-func (m *ZitiManager) reEnroll(ctx context.Context) error {
-	enrollCtx, cancel := context.WithTimeout(ctx, m.enrollTimeout)
-	defer cancel()
-	zitiCtx, identityID, err := m.enroll(enrollCtx)
-	if err != nil {
-		return err
-	}
-
-	m.mu.Lock()
-	oldCtx := m.zitiCtx
-	m.zitiCtx = zitiCtx
-	m.identityID = identityID
-	m.mu.Unlock()
-
-	if oldCtx != nil {
-		oldCtx.Close()
-	}
-	return nil
 }
 
 func (m *ZitiManager) enroll(ctx context.Context) (ziti.Context, string, error) {
@@ -312,31 +269,6 @@ func isRetryableGrpcError(err error) bool {
 func isNotFoundGrpcError(err error) bool {
 	statusErr, ok := status.FromError(err)
 	return ok && statusErr.Code() == codes.NotFound
-}
-
-func (m *ZitiManager) effectiveContext(ctx context.Context) context.Context {
-	if ctx != nil {
-		return ctx
-	}
-	if m.parentCtx != nil {
-		return m.parentCtx
-	}
-	return context.Background()
-}
-
-func waitForReEnroll(ctx context.Context, ch <-chan error) error {
-	if ch == nil {
-		return nil
-	}
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err, ok := <-ch:
-		if !ok {
-			return nil
-		}
-		return err
-	}
 }
 
 func waitWithContext(ctx context.Context, delay time.Duration) error {

--- a/internal/zitimanager/manager_test.go
+++ b/internal/zitimanager/manager_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,25 +74,13 @@ func TestNewEnrollsIdentity(t *testing.T) {
 	}
 }
 
-func TestRunLeaseRenewalReEnrollsOnNotFound(t *testing.T) {
+func TestRunLeaseRenewalSignalsIdentityLostOnNotFound(t *testing.T) {
 	resetTestHooks(t)
 	leaseRetryBackoff = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
 
 	client := &fakeZitiMgmtClient{}
-	var mu sync.Mutex
-	requestCalls := 0
-	reEnrollCh := make(chan struct{}, 1)
 	client.requestServiceIdentity = func(context.Context, *zitimgmtv1.RequestServiceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
-		mu.Lock()
-		defer mu.Unlock()
-		requestCalls++
-		if requestCalls > 1 {
-			select {
-			case reEnrollCh <- struct{}{}:
-			default:
-			}
-		}
-		return identityResponse(fmt.Sprintf("id-%d", requestCalls)), nil
+		return identityResponse("id-1"), nil
 	}
 	client.extendIdentityLease = func(context.Context, *zitimgmtv1.ExtendIdentityLeaseRequest, ...grpc.CallOption) (*zitimgmtv1.ExtendIdentityLeaseResponse, error) {
 		return nil, status.Error(codes.NotFound, "missing")
@@ -109,65 +97,32 @@ func TestRunLeaseRenewalReEnrollsOnNotFound(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		manager.RunLeaseRenewal(ctx)
-	}()
+	defer cancel()
+	go manager.RunLeaseRenewal(ctx)
+
 	select {
-	case <-reEnrollCh:
-		cancel()
+	case err := <-manager.IdentityLost():
+		if !errors.Is(err, ErrIdentityLost) {
+			t.Fatalf("expected ErrIdentityLost, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "id-1") {
+			t.Fatalf("expected error to name lost identity, got %v", err)
+		}
 	case <-time.After(500 * time.Millisecond):
-		cancel()
-		t.Fatal("expected re-enrollment after lease NotFound")
-	}
-	waitForIdentity(t, manager, "id-2")
-}
-
-func TestNotifyAuthFailureReEnrolls(t *testing.T) {
-	resetTestHooks(t)
-
-	client := &fakeZitiMgmtClient{}
-	requestCalls := 0
-	client.requestServiceIdentity = func(context.Context, *zitimgmtv1.RequestServiceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
-		requestCalls++
-		return identityResponse(fmt.Sprintf("id-%d", requestCalls)), nil
-	}
-
-	newZitiContext = func(*ziti.Config) (ziti.Context, error) {
-		return &fakeZitiContext{}, nil
-	}
-	configureZitiContext = func(ziti.Context) error { return nil }
-
-	manager, err := New(context.Background(), client, time.Second, time.Minute)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	manager.NotifyAuthFailure(context.Background())
-	if manager.currentIdentityID() != "id-2" {
-		t.Fatalf("expected re-enrolled identity id-2, got %q", manager.currentIdentityID())
-	}
-	if requestCalls != 2 {
-		t.Fatalf("expected 2 enrollment calls, got %d", requestCalls)
+		t.Fatal("expected IdentityLost signal after lease NotFound")
 	}
 }
 
-func TestNotifyAuthFailureDebounces(t *testing.T) {
+func TestNotifyAuthFailureSignalsIdentityLostWhenGone(t *testing.T) {
 	resetTestHooks(t)
+	leaseRetryBackoff = []time.Duration{time.Millisecond}
 
 	client := &fakeZitiMgmtClient{}
-	requestCalls := 0
-	reEnrollStart := make(chan struct{}, 1)
-	releaseEnroll := make(chan struct{})
 	client.requestServiceIdentity = func(context.Context, *zitimgmtv1.RequestServiceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
-		requestCalls++
-		if requestCalls == 1 {
-			return identityResponse("id-1"), nil
-		}
-		select {
-		case reEnrollStart <- struct{}{}:
-		default:
-		}
-		<-releaseEnroll
-		return identityResponse("id-2"), nil
+		return identityResponse("id-1"), nil
+	}
+	client.extendIdentityLease = func(context.Context, *zitimgmtv1.ExtendIdentityLeaseRequest, ...grpc.CallOption) (*zitimgmtv1.ExtendIdentityLeaseResponse, error) {
+		return nil, status.Error(codes.NotFound, "missing")
 	}
 
 	newZitiContext = func(*ziti.Config) (ziti.Context, error) {
@@ -180,66 +135,31 @@ func TestNotifyAuthFailureDebounces(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	var wg sync.WaitGroup
-	start := make(chan struct{})
-	ready := make(chan struct{}, 3)
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			ready <- struct{}{}
-			<-start
-			manager.NotifyAuthFailure(context.Background())
-		}()
-	}
-	for i := 0; i < 3; i++ {
-		<-ready
-	}
-	close(start)
+	manager.NotifyAuthFailure(context.Background())
 
 	select {
-	case <-reEnrollStart:
+	case err := <-manager.IdentityLost():
+		if !errors.Is(err, ErrIdentityLost) {
+			t.Fatalf("expected ErrIdentityLost, got %v", err)
+		}
 	case <-time.After(500 * time.Millisecond):
-		close(releaseEnroll)
-		wg.Wait()
-		t.Fatal("expected re-enrollment to start")
-	}
-	close(releaseEnroll)
-	wg.Wait()
-	if requestCalls != 2 {
-		t.Fatalf("expected 2 enrollment calls, got %d", requestCalls)
+		t.Fatal("expected IdentityLost signal after auth failure with missing identity")
 	}
 }
 
-func TestNotifyAuthFailureKeepsContextOnFailure(t *testing.T) {
+func TestNotifyAuthFailureIgnoresTransient(t *testing.T) {
 	resetTestHooks(t)
 
 	client := &fakeZitiMgmtClient{}
-	requestCalls := 0
 	client.requestServiceIdentity = func(context.Context, *zitimgmtv1.RequestServiceIdentityRequest, ...grpc.CallOption) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
-		requestCalls++
-		switch requestCalls {
-		case 1:
-			return identityResponse("id-1"), nil
-		case 2:
-			return nil, status.Error(codes.InvalidArgument, "invalid")
-		case 3:
-			return identityResponse("id-2"), nil
-		default:
-			return nil, errors.New("unexpected enrollment call")
-		}
+		return identityResponse("id-1"), nil
+	}
+	client.extendIdentityLease = func(context.Context, *zitimgmtv1.ExtendIdentityLeaseRequest, ...grpc.CallOption) (*zitimgmtv1.ExtendIdentityLeaseResponse, error) {
+		return &zitimgmtv1.ExtendIdentityLeaseResponse{}, nil
 	}
 
-	closed := 0
-	ctxCalls := 0
-	ctx1 := &fakeZitiContext{closeFunc: func() { closed++ }}
-	ctx2 := &fakeZitiContext{}
 	newZitiContext = func(*ziti.Config) (ziti.Context, error) {
-		ctxCalls++
-		if ctxCalls == 1 {
-			return ctx1, nil
-		}
-		return ctx2, nil
+		return &fakeZitiContext{}, nil
 	}
 	configureZitiContext = func(ziti.Context) error { return nil }
 
@@ -249,25 +169,11 @@ func TestNotifyAuthFailureKeepsContextOnFailure(t *testing.T) {
 	}
 
 	manager.NotifyAuthFailure(context.Background())
-	if manager.zitiCtx != ctx1 {
-		t.Fatal("expected context to remain after failed re-enroll")
-	}
-	if manager.identityID != "id-1" {
-		t.Fatalf("expected identity id to remain id-1, got %q", manager.identityID)
-	}
-	if closed != 0 {
-		t.Fatalf("expected old context to remain open, closed %d", closed)
-	}
 
-	manager.NotifyAuthFailure(context.Background())
-	if manager.zitiCtx != ctx2 {
-		t.Fatal("expected context to swap after successful re-enroll")
-	}
-	if manager.identityID != "id-2" {
-		t.Fatalf("expected identity id to update to id-2, got %q", manager.identityID)
-	}
-	if closed != 1 {
-		t.Fatalf("expected old context to close after swap, closed %d", closed)
+	select {
+	case err := <-manager.IdentityLost():
+		t.Fatalf("expected no identity loss on transient auth failure, got %v", err)
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 
@@ -374,13 +280,12 @@ func TestDialContextUsesCurrentContext(t *testing.T) {
 		t.Fatalf("expected dial with ctx-1, got %q", first)
 	}
 
-	manager.NotifyAuthFailure(context.Background())
 	if _, err := manager.DialContext(context.Background(), "service-b"); err != nil {
-		t.Fatalf("DialContext after re-enroll: %v", err)
+		t.Fatalf("DialContext second: %v", err)
 	}
 	second := <-dialedCh
-	if second != "ctx-2" {
-		t.Fatalf("expected dial with ctx-2, got %q", second)
+	if second != "ctx-1" {
+		t.Fatalf("expected dial with current context ctx-1, got %q", second)
 	}
 }
 


### PR DESCRIPTION
Part of the sandboxes feature — the Orchestrator side.

**Flavor resolution moved to the runner's catalog.** The assembler took a flavor id and fetched a platform-owned row; it now resolves the environment's flavor *name* against the reported catalog of the runner the environment names. An empty name takes the runner's default; a name the runner does not report is a scheduling failure, surfaced as one rather than silently substituting something else.

**Sandbox reconciliation.** Sandboxes are always reconciled, stopped ones converge, workspace volumes are reconciled with them, and the loop wakes on sandbox notifications instead of only on its poll interval. Orphaned sandbox Ziti identities are swept.

**Identity loss is fatal.** A pod whose OpenZiti identity has been garbage-collected terminates rather than running on without overlay connectivity — recovery is the normal restart, which enrolls a fresh identity.

**Metering** labels sandbox usage with its owner.

Depends on agynio/agents#66 (environments carrying runner + flavor) and agynio/runners#72 (the catalog being resolved against).