### PR TITLE
Pin agyn-cli-init to 0.3.0

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -130,7 +130,7 @@ env:
   - name: AGYND_CLI_INIT_IMAGE
     value: "ghcr.io/agynio/agynd-cli-init:0.14.37"
   - name: AGYN_CLI_INIT_IMAGE
-    value: "ghcr.io/agynio/agyn-cli-init:0.2.22"
+    value: "ghcr.io/agynio/agyn-cli-init:0.3.0"
   - name: SANDBOX_INIT_IMAGE
     value: "ghcr.io/agynio/agent-init-codex:latest"
   - name: SANDBOX_WORKSPACE_SIZE_GB


### PR DESCRIPTION
`0.2.22` predates `agyn sandbox sync serve`. A sandbox running it answers the sync exec with `unknown flag: --root`, and the session halts on a version gap — workspace sync cannot work until workloads carry the CLI that provides the endpoint.

`agyn-cli` `v0.3.0` published `ghcr.io/agynio/agyn-cli-init:0.3.0` (`sha-5bb00fa`).

`agynd-cli-init` is unchanged. Chart version left alone, matching how these pins were introduced in `ee7b1f9`.

Paired with agynio/bundle-vm, whose overlay repeats the same env block.