### PR TITLE
Read the idle timeout of agents that have a workload running

### DIFF
--- a/internal/reconciler/desired.go
+++ b/internal/reconciler/desired.go
@@ -3,9 +3,11 @@ package reconciler
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	"github.com/agynio/agents-orchestrator/internal/uuidutil"
 	"github.com/google/uuid"
 )
@@ -205,4 +207,39 @@ func (r *Reconciler) fetchAgent(ctx context.Context, agentID uuid.UUID) (*agents
 		return nil, err
 	}
 	return agent, nil
+}
+
+// addIdleTimeoutsForWorkloads fills in the idle timeout of every agent that has
+// a workload running, so the stop decision knows what the agent asked for even
+// after it has dropped out of the desired set. Timeouts already resolved are
+// left alone, and an agent that cannot be read is skipped rather than failing
+// the cycle: the fallback still applies, which is what it did before.
+func (r *Reconciler) addIdleTimeoutsForWorkloads(ctx context.Context, workloads []*runnersv1.Workload, idleTimeouts map[uuid.UUID]time.Duration) error {
+	if idleTimeouts == nil {
+		return fmt.Errorf("idle timeouts map is nil")
+	}
+	for _, workload := range workloads {
+		if workload == nil {
+			continue
+		}
+		agentID, err := uuidutil.ParseUUID(workloadAgentClassID(workload), "workload.agent_class_id")
+		if err != nil {
+			return err
+		}
+		if _, ok := idleTimeouts[agentID]; ok {
+			continue
+		}
+		agent, err := r.fetchAgent(ctx, agentID)
+		if err != nil {
+			log.Printf("reconciler: read idle timeout for agent %s: %v; using the default", agentID, err)
+			continue
+		}
+		idleTimeout, err := agentIdleTimeout(agent, agentID, r.idle)
+		if err != nil {
+			log.Printf("reconciler: %v; using the default", err)
+			continue
+		}
+		idleTimeouts[agentID] = idleTimeout
+	}
+	return nil
 }

--- a/internal/reconciler/idle_timeout_for_workloads_test.go
+++ b/internal/reconciler/idle_timeout_for_workloads_test.go
@@ -1,0 +1,95 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agents-orchestrator/internal/testutil"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+// An idle timeout only decides anything once the agent has gone idle, and by
+// then it has no unacked inbox and has dropped out of the desired set. Reading
+// the timeouts from the desired set alone meant a workload was stopped on the
+// platform fallback the moment it finished answering: an agent asking for 10m
+// was torn down 30s after its reply.
+func TestIdleTimeoutsResolvedForRunningWorkloads(t *testing.T) {
+	agentID := uuid.New()
+	agents := &testutil.FakeAgentsClient{
+		GetAgentFunc: func(_ context.Context, req *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			if req.GetId() != agentID.String() {
+				return nil, errors.New("unexpected agent id")
+			}
+			idle := "10m"
+			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{
+				Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
+				OrganizationId: uuid.NewString(),
+				IdleTimeout:    &idle,
+			}}, nil
+		},
+	}
+	reconciler := newTestReconciler(Config{Agents: agents, Idle: 30 * time.Second})
+
+	idleTimeouts := map[uuid.UUID]time.Duration{}
+	workloads := []*runnersv1.Workload{workloadForAgent(agentID)}
+	if err := reconciler.addIdleTimeoutsForWorkloads(context.Background(), workloads, idleTimeouts); err != nil {
+		t.Fatalf("add idle timeouts: %v", err)
+	}
+
+	if got := idleTimeouts[agentID]; got != 10*time.Minute {
+		t.Fatalf("expected 10m for the running workload's agent, got %v", got)
+	}
+}
+
+// A timeout already resolved from the desired set is authoritative; re-reading
+// it would be a needless call per workload per cycle.
+func TestIdleTimeoutsKeepAlreadyResolvedEntries(t *testing.T) {
+	agentID := uuid.New()
+	agents := &testutil.FakeAgentsClient{
+		GetAgentFunc: func(context.Context, *agentsv1.GetAgentRequest, ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			t.Fatal("expected no lookup for an agent already resolved")
+			return nil, nil
+		},
+	}
+	reconciler := newTestReconciler(Config{Agents: agents})
+
+	idleTimeouts := map[uuid.UUID]time.Duration{agentID: 5 * time.Minute}
+	workloads := []*runnersv1.Workload{workloadForAgent(agentID)}
+	if err := reconciler.addIdleTimeoutsForWorkloads(context.Background(), workloads, idleTimeouts); err != nil {
+		t.Fatalf("add idle timeouts: %v", err)
+	}
+	if got := idleTimeouts[agentID]; got != 5*time.Minute {
+		t.Fatalf("expected the resolved 5m to stand, got %v", got)
+	}
+}
+
+// An agent that cannot be read must not fail the cycle: the fallback applies,
+// which is what happened before.
+func TestIdleTimeoutsSkipUnreadableAgents(t *testing.T) {
+	agentID := uuid.New()
+	agents := &testutil.FakeAgentsClient{
+		GetAgentFunc: func(context.Context, *agentsv1.GetAgentRequest, ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			return nil, errors.New("agents is down")
+		},
+	}
+	reconciler := newTestReconciler(Config{Agents: agents})
+
+	idleTimeouts := map[uuid.UUID]time.Duration{}
+	workloads := []*runnersv1.Workload{workloadForAgent(agentID)}
+	if err := reconciler.addIdleTimeoutsForWorkloads(context.Background(), workloads, idleTimeouts); err != nil {
+		t.Fatalf("expected an unreadable agent to be skipped, got %v", err)
+	}
+	if _, ok := idleTimeouts[agentID]; ok {
+		t.Fatal("expected no entry for an agent that could not be read")
+	}
+}
+
+func workloadForAgent(agentID uuid.UUID) *runnersv1.Workload {
+	id := agentID.String()
+	return &runnersv1.Workload{AgentClassId: &id}
+}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -129,6 +129,14 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// The agents behind running workloads, not just the ones with work waiting.
+	// An idle timeout only decides anything once an agent has gone idle, and by
+	// then it has dropped out of the desired set -- so reading the timeout from
+	// the desired set alone meant a workload was stopped on the platform
+	// fallback the moment it finished answering, whatever the agent asked for.
+	if err := r.addIdleTimeoutsForWorkloads(ctx, actual, idleTimeouts); err != nil {
+		return err
+	}
 	actions, err := ComputeActions(desired, actual, idleTimeouts, r.idle, time.Now().UTC())
 	if err != nil {
 		return err


### PR DESCRIPTION
`idleTimeouts` is built only from agents in the **desired** set, and an agent is desired while it has unacked inbox items. An idle timeout only decides anything once the agent has gone *idle* — by which point it has dropped out of the desired set — so the stop decision fell back to `IDLE_TIMEOUT` (30s on the platform VM) exactly when the agent's own setting was supposed to apply.

Observed: an agent configured `idle_timeout = 10m` was stopped 49s after start, seconds after posting its answer.

Timeouts are now also resolved for the agents behind running workloads. Already-known entries are left alone (no extra call per workload per cycle), and an agent that cannot be read is skipped rather than failing the cycle — the fallback still applies, as before.