### PR TITLE
Reconcile sandbox workloads

### DIFF
--- a/internal/reconciler/actual.go
+++ b/internal/reconciler/actual.go
@@ -56,6 +56,8 @@ func (r *Reconciler) listActiveWorkloads(ctx context.Context, orgIdentities map[
 			return nil, fmt.Errorf("list workloads: %w", err)
 		}
 		for _, workload := range resp.GetWorkloads() {
+			// Agent workloads only. The callers that diff this against desired
+			// agent instances would read a sandbox as an orphan and stop it.
 			if workload.GetOwnerKind() == runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
 				continue
 			}

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -22,6 +22,68 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// Sandbox workloads were skipped outright, so a sandbox whose pod was gone sat
+// in running forever: the Console kept listing it as active compute and the
+// flavor-seconds sampler kept billing it.
+func TestReconcileWorkloadsFailsMissingSandbox(t *testing.T) {
+	ctx := context.Background()
+	runnerID := "runner-1"
+	workloadKey := "workload-sandbox-1"
+	sandboxID := uuid.New().String()
+
+	var updateReq *runnersv1.UpdateWorkloadRequest
+	runners := &fakeRunnersClient{
+		listWorkloads: func(_ context.Context, _ *runnersv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
+			return &runnersv1.ListWorkloadsResponse{Workloads: []*runnersv1.Workload{
+				{
+					Meta:           &runnersv1.EntityMeta{Id: workloadKey},
+					RunnerId:       runnerID,
+					OrganizationId: testOrganizationID,
+					OwnerKind:      runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX,
+					OwnerId:        sandboxID,
+					Status:         runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+				},
+			}}, nil
+		},
+		listRunners: func(_ context.Context, _ *runnersv1.ListRunnersRequest, _ ...grpc.CallOption) (*runnersv1.ListRunnersResponse, error) {
+			return &runnersv1.ListRunnersResponse{Runners: []*runnersv1.Runner{buildRunner(runnerID)}}, nil
+		},
+		updateWorkload: func(_ context.Context, req *runnersv1.UpdateWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.UpdateWorkloadResponse, error) {
+			updateReq = req
+			return &runnersv1.UpdateWorkloadResponse{}, nil
+		},
+	}
+
+	// The runner no longer reports it.
+	runner := &fakeRunnerClient{
+		listWorkloads: func(_ context.Context, _ *runnerv1.ListWorkloadsRequest, _ ...grpc.CallOption) (*runnerv1.ListWorkloadsResponse, error) {
+			return &runnerv1.ListWorkloadsResponse{}, nil
+		},
+	}
+	runnerDialer := &fakeRunnerDialer{
+		dial: func(_ context.Context, _ string) (runnerv1.RunnerServiceClient, error) { return runner, nil },
+	}
+
+	reconciler := newTestReconciler(Config{
+		RunnerDialer: runnerDialer,
+		Runners:      runners,
+		Agents:       &testutil.FakeAgentsClient{},
+		Assembler:    newTestAssembler(uuid.New(), false),
+	})
+	if err := reconciler.reconcileWorkloads(ctx); err != nil {
+		t.Fatalf("reconcile workloads: %v", err)
+	}
+	if updateReq == nil {
+		t.Fatal("expected the sandbox workload to be updated")
+	}
+	if updateReq.GetStatus() != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
+		t.Fatalf("expected failed, got %s", updateReq.GetStatus())
+	}
+	if updateReq.GetFailureReason() != runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST {
+		t.Fatalf("expected runtime_lost, got %s", updateReq.GetFailureReason())
+	}
+}
+
 func TestReconcileWorkloadsTransitionsStartingToRunning(t *testing.T) {
 	ctx := context.Background()
 	runnerID := "runner-1"

--- a/internal/reconciler/runtime_record_identity.go
+++ b/internal/reconciler/runtime_record_identity.go
@@ -1,5 +1,11 @@
 package reconciler
 
+import (
+	"strings"
+
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+)
+
 func workloadAgentInstanceID(workload interface{ GetAgentInstanceId() string }) string {
 	return workload.GetAgentInstanceId()
 }
@@ -10,4 +16,14 @@ func workloadAgentClassID(workload interface{ GetAgentClassId() string }) string
 
 func volumeAgentInstanceID(volume interface{ GetAgentInstanceId() string }) string {
 	return volume.GetAgentInstanceId()
+}
+
+// workloadRunnerIdentityID is the identity the Orchestrator presents to a
+// runner when acting on a workload. An agent workload is reached as its
+// instance; a sandbox has no instance and is reached as its owner.
+func workloadRunnerIdentityID(workload *runnersv1.Workload) string {
+	if workload.GetOwnerKind() == runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
+		return strings.TrimSpace(workload.GetOwnerId())
+	}
+	return strings.TrimSpace(workload.GetAgentInstanceId())
 }

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -27,9 +27,9 @@ func runnerIdentityForWorkloads(runnerID string, runnerOrganizationID string, or
 	}
 	var identityID string
 	for workloadID, workload := range workloads {
-		workloadIdentityID := strings.TrimSpace(workloadAgentInstanceID(workload))
+		workloadIdentityID := workloadRunnerIdentityID(workload)
 		if workloadIdentityID == "" {
-			return "", fmt.Errorf("workload %s missing agent instance id", workloadID)
+			return "", fmt.Errorf("workload %s missing owner identity", workloadID)
 		}
 		if identityID == "" {
 			identityID = workloadIdentityID
@@ -51,21 +51,27 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Sandboxes are reconciled here too -- nothing else moves a workload out of
+	// running, so a sandbox whose pod was gone stayed active forever. They are
+	// listed separately because the agent listing feeds callers that would read
+	// a sandbox as an orphan.
+	sandboxes, err := r.listActiveSandboxWorkloads(ctx)
+	if err != nil {
+		return err
+	}
+	tracked = append(tracked, sandboxes...)
 	runnerIDs := map[string]struct{}{}
 	workloadsByRunner := make(map[string]map[string]*runnersv1.Workload)
 	runnerIdentities := map[string]string{}
 	for _, workload := range tracked {
-		if workload.GetOwnerKind() == runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX {
-			continue
-		}
 		runnerID := workload.GetRunnerId()
 		if runnerID == "" {
 			log.Printf("reconciler: warn: workload %s missing runner id", workload.GetMeta().GetId())
 			continue
 		}
-		identityID := strings.TrimSpace(workloadAgentInstanceID(workload))
+		identityID := workloadRunnerIdentityID(workload)
 		if identityID == "" {
-			return fmt.Errorf("workload %s missing agent instance id", workload.GetMeta().GetId())
+			return fmt.Errorf("workload %s missing owner identity", workload.GetMeta().GetId())
 		}
 		workloadID := workload.GetMeta().GetId()
 		if workloadID == "" {
@@ -121,14 +127,16 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 		}
 		if _, ok := enrolledRunnerIDs[runnerID]; !ok {
 			for workloadID, workload := range trackedWorkloads {
-				workloadCtx, err := runnerIdentityContext(ctx, workloadAgentInstanceID(workload))
+				workloadCtx, err := runnerIdentityContext(ctx, workloadRunnerIdentityID(workload))
 				if err != nil {
 					return err
 				}
 				if err := r.handleMissingRunnerWorkload(workloadCtx, workload); err != nil {
 					log.Printf("reconciler: warn: handle missing workload %s on unenrolled runner: %v", workloadID, err)
 				}
-				r.pauseInstance(workloadCtx, workloadAgentInstanceID(workload), pauseReasonRunnerDeprovisioned)
+				if instanceID := strings.TrimSpace(workloadAgentInstanceID(workload)); instanceID != "" {
+					r.pauseInstance(workloadCtx, instanceID, pauseReasonRunnerDeprovisioned)
+				}
 			}
 			continue
 		}
@@ -140,7 +148,7 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 		if err != nil {
 			if runnerdial.IsNoTerminators(err) {
 				for workloadID, workload := range trackedWorkloads {
-					workloadCtx, err := runnerIdentityContext(ctx, workloadAgentInstanceID(workload))
+					workloadCtx, err := runnerIdentityContext(ctx, workloadRunnerIdentityID(workload))
 					if err != nil {
 						return err
 					}
@@ -157,7 +165,7 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 		if err != nil {
 			if runnerdial.IsNoTerminators(err) {
 				for workloadID, workload := range trackedWorkloads {
-					workloadCtx, err := runnerIdentityContext(ctx, workloadAgentInstanceID(workload))
+					workloadCtx, err := runnerIdentityContext(ctx, workloadRunnerIdentityID(workload))
 					if err != nil {
 						return err
 					}
@@ -188,7 +196,7 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 		}
 
 		for workloadID, workload := range trackedWorkloads {
-			workloadCtx, err := runnerIdentityContext(ctx, workloadAgentInstanceID(workload))
+			workloadCtx, err := runnerIdentityContext(ctx, workloadRunnerIdentityID(workload))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Workload reconciliation skipped every sandbox, so nothing moved one out of `running`. A sandbox whose pod was gone stayed active indefinitely — the Console listed it as running compute hours later, and the flavor-seconds sampler kept billing it.

`architecture/agents-orchestrator.md#workload-reconciliation` lists by runner, not by agent, and calls for running-and-absent to become `failed(runtime_lost)`. Sandboxes are listed separately from the agent set, whose callers diff against desired agent instances and would read a sandbox as an orphan to stop.