### PR TITLE
Add the egress CA to the roots instead of replacing them

### DIFF
--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -1640,8 +1640,11 @@ func TestAssemblerDistributesEgressCA(t *testing.T) {
 		t.Fatalf("assemble: %v", err)
 	}
 	request := result.Request
-	if string(request.GetInlineFiles()[egressCACertPath]) != string(cert) {
-		t.Fatalf("expected egress CA inline file bytes")
+	// Contains, not equals: the file is a bundle -- the public roots with the
+	// egress CA appended -- because installing the CA as the whole trust store
+	// broke every connection egress does not intercept.
+	if !strings.Contains(string(request.GetInlineFiles()[egressCACertPath]), string(cert)) {
+		t.Fatalf("expected the egress CA in the inline bundle")
 	}
 	containers := []*runnerv1.ContainerSpec{request.Main}
 	containers = append(containers, request.GetSidecars()...)

--- a/internal/assembler/egress_ca.go
+++ b/internal/assembler/egress_ca.go
@@ -1,8 +1,11 @@
 package assembler
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -11,6 +14,37 @@ const (
 	egressCASecretName = "egress-ca"
 	egressCASecretKey  = "tls.crt"
 )
+
+// systemRootsPath is this image's own trust store. The bundle handed to a
+// workload is built from it, so pointing SSL_CERT_FILE at that bundle adds the
+// egress CA to the public roots instead of replacing them. A variable so the
+// tests can point it somewhere predictable.
+var systemRootsPath = "/etc/ssl/certs/ca-certificates.crt"
+
+// EgressCABundle returns the certificate bundle to install in every workload:
+// the public roots this image trusts, with the egress CA appended.
+//
+// The egress CA alone is not a trust store. Installed as one it broke every
+// connection egress does not intercept -- an agent could not reach the ziti
+// controller or its own MCP sidecars, because a store holding one private CA
+// vouches for nothing else. Traffic the egress gateway does terminate is still
+// trusted, because its CA is in here too.
+func EgressCABundle(cert []byte) []byte {
+	if len(cert) == 0 {
+		return nil
+	}
+	roots, err := os.ReadFile(systemRootsPath)
+	if err != nil {
+		// Better a store that trusts only the egress CA than no egress at all,
+		// but say so: everything else this workload dials will fail to verify.
+		log.Printf("assembler: read system roots %s: %v; workloads get the egress CA alone", systemRootsPath, err)
+		return append([]byte(nil), cert...)
+	}
+	bundle := make([]byte, 0, len(roots)+len(cert)+1)
+	bundle = append(bundle, bytes.TrimRight(roots, "\n")...)
+	bundle = append(bundle, '\n')
+	return append(bundle, cert...)
+}
 
 type secretGetter interface {
 	Get(ctx context.Context, namespace string, name string) (*corev1.Secret, error)

--- a/internal/assembler/egress_ca_apply.go
+++ b/internal/assembler/egress_ca_apply.go
@@ -19,11 +19,15 @@ func egressCAEnvVars() []*runnerv1.EnvVar {
 	}
 }
 
+// egressCAInlineFiles writes the bundle, not the bare certificate: the env vars
+// above name it as the trust store, and a store containing only the egress CA
+// vouches for nothing the egress gateway does not terminate.
 func egressCAInlineFiles(cert []byte) map[string][]byte {
-	if len(cert) == 0 {
+	bundle := EgressCABundle(cert)
+	if len(bundle) == 0 {
 		return nil
 	}
-	return map[string][]byte{egressCACertPath: append([]byte(nil), cert...)}
+	return map[string][]byte{egressCACertPath: bundle}
 }
 
 func egressCAInlineFileMounts(cert []byte) []*runnerv1.InlineFileMount {

--- a/internal/assembler/egress_ca_bundle_test.go
+++ b/internal/assembler/egress_ca_bundle_test.go
@@ -1,0 +1,81 @@
+package assembler
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The egress CA is not a trust store. Installed as one it broke every
+// connection egress does not intercept: ziti enrolment could not verify the
+// controller, and codex refused to start because its MCP sidecar could not
+// either. The bundle has to keep the public roots and add the CA to them.
+func TestEgressCABundleKeepsTheSystemRoots(t *testing.T) {
+	roots := "-----BEGIN CERTIFICATE-----\nroot-one\n-----END CERTIFICATE-----\n"
+	cert := []byte("-----BEGIN CERTIFICATE-----\negress\n-----END CERTIFICATE-----\n")
+	withSystemRoots(t, roots)
+
+	bundle := string(EgressCABundle(cert))
+	if !strings.Contains(bundle, "root-one") {
+		t.Fatalf("expected the system roots to survive:\n%s", bundle)
+	}
+	if !strings.Contains(bundle, "egress") {
+		t.Fatalf("expected the egress CA to be present:\n%s", bundle)
+	}
+	if strings.Count(bundle, "BEGIN CERTIFICATE") != 2 {
+		t.Fatalf("expected both certificates, got:\n%s", bundle)
+	}
+}
+
+// Callers use an empty result to mean "mount nothing", so an absent CA must not
+// produce a bundle of bare system roots.
+func TestEgressCABundleIsEmptyWithoutACertificate(t *testing.T) {
+	withSystemRoots(t, "-----BEGIN CERTIFICATE-----\nroot\n-----END CERTIFICATE-----\n")
+	if bundle := EgressCABundle(nil); bundle != nil {
+		t.Fatalf("expected no bundle, got %q", bundle)
+	}
+}
+
+// Losing the roots is worse than losing egress, but it must not lose the CA.
+func TestEgressCABundleFallsBackToTheCertificateAlone(t *testing.T) {
+	withSystemRootsPath(t, filepath.Join(t.TempDir(), "absent.crt"))
+	cert := []byte("-----BEGIN CERTIFICATE-----\negress\n-----END CERTIFICATE-----\n")
+
+	if bundle := EgressCABundle(cert); !bytes.Equal(bundle, cert) {
+		t.Fatalf("expected the certificate alone, got %q", bundle)
+	}
+}
+
+// The inline file is what actually reaches the container, so it carries the
+// bundle rather than the bare certificate.
+func TestEgressCAInlineFilesCarryTheBundle(t *testing.T) {
+	withSystemRoots(t, "-----BEGIN CERTIFICATE-----\nroot-one\n-----END CERTIFICATE-----\n")
+	cert := []byte("-----BEGIN CERTIFICATE-----\negress\n-----END CERTIFICATE-----\n")
+
+	files := egressCAInlineFiles(cert)
+	content, ok := files[egressCACertPath]
+	if !ok {
+		t.Fatalf("expected an inline file at %s, got %v", egressCACertPath, files)
+	}
+	if !strings.Contains(string(content), "root-one") {
+		t.Fatalf("expected the system roots in the inline file:\n%s", content)
+	}
+}
+
+func withSystemRoots(t *testing.T, content string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ca-certificates.crt")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write system roots: %v", err)
+	}
+	withSystemRootsPath(t, path)
+}
+
+func withSystemRootsPath(t *testing.T, path string) {
+	t.Helper()
+	original := systemRootsPath
+	systemRootsPath = path
+	t.Cleanup(func() { systemRootsPath = original })
+}

--- a/internal/assembler/sandbox_test.go
+++ b/internal/assembler/sandbox_test.go
@@ -341,7 +341,9 @@ func TestAssembleSandboxDistributesEgressCA(t *testing.T) {
 	result := fixture.assemble(t)
 
 	inlineFiles := result.Request.GetInlineFiles()
-	if string(inlineFiles[egressCACertPath]) != "egress-ca-cert" {
+	// Contains, not equals: the inline file is the public roots with the egress
+	// CA appended; see EgressCABundle.
+	if !strings.Contains(string(inlineFiles[egressCACertPath]), "egress-ca-cert") {
 		t.Fatalf("expected the egress CA inline file, got %v", inlineFiles)
 	}
 	main := result.Request.GetMain()


### PR DESCRIPTION
The egress CA was installed as the entire trust store: `SSL_CERT_FILE`, `SSL_CERT_DIR`, `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` all pointed at a file holding one private certificate.

A store with one CA in it vouches for nothing else, so every connection the egress gateway does not terminate lost its trust:

```
ziti-enroll: failed to enroll: expected 1 or more CAs from controller, got 0
codex:       files_mcp: Failed to read CA certificate file ... selected by SSL_CERT_FILE
```

Workloads now get the public roots the orchestrator image trusts with the egress CA appended. Intercepted traffic verifies against the CA; everything else verifies as it did before.