### PR TITLE
feat(assembler): resolve an agent's workload through its environment

### DIFF
--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -13,6 +13,7 @@ import (
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	secretsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/secrets/v1"
 	"github.com/agynio/agents-orchestrator/internal/config"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
@@ -354,9 +355,13 @@ type Assembler struct {
 }
 
 type AssembleResult struct {
-	Request                *runnerv1.StartWorkloadRequest
-	OrganizationID         string
-	RunnerLabels           map[string]string
+	Request        *runnerv1.StartWorkloadRequest
+	OrganizationID string
+	RunnerLabels   map[string]string
+	// RunnerID names the runner the agent's environment places workloads on.
+	// Empty for an agent without an environment, which is still placed by
+	// labels and capabilities.
+	RunnerID               string
 	PersistentVolumes      []PersistentVolumeInfo
 	AllocatedCPUMillicores int32
 	AllocatedRAMBytes      int64
@@ -400,6 +405,11 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	volumeResolver := newVolumeResolver(a.agents, threadID)
 	imagePullResolver := newImagePullResolver(a.secrets)
 
+	environment, flavor, err := a.resolveAgentEnvironment(ctx, agent)
+	if err != nil {
+		return nil, err
+	}
+
 	agentEnvs, err := a.listEnvs(ctx, &agentsv1.ListEnvsRequest{AgentId: agentID.String()})
 	if err != nil {
 		return nil, fmt.Errorf("list agent envs: %w", err)
@@ -425,7 +435,35 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		return nil, fmt.Errorf("resolve agent image pull secrets: %w", err)
 	}
 
+	mainImage := agent.GetImage()
+	var environmentEnvVars []*runnerv1.EnvVar
+	if environment != nil {
+		environmentID := environment.GetMeta().GetId()
+		mainImage = environment.GetImage()
+		environmentEnvs, err := a.listEnvs(ctx, &agentsv1.ListEnvsRequest{EnvironmentId: environmentID})
+		if err != nil {
+			return nil, fmt.Errorf("list environment envs: %w", err)
+		}
+		environmentEnvVars, err = resolver.ResolveEnvVars(ctx, environmentEnvs)
+		if err != nil {
+			return nil, fmt.Errorf("resolve environment envs: %w", err)
+		}
+		environmentImagePullAttachments, err := a.listImagePullSecretAttachments(ctx, &agentsv1.ListImagePullSecretAttachmentsRequest{EnvironmentId: environmentID})
+		if err != nil {
+			return nil, fmt.Errorf("list environment image pull secret attachments: %w", err)
+		}
+		if err := imagePullResolver.Resolve(ctx, environmentImagePullAttachments); err != nil {
+			return nil, fmt.Errorf("resolve environment image pull secrets: %w", err)
+		}
+	}
+
 	mainEnv := mergeEnvVars(a.baseAgentEnvVars(agent, agentID, threadID), agentEnvVars, fmt.Sprintf("agent %s", agentID.String()))
+	if len(environmentEnvVars) > 0 {
+		// mergeEnvVars keeps the first occurrence of a name, so layering the
+		// environment's envs onto the agent's leaves the agent's own value in
+		// place on a collision: it is the more specific of the two.
+		mainEnv = mergeEnvVars(mainEnv, environmentEnvVars, fmt.Sprintf("environment %s", environment.GetMeta().GetId()))
+	}
 	mainEnv = appendEgressCAEnvVars(mainEnv)
 
 	initImage := agent.GetInitImage()
@@ -436,7 +474,7 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 	mainMounts := append([]*runnerv1.VolumeMount{}, agentMounts...)
 	mainMounts = append(mainMounts, &runnerv1.VolumeMount{Volume: agynBinVolumeName, MountPath: agynBinMountPath})
 	main := &runnerv1.ContainerSpec{
-		Image:            agent.GetImage(),
+		Image:            mainImage,
 		Name:             fmt.Sprintf("agent-%s-%s", agentID.String()[:8], threadID.String()[:8]),
 		Cmd:              []string{agynBinBinaryPath},
 		Env:              mainEnv,
@@ -607,10 +645,34 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, threadID uuid.UUID) (
 		Request:                request,
 		OrganizationID:         agent.GetOrganizationId(),
 		RunnerLabels:           runnerLabels,
+		RunnerID:               flavor.GetRunnerId(),
 		PersistentVolumes:      persistentVolumes,
 		AllocatedCPUMillicores: allocatedCPU,
 		AllocatedRAMBytes:      allocatedRAM,
 	}, nil
+}
+
+// resolveAgentEnvironment resolves the environment an agent runs in the same
+// way a sandbox resolves its own. environment_id is optional: every agent
+// created before environments existed has none and keeps its inline image and
+// label-based placement, so a missing id resolves to nil rather than an error.
+func (a *Assembler) resolveAgentEnvironment(ctx context.Context, agent *agentsv1.Agent) (*agentsv1.Environment, *runnersv1.Flavor, error) {
+	if strings.TrimSpace(agent.GetEnvironmentId()) == "" {
+		return nil, nil, nil
+	}
+	environmentID, err := uuidutil.ParseUUID(agent.GetEnvironmentId(), "agent.environment_id")
+	if err != nil {
+		return nil, nil, err
+	}
+	environment, err := a.fetchEnvironment(ctx, environmentID)
+	if err != nil {
+		return nil, nil, err
+	}
+	flavor, err := a.resolveFlavor(ctx, environment.GetRunnerId(), environment.GetFlavor())
+	if err != nil {
+		return nil, nil, err
+	}
+	return environment, flavor, nil
 }
 
 func zitiEnvVars() []*runnerv1.EnvVar {

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -14,6 +14,7 @@ import (
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	secretsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/secrets/v1"
 	"github.com/agynio/agents-orchestrator/internal/config"
 	"github.com/agynio/agents-orchestrator/internal/testutil"
@@ -2216,5 +2217,211 @@ func TestZitiSidecarUsesWorkloadDNSForRuntimeAuth(t *testing.T) {
 	}
 	if strings.Contains(zitiSidecarScript, ZitiEnrollmentTokenEnvVar) {
 		t.Fatalf("expected sidecar script not to consume %s", ZitiEnrollmentTokenEnvVar)
+	}
+}
+
+const (
+	testAgentInlineImage         = "agent-image"
+	testAgentEnvironmentImage    = "environment-image"
+	testAgentEnvironmentFlavor   = "ram-2gb"
+	testAgentEnvironmentRunnerID = "runner-environment"
+)
+
+type agentEnvironmentFixture struct {
+	agentID       uuid.UUID
+	threadID      uuid.UUID
+	environmentID uuid.UUID
+	agent         *agentsv1.Agent
+	agents        *testutil.FakeAgentsClient
+	runners       *fakeRunnersClient
+	secrets       *testutil.FakeSecretsClient
+	cfg           *config.Config
+}
+
+func newAgentEnvironmentFixture() *agentEnvironmentFixture {
+	agentID := uuid.New()
+	environmentID := uuid.New()
+	fixture := &agentEnvironmentFixture{
+		agentID:       agentID,
+		threadID:      uuid.New(),
+		environmentID: environmentID,
+		secrets:       &testutil.FakeSecretsClient{},
+		cfg: &config.Config{
+			AgentGatewayAddress: "gateway:50051",
+			AgentLLMBaseURL:     "http://llm:8080/v1",
+		},
+	}
+	fixture.agent = &agentsv1.Agent{
+		Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
+		OrganizationId: "org-1",
+		Name:           "assistant",
+		Image:          testAgentInlineImage,
+		InitImage:      "agent-init-image",
+		EnvironmentId:  environmentID.String(),
+	}
+	fixture.agents = &testutil.FakeAgentsClient{
+		GetAgentFunc: func(_ context.Context, req *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			if req.GetId() != agentID.String() {
+				return nil, errors.New("unexpected agent id")
+			}
+			return &agentsv1.GetAgentResponse{Agent: fixture.agent}, nil
+		},
+		GetEnvironmentFunc: func(_ context.Context, req *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
+			if req.GetId() != environmentID.String() {
+				return nil, errors.New("unexpected environment id")
+			}
+			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{
+				Meta:           &agentsv1.EntityMeta{Id: environmentID.String()},
+				OrganizationId: "org-1",
+				Name:           "shared-runtime",
+				Image:          testAgentEnvironmentImage,
+				RunnerId:       testAgentEnvironmentRunnerID,
+				Flavor:         testAgentEnvironmentFlavor,
+			}}, nil
+		},
+		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
+			return &agentsv1.ListEnvsResponse{}, nil
+		},
+		ListVolumeAttachmentsFunc: func(context.Context, *agentsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		},
+		ListImagePullSecretAttachmentsFunc: func(context.Context, *agentsv1.ListImagePullSecretAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error) {
+			return &agentsv1.ListImagePullSecretAttachmentsResponse{}, nil
+		},
+		ListMcpsFunc: func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
+			return &agentsv1.ListMcpsResponse{}, nil
+		},
+		ListHooksFunc: func(context.Context, *agentsv1.ListHooksRequest, ...grpc.CallOption) (*agentsv1.ListHooksResponse, error) {
+			return &agentsv1.ListHooksResponse{}, nil
+		},
+	}
+	fixture.runners = &fakeRunnersClient{
+		listFlavors: func(_ context.Context, req *runnersv1.ListFlavorsRequest, _ ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			if req.GetRunnerId() != testAgentEnvironmentRunnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{
+				{RunnerId: testAgentEnvironmentRunnerID, Name: "other", Default: true},
+				{RunnerId: testAgentEnvironmentRunnerID, Name: testAgentEnvironmentFlavor},
+			}}, nil
+		},
+	}
+	return fixture
+}
+
+func (f *agentEnvironmentFixture) assemble(t *testing.T) *AssembleResult {
+	t.Helper()
+	assembler := NewWithRunners(f.agents, f.runners, f.secrets, f.cfg)
+	result, err := assembler.Assemble(context.Background(), f.agentID, f.threadID)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	return result
+}
+
+func TestAssemblerUsesEnvironmentImageAndRunner(t *testing.T) {
+	fixture := newAgentEnvironmentFixture()
+	result := fixture.assemble(t)
+
+	main := result.Request.GetMain()
+	if main == nil {
+		t.Fatal("expected main container")
+	}
+	if main.GetImage() != testAgentEnvironmentImage {
+		t.Fatalf("expected environment image %q, got %q", testAgentEnvironmentImage, main.GetImage())
+	}
+	if result.RunnerID != testAgentEnvironmentRunnerID {
+		t.Fatalf("expected environment runner %q, got %q", testAgentEnvironmentRunnerID, result.RunnerID)
+	}
+	// The init image stays the agent's: an environment supplies the runtime an
+	// agent runs in, not the bootstrap that seeds it.
+	initContainer := testutil.FindInitContainer(result.Request.GetInitContainers(), "agent-init")
+	if initContainer == nil || initContainer.GetImage() != "agent-init-image" {
+		t.Fatalf("expected the agent's init image, got %+v", initContainer)
+	}
+}
+
+func TestAssemblerWithoutEnvironmentKeepsAgentImageAndPlacement(t *testing.T) {
+	fixture := newAgentEnvironmentFixture()
+	fixture.agent.EnvironmentId = ""
+	// Agents predating environments must not reach for one at all.
+	fixture.agents.GetEnvironmentFunc = func(context.Context, *agentsv1.GetEnvironmentRequest, ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
+		return nil, errors.New("unexpected environment lookup")
+	}
+	fixture.agents.ListEnvsFunc = func(_ context.Context, req *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
+		if req.GetEnvironmentId() != "" {
+			return nil, errors.New("unexpected environment-scoped env listing")
+		}
+		return &agentsv1.ListEnvsResponse{}, nil
+	}
+	fixture.agents.ListImagePullSecretAttachmentsFunc = func(_ context.Context, req *agentsv1.ListImagePullSecretAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error) {
+		if req.GetEnvironmentId() != "" {
+			return nil, errors.New("unexpected environment-scoped image pull secret listing")
+		}
+		return &agentsv1.ListImagePullSecretAttachmentsResponse{}, nil
+	}
+	fixture.runners.listFlavors = func(context.Context, *runnersv1.ListFlavorsRequest, ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+		return nil, errors.New("unexpected flavor lookup")
+	}
+
+	result := fixture.assemble(t)
+
+	if result.Request.GetMain().GetImage() != testAgentInlineImage {
+		t.Fatalf("expected the agent's inline image %q, got %q", testAgentInlineImage, result.Request.GetMain().GetImage())
+	}
+	// An empty runner id is what keeps these agents on label and capability
+	// selection in the reconciler.
+	if result.RunnerID != "" {
+		t.Fatalf("expected no environment runner, got %q", result.RunnerID)
+	}
+}
+
+func TestAssemblerInheritsEnvironmentEnvsAndImagePullSecrets(t *testing.T) {
+	fixture := newAgentEnvironmentFixture()
+	environmentSecretID := uuid.NewString()
+	fixture.agents.ListEnvsFunc = func(_ context.Context, req *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
+		switch {
+		case req.GetAgentId() == fixture.agentID.String():
+			return &agentsv1.ListEnvsResponse{Envs: []*agentsv1.Env{
+				{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "AGENT_ONLY", Source: &agentsv1.Env_Value{Value: "agent-only"}},
+				{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "SHARED", Source: &agentsv1.Env_Value{Value: "from-agent"}},
+			}}, nil
+		case req.GetEnvironmentId() == fixture.environmentID.String():
+			return &agentsv1.ListEnvsResponse{Envs: []*agentsv1.Env{
+				{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "ENVIRONMENT_ONLY", Source: &agentsv1.Env_Value{Value: "environment-only"}},
+				{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "SHARED", Source: &agentsv1.Env_Value{Value: "from-environment"}},
+			}}, nil
+		}
+		return &agentsv1.ListEnvsResponse{}, nil
+	}
+	fixture.agents.ListImagePullSecretAttachmentsFunc = func(_ context.Context, req *agentsv1.ListImagePullSecretAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error) {
+		if req.GetEnvironmentId() == fixture.environmentID.String() {
+			return &agentsv1.ListImagePullSecretAttachmentsResponse{ImagePullSecretAttachments: []*agentsv1.ImagePullSecretAttachment{
+				{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, ImagePullSecretId: environmentSecretID},
+			}}, nil
+		}
+		return &agentsv1.ListImagePullSecretAttachmentsResponse{}, nil
+	}
+	fixture.secrets.ResolveImagePullSecretFunc = func(_ context.Context, req *secretsv1.ResolveImagePullSecretRequest, _ ...grpc.CallOption) (*secretsv1.ResolveImagePullSecretResponse, error) {
+		if req.GetId() != environmentSecretID {
+			return nil, errors.New("unexpected image pull secret id")
+		}
+		return &secretsv1.ResolveImagePullSecretResponse{Registry: "registry.example.com", Username: "robot", Password: "token"}, nil
+	}
+
+	result := fixture.assemble(t)
+
+	envs := envMap(result.Request.GetMain().GetEnv())
+	assertEnv(t, envs, "ENVIRONMENT_ONLY", "environment-only")
+	assertEnv(t, envs, "AGENT_ONLY", "agent-only")
+	// The agent's own value is the more specific of the two, so it wins.
+	assertEnv(t, envs, "SHARED", "from-agent")
+
+	credentials := result.Request.GetImagePullCredentials()
+	if len(credentials) != 1 {
+		t.Fatalf("expected 1 image pull credential, got %d", len(credentials))
+	}
+	if credentials[0].GetRegistry() != "registry.example.com" || credentials[0].GetUsername() != "robot" || credentials[0].GetPassword() != "token" {
+		t.Fatalf("unexpected image pull credential: %v", credentials[0])
 	}
 }

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -32,6 +32,7 @@ const (
 	testAgentIDAlt             = "33333333-3333-3333-3333-333333333333"
 	testAllocatedCPUMillicores = int32(500)
 	testAllocatedRAMBytes      = int64(1 << 30)
+	testEnvironmentImage       = "environment-image"
 )
 
 var errNotImplemented = errors.New("not implemented")
@@ -476,6 +477,186 @@ func TestStartWorkloadDegradesWhenPinnedRunnerNotEnrolled(t *testing.T) {
 	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
 
 	if !reflect.DeepEqual(calls, []string{"list-volumes", "get-runner", "degrade"}) {
+		t.Fatalf("unexpected call order: %v", calls)
+	}
+}
+
+func TestStartWorkloadPlacesEnvironmentAgentOnEnvironmentRunner(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	threadID := uuid.New()
+	environmentID := uuid.New()
+	environmentRunnerID := "runner-environment"
+	mainContainerID := "container-main"
+	testAssembler := newTestEnvironmentAssembler(agentID, environmentID, environmentRunnerID)
+
+	var calls []string
+	runner := &fakeRunnerClient{
+		startWorkload: func(_ context.Context, req *runnerv1.StartWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StartWorkloadResponse, error) {
+			calls = append(calls, "start")
+			if req.GetMain().GetImage() != testEnvironmentImage {
+				return nil, errors.New("unexpected main image")
+			}
+			return &runnerv1.StartWorkloadResponse{
+				Id:     req.GetWorkloadId(),
+				Status: runnerv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+				Containers: &runnerv1.WorkloadContainers{
+					Main: mainContainerID,
+				},
+			}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			calls = append(calls, "dial")
+			if id != environmentRunnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+
+	runners := &fakeRunnersClient{
+		listVolumesByThread: func(_ context.Context, req *runnersv1.ListVolumesByThreadRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error) {
+			calls = append(calls, "list-volumes")
+			if req.GetThreadId() != threadID.String() {
+				return nil, errors.New("unexpected thread id")
+			}
+			return &runnersv1.ListVolumesByThreadResponse{}, nil
+		},
+		getRunner: func(_ context.Context, req *runnersv1.GetRunnerRequest, _ ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
+			calls = append(calls, "get-runner")
+			if req.GetId() != environmentRunnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return &runnersv1.GetRunnerResponse{Runner: buildRunner(environmentRunnerID)}, nil
+		},
+		createWorkload: func(_ context.Context, req *runnersv1.CreateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error) {
+			calls = append(calls, "create-workload")
+			if req.GetRunnerId() != environmentRunnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return &runnersv1.CreateWorkloadResponse{}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			calls = append(calls, "update-workload")
+			if req.GetInstanceId() == "" {
+				return nil, errors.New("missing instance id")
+			}
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+		listRunners: func(context.Context, *runnersv1.ListRunnersRequest, ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return nil, errors.New("unexpected list runners")
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Assembler:    testAssembler,
+	})
+	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
+
+	// No list-runners: the environment's runner replaces label and capability
+	// selection for an unpinned thread.
+	if !reflect.DeepEqual(calls, []string{"list-volumes", "get-runner", "dial", "create-workload", "start", "update-workload"}) {
+		t.Fatalf("unexpected call order: %v", calls)
+	}
+}
+
+func TestStartWorkloadKeepsPinnedRunnerWhenEnvironmentNamesAnother(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	threadID := uuid.New()
+	environmentID := uuid.New()
+	environmentRunnerID := "runner-environment"
+	pinnedRunnerID := "runner-pinned"
+	volumeKey := "volume-1"
+	mainContainerID := "container-main"
+	testAssembler := newTestEnvironmentAssembler(agentID, environmentID, environmentRunnerID)
+
+	var calls []string
+	threads := &fakeThreadsClient{
+		degradeThread: func(context.Context, *threadsv1.DegradeThreadRequest, ...grpc.CallOption) (*threadsv1.DegradeThreadResponse, error) {
+			calls = append(calls, "degrade")
+			return &threadsv1.DegradeThreadResponse{}, nil
+		},
+	}
+	runner := &fakeRunnerClient{
+		startWorkload: func(_ context.Context, req *runnerv1.StartWorkloadRequest, _ ...grpc.CallOption) (*runnerv1.StartWorkloadResponse, error) {
+			calls = append(calls, "start")
+			return &runnerv1.StartWorkloadResponse{
+				Id:     req.GetWorkloadId(),
+				Status: runnerv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+				Containers: &runnerv1.WorkloadContainers{
+					Main: mainContainerID,
+				},
+			}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, id string) (runnerv1.RunnerServiceClient, error) {
+			calls = append(calls, "dial")
+			if id != pinnedRunnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return runner, nil
+		},
+	}
+
+	runners := &fakeRunnersClient{
+		listVolumesByThread: func(_ context.Context, req *runnersv1.ListVolumesByThreadRequest, _ ...grpc.CallOption) (*runnersv1.ListVolumesByThreadResponse, error) {
+			calls = append(calls, "list-volumes")
+			if req.GetThreadId() != threadID.String() {
+				return nil, errors.New("unexpected thread id")
+			}
+			return &runnersv1.ListVolumesByThreadResponse{Volumes: []*runnersv1.Volume{
+				{
+					Meta:     &runnersv1.EntityMeta{Id: volumeKey},
+					RunnerId: pinnedRunnerID,
+					Status:   runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE,
+					ThreadId: threadID.String(),
+					VolumeId: "volume-id",
+				},
+			}}, nil
+		},
+		getRunner: func(_ context.Context, req *runnersv1.GetRunnerRequest, _ ...grpc.CallOption) (*runnersv1.GetRunnerResponse, error) {
+			calls = append(calls, "get-runner")
+			if req.GetId() != pinnedRunnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return &runnersv1.GetRunnerResponse{Runner: buildRunner(pinnedRunnerID)}, nil
+		},
+		createWorkload: func(_ context.Context, req *runnersv1.CreateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.CreateWorkloadResponse, error) {
+			calls = append(calls, "create-workload")
+			if req.GetRunnerId() != pinnedRunnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return &runnersv1.CreateWorkloadResponse{}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			calls = append(calls, "update-workload")
+			if req.GetInstanceId() == "" {
+				return nil, errors.New("missing instance id")
+			}
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+		listRunners: func(context.Context, *runnersv1.ListRunnersRequest, ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return nil, errors.New("unexpected list runners")
+		},
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Threads:      threads,
+		Assembler:    testAssembler,
+	})
+	reconciler.startWorkload(ctx, AgentThread{AgentID: agentID, ThreadID: threadID}, newDegradeTracker())
+
+	// The pin wins over the environment's runner and is not a fault: the agent's
+	// state volume physically lives on the pinned runner, so nothing degrades.
+	if !reflect.DeepEqual(calls, []string{"list-volumes", "get-runner", "dial", "create-workload", "start", "update-workload"}) {
 		t.Fatalf("unexpected call order: %v", calls)
 	}
 }
@@ -1611,6 +1792,81 @@ func newTestAssembler(agentID uuid.UUID, zitiEnabled bool) *assembler.Assembler 
 		ZitiRuntimeControllerPort:           "443",
 	}
 	return assembler.New(agentsClient, &testutil.FakeSecretsClient{}, cfg)
+}
+
+// newTestEnvironmentAssembler builds an assembler for an agent that runs in an
+// environment: its image and runner come from the environment rather than from
+// the agent's own deprecated inline image and label-based placement.
+func newTestEnvironmentAssembler(agentID, environmentID uuid.UUID, runnerID string) *assembler.Assembler {
+	agentsClient := &testutil.FakeAgentsClient{
+		GetAgentFunc: func(_ context.Context, req *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			if req.GetId() != agentID.String() {
+				return nil, errors.New("unexpected agent id")
+			}
+			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{
+				Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
+				OrganizationId: testOrganizationID,
+				Image:          "agent-image",
+				InitImage:      "agent-init-image",
+				EnvironmentId:  environmentID.String(),
+				Resources: &agentsv1.ComputeResources{
+					RequestsCpu:    "500m",
+					RequestsMemory: "1Gi",
+				},
+			}}, nil
+		},
+		GetEnvironmentFunc: func(_ context.Context, req *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
+			if req.GetId() != environmentID.String() {
+				return nil, errors.New("unexpected environment id")
+			}
+			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{
+				Meta:           &agentsv1.EntityMeta{Id: environmentID.String()},
+				OrganizationId: testOrganizationID,
+				Name:           "shared-runtime",
+				Image:          testEnvironmentImage,
+				RunnerId:       runnerID,
+			}}, nil
+		},
+		ListSkillsFunc: func(context.Context, *agentsv1.ListSkillsRequest, ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
+			return &agentsv1.ListSkillsResponse{}, nil
+		},
+		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
+			return &agentsv1.ListEnvsResponse{}, nil
+		},
+		ListInitScriptsFunc: func(context.Context, *agentsv1.ListInitScriptsRequest, ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
+			return &agentsv1.ListInitScriptsResponse{}, nil
+		},
+		ListVolumeAttachmentsFunc: func(context.Context, *agentsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		},
+		ListImagePullSecretAttachmentsFunc: func(context.Context, *agentsv1.ListImagePullSecretAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error) {
+			return &agentsv1.ListImagePullSecretAttachmentsResponse{}, nil
+		},
+		ListMcpsFunc: func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
+			return &agentsv1.ListMcpsResponse{}, nil
+		},
+		ListHooksFunc: func(context.Context, *agentsv1.ListHooksRequest, ...grpc.CallOption) (*agentsv1.ListHooksResponse, error) {
+			return &agentsv1.ListHooksResponse{}, nil
+		},
+	}
+
+	// The environment names no flavor, so it takes the runner's default.
+	runnersClient := &fakeRunnersClient{
+		listFlavors: func(_ context.Context, req *runnersv1.ListFlavorsRequest, _ ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			if req.GetRunnerId() != runnerID {
+				return nil, errors.New("unexpected runner id")
+			}
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{
+				{RunnerId: runnerID, Name: "ram-1gb", Default: true},
+			}}, nil
+		},
+	}
+
+	cfg := &config.Config{
+		AgentGatewayAddress: "gateway:50051",
+		AgentLLMBaseURL:     "http://llm:8080/v1",
+	}
+	return assembler.NewWithRunners(agentsClient, runnersClient, &testutil.FakeSecretsClient{}, cfg)
 }
 
 func envMap(envs []*runnerv1.EnvVar) map[string]string {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -247,6 +247,21 @@ func (r *Reconciler) startWorkload(ctx context.Context, target AgentThread, degr
 			return
 		}
 		selectedRunner = runner
+	} else if assembled.RunnerID != "" {
+		// An agent with an environment is placed on the environment's runner
+		// instead of by labels and capabilities. A thread that already has
+		// volumes keeps its pin above: the agent's state physically lives on
+		// that runner and cannot be moved by picking a different one.
+		runner, enrolled, err := r.getRunnerIfEnrolled(runnerCtx, assembled.RunnerID)
+		if err != nil {
+			log.Printf("reconciler: get environment runner %s for agent %s thread %s: %v", assembled.RunnerID, target.AgentID.String(), target.ThreadID.String(), err)
+			return
+		}
+		if !enrolled {
+			log.Printf("reconciler: environment runner %s is not enrolled for agent %s thread %s", assembled.RunnerID, target.AgentID.String(), target.ThreadID.String())
+			return
+		}
+		selectedRunner = runner
 	} else {
 		selectedRunner, err = r.selectRunner(ctx, assembled.OrganizationID, assembled.RunnerLabels, assembled.Request.GetCapabilities())
 		if err != nil {


### PR DESCRIPTION
An environment is the reusable runtime definition — image, runner, flavor, and the ENVs and image pull secrets attached to it. Sandboxes have resolved through it since they shipped; agents ignored it even after gaining `environment_id` (agynio/api#166, agynio/agents#68), still taking their image from the deprecated inline field and being placed by capabilities.

An agent with an environment now resolves the same way a sandbox does, reusing the existing helpers rather than a parallel path: `fetchEnvironment` → `resolveFlavor(runnerId, flavor)`, then `listEnvs`/`listImagePullSecretAttachments` scoped to the environment, fed through the same resolvers the agent's own attachments already use.

**Placement.** The environment's runner becomes a new branch *below* the existing pin, so it only replaces what an **unpinned** thread does. A pinned thread is untouched: its state volume physically lives on that runner and cannot be moved by naming another. Nothing degrades on a mismatch — the pin is simply the answer, exactly as it already is when a pin disagrees with what `selectRunner` would have chosen.

**ENV precedence** is platform > agent > environment. `mergeEnvVars` keeps the first occurrence of a name and applies reserved-name filtering only to its second argument, so the layering is two calls, letting each user-supplied set pass filtering exactly once. The direction was confirmed empirically: inverting the arguments flips the collision test and drops every platform variable as reserved.

**Agents without an environment are completely unchanged** — it is optional, and every agent predating it has none.

## Known gap, deliberately not fixed here

Compute allocation still comes from the agent's deprecated inline `resources`, so an env-backed agent typically records **0** allocated CPU/RAM where a sandbox derives them from the flavor. `runnerv1.ContainerSpec` carries no resources field in either path, so this never reaches the runner — the consequence is under-reported **metering**, not mis-scheduling. Worth a follow-up decision on whether env-backed agents should bill the flavor.

Two assembler tests fail locally (`TestZitiEnrollScript...`) — they exec the Linux path `/usr/bin/bash`, absent on macOS. Verified identical on the parent commit; CI runs Ubuntu.
