### PR TITLE
Subscribe to the sandbox org room on its own

### DIFF
--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -236,7 +236,8 @@ func (s *Subscriber) buildRoomSubscriptions(ctx context.Context) ([]roomSubscrip
 	if len(roomsByIdentity) == 0 {
 		return nil, "", fmt.Errorf("no agent instance rooms available")
 	}
-	if err := s.applySandboxOrgRooms(roomsByIdentity, sandboxOrgIdentities); err != nil {
+	sandboxOrgRooms, err := s.sandboxOrgRooms(roomsByIdentity, sandboxOrgIdentities)
+	if err != nil {
 		return nil, "", err
 	}
 
@@ -257,17 +258,42 @@ func (s *Subscriber) buildRoomSubscriptions(ctx context.Context) ([]roomSubscrip
 		})
 		fingerprints = append(fingerprints, fingerprint)
 	}
+	// Kept out of the subscriptions above rather than folded into them.
+	// Notifications refuses a whole Subscribe when any one room is
+	// unauthorized, and an instance identity cannot hold can_list_sandboxes --
+	// it is a member of its organization, and that room wants the owner. Bundled
+	// together, the sandbox room took the instance's own inbox down with it and
+	// no delivery ever woke the reconciler.
+	for _, identityID := range sortedIdentities(sandboxOrgRooms) {
+		rooms := sortedRooms(sandboxOrgRooms[identityID])
+		subscriptions = append(subscriptions, roomSubscription{
+			identityID: identityID,
+			rooms:      rooms,
+		})
+		fingerprints = append(fingerprints, identityID.String()+":"+strings.Join(rooms, ","))
+	}
 	return subscriptions, strings.Join(fingerprints, "|"), nil
 }
 
-// applySandboxOrgRooms attaches the org-level sandbox room of every organization
-// the reconciler covers to one subscription per organization, so sandbox status
-// changes wake the sandbox loop without waiting for the next poll tick.
-func (s *Subscriber) applySandboxOrgRooms(roomsByIdentity map[uuid.UUID]map[string]struct{}, sandboxOrgIdentities map[string]uuid.UUID) error {
+func sortedIdentities(roomsByIdentity map[uuid.UUID]map[string]struct{}) []uuid.UUID {
+	identityIDs := make([]uuid.UUID, 0, len(roomsByIdentity))
+	for identityID := range roomsByIdentity {
+		identityIDs = append(identityIDs, identityID)
+	}
+	sort.Slice(identityIDs, func(i, j int) bool { return identityIDs[i].String() < identityIDs[j].String() })
+	return identityIDs
+}
+
+// sandboxOrgRooms elects one identity per organization to watch its org-level
+// sandbox room, so sandbox status changes wake the sandbox loop without waiting
+// for the next poll tick. The result is subscribed separately from the instance
+// rooms; see the caller.
+func (s *Subscriber) sandboxOrgRooms(roomsByIdentity map[uuid.UUID]map[string]struct{}, sandboxOrgIdentities map[string]uuid.UUID) (map[uuid.UUID]map[string]struct{}, error) {
+	roomsByElected := map[uuid.UUID]map[string]struct{}{}
 	for _, configuredOrgID := range s.sandboxOrgIDs {
 		parsedOrgID, err := uuidutil.ParseUUID(strings.TrimSpace(configuredOrgID), "sandbox_reconcile.organization_id")
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if _, ok := sandboxOrgIdentities[parsedOrgID.String()]; ok {
 			continue
@@ -277,13 +303,17 @@ func (s *Subscriber) applySandboxOrgRooms(roomsByIdentity map[uuid.UUID]map[stri
 		sandboxOrgIdentities[parsedOrgID.String()] = lowestIdentity(roomsByIdentity)
 	}
 	for orgID, identityID := range sandboxOrgIdentities {
-		rooms, ok := roomsByIdentity[identityID]
-		if !ok {
+		if _, ok := roomsByIdentity[identityID]; !ok {
 			continue
+		}
+		rooms, ok := roomsByElected[identityID]
+		if !ok {
+			rooms = map[string]struct{}{}
+			roomsByElected[identityID] = rooms
 		}
 		rooms[sandboxOrgRoomPrefix+orgID] = struct{}{}
 	}
-	return nil
+	return roomsByElected, nil
 }
 
 func lowestIdentity(roomsByIdentity map[uuid.UUID]map[string]struct{}) uuid.UUID {

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -239,6 +239,22 @@ func waitForSubscribeRequests(t *testing.T, subscribeReqs <-chan subscribeCall, 
 	return reqs
 }
 
+// assertSubscribeRooms finds the one subscription whose rooms match exactly.
+// Subscriptions run concurrently, so arrival order says nothing.
+func assertSubscribeRooms(t *testing.T, reqs []subscribeCall, expected []string) {
+	t.Helper()
+	for _, req := range reqs {
+		if reflect.DeepEqual(req.req.GetRooms(), expected) {
+			return
+		}
+	}
+	got := make([][]string, 0, len(reqs))
+	for _, req := range reqs {
+		got = append(got, req.req.GetRooms())
+	}
+	t.Fatalf("expected a subscription for rooms %v, got %v", expected, got)
+}
+
 func assertSubscribeRequestForIdentity(t *testing.T, reqs []subscribeCall, instanceID string) {
 	t.Helper()
 	expected := []string{"agent_instance:" + instanceID, "instance_inbox:" + instanceID}
@@ -363,11 +379,13 @@ func TestSubscriberWakesSandboxOnSandboxUpdated(t *testing.T) {
 	harness := newSubscriberHarness(t, responses, ack, []*agentsv1.AgentInstance{instanceInOrgFixture(instanceID, orgID)}, time.Hour)
 	defer harness.cancel()
 
-	req := waitForSubscribe(t, harness.subscribeReqs, 1)
-	expected := []string{"agent_instance:" + instanceID, "instance_inbox:" + instanceID, "sandbox_org:" + orgID}
-	if !reflect.DeepEqual(req.req.GetRooms(), expected) {
-		t.Fatalf("expected rooms %v, got %v", expected, req.req.GetRooms())
-	}
+	// Two subscriptions, not one: an instance identity cannot hold
+	// can_list_sandboxes, and Notifications refuses a whole Subscribe when any
+	// room in it is unauthorized. Bundled, the sandbox room took the instance's
+	// own inbox down with it.
+	reqs := waitForSubscribeRequests(t, harness.subscribeReqs, 2)
+	assertSubscribeRequestForIdentity(t, reqs, instanceID)
+	assertSubscribeRooms(t, reqs, []string{"sandbox_org:" + orgID})
 
 	responses <- messageEnvelope("sandbox.updated")
 	waitForAck(t, ack, 1)
@@ -397,11 +415,9 @@ func TestSubscriberSubscribesConfiguredSandboxOrganizations(t *testing.T) {
 	harness := newSubscriberHarnessWithSandboxOrgs(t, responses, ack, []*agentsv1.AgentInstance{instanceFixture(instanceID)}, time.Hour, []string{configuredOrgID})
 	defer harness.cancel()
 
-	req := waitForSubscribe(t, harness.subscribeReqs, 1)
-	expected := []string{"agent_instance:" + instanceID, "instance_inbox:" + instanceID, "sandbox_org:" + configuredOrgID}
-	if !reflect.DeepEqual(req.req.GetRooms(), expected) {
-		t.Fatalf("expected rooms %v, got %v", expected, req.req.GetRooms())
-	}
+	reqs := waitForSubscribeRequests(t, harness.subscribeReqs, 2)
+	assertSubscribeRequestForIdentity(t, reqs, instanceID)
+	assertSubscribeRooms(t, reqs, []string{"sandbox_org:" + configuredOrgID})
 
 	harness.cancel()
 	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {


### PR DESCRIPTION
Notifications refuses an entire `Subscribe` when any one room in it is unauthorized. An agent instance identity cannot hold `can_list_sandboxes` — `define can_list_sandboxes: owner or admin from cluster`, and an instance is only a `member` of its organization — so the elected instance's subscription was refused wholesale, taking `instance_inbox:<id>` with it. No inbox delivery ever woke the reconciler.

Splitting the sandbox org room into its own subscription leaves it failing alone. That remaining failure is a real, separate gap: nothing the reconciler can present satisfies `sandbox_org:{org}`, so org sandbox status changes only reach the reconciler on its poll tick. Worth its own issue — the fix is a design call about which identity the platform watches org sandbox rooms as.