### PR TITLE
Let each room subscription fail on its own

### DIFF
--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -110,30 +110,40 @@ func (s *Subscriber) Run(ctx context.Context) error {
 
 var errRoomsChanged = errors.New("rooms changed")
 
+// runSubscriptions holds every room until the room set changes or the context
+// ends. Each subscription reconnects on its own: one instance the platform can
+// no longer resolve used to end the whole set, and every wake delivered while
+// the rest were being rebuilt was lost.
 func (s *Subscriber) runSubscriptions(ctx context.Context, subscriptions []roomSubscription, roomsUpdated <-chan struct{}) error {
-	errCh := make(chan error, len(subscriptions))
 	for _, subscription := range subscriptions {
 		subscription := subscription
-		go func() {
-			errCh <- s.runSubscription(ctx, subscription)
-		}()
+		go s.keepSubscribed(ctx, subscription)
 	}
 
-	remaining := len(subscriptions)
-	for remaining > 0 {
-		select {
-		case <-roomsUpdated:
-			return errRoomsChanged
-		case <-ctx.Done():
-			return ctx.Err()
-		case err := <-errCh:
-			remaining--
-			if err != nil {
-				return err
-			}
-		}
+	select {
+	case <-roomsUpdated:
+		return errRoomsChanged
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-	return nil
+}
+
+// keepSubscribed reconnects a single subscription until its context ends.
+func (s *Subscriber) keepSubscribed(ctx context.Context, subscription roomSubscription) {
+	backoff := time.Second
+	for {
+		err := s.runSubscription(ctx, subscription)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			log.Printf("subscriber: %v", err)
+		}
+		if waitWithBackoff(ctx, backoff) != nil {
+			return
+		}
+		backoff = nextBackoff(backoff)
+	}
 }
 
 func (s *Subscriber) runSubscription(ctx context.Context, subscription roomSubscription) error {

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -13,7 +13,9 @@ import (
 	notificationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/notifications/v1"
 	"github.com/agynio/agents-orchestrator/internal/testutil"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 func TestSubscriberWakeOnMessageCreated(t *testing.T) {
@@ -156,6 +158,81 @@ func TestSubscriberResubscribesOnInstanceChange(t *testing.T) {
 
 	harness.cancel()
 	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected run error: %v", err)
+	}
+}
+
+// One instance the platform can no longer resolve used to end every other
+// instance's stream too, and a wake delivered during the rebuild was lost.
+func TestSubscriberKeepsHealthySubscriptionsWhenOneFails(t *testing.T) {
+	failing := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	healthy := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+	responses := make(chan *notificationsv1.SubscribeResponse)
+	var mu sync.Mutex
+	calls := map[string]int{}
+
+	agentsClient := &testutil.FakeAgentsClient{ListInstancesFunc: func(context.Context, *agentsv1.ListInstancesRequest, ...grpc.CallOption) (*agentsv1.ListInstancesResponse, error) {
+		return &agentsv1.ListInstancesResponse{Instances: []*agentsv1.AgentInstance{
+			instanceFixture(failing), instanceFixture(healthy),
+		}}, nil
+	}}
+	client := &fakeNotificationsClient{subscribe: func(ctx context.Context, req *notificationsv1.SubscribeRequest, opts ...grpc.CallOption) (notificationsv1.NotificationsService_SubscribeClient, error) {
+		identity := ""
+		if md, ok := metadata.FromOutgoingContext(ctx); ok {
+			if values := md.Get(identityMetadataKey); len(values) > 0 {
+				identity = values[0]
+			}
+		}
+		mu.Lock()
+		calls[identity]++
+		mu.Unlock()
+		if identity == failing {
+			return nil, status.Error(codes.PermissionDenied, "permission denied")
+		}
+		return &fakeSubscribeStream{fakeClientStream: fakeClientStream{ctx: ctx}, responses: responses}, nil
+	}}
+
+	subscriber := NewWithSandboxOrganizations(client, agentsClient, nil)
+	subscriber.roomRefreshInterval = time.Hour
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- subscriber.Run(ctx) }()
+
+	// Long enough for the failing subscription to retry past its first backoff.
+	deadline := time.After(10 * time.Second)
+	for {
+		mu.Lock()
+		failed, ok := calls[failing], calls[healthy]
+		mu.Unlock()
+		if failed >= 3 {
+			if ok != 1 {
+				t.Fatalf("healthy subscription was rebuilt %d times while the other failed %d times", ok, failed)
+			}
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("failing subscription only retried %d times", failed)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	// The surviving stream still delivers.
+	select {
+	case responses <- messageEnvelope("message.created"):
+	case <-time.After(time.Second):
+		t.Fatal("healthy subscription was not receiving")
+	}
+	select {
+	case <-subscriber.Wake():
+	case <-time.After(time.Second):
+		t.Fatal("expected wake signal")
+	}
+
+	cancel()
+	if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("unexpected run error: %v", err)
 	}
 }


### PR DESCRIPTION
One instance the platform could no longer resolve ended every other
instance's stream: runSubscriptions returned on the first error, which
cancelled its siblings mid-check. The set was rebuilt every 30s and any
wake delivered in the gap was lost, so an agent was never started and the
message sat unacked.

Each subscription now reconnects independently; the set is still rebuilt
when the rooms themselves change.
