### PR TITLE
Pin the Ziti tunnel to 2.0.0-pre8

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1174,7 +1174,7 @@ jobs:
                 - cluster.local
             containers:
               - name: ziti-sidecar-dns-preflight
-                image: openziti/ziti-tunnel:1.6.15
+                image: openziti/ziti-tunnel:2.0.0-pre8
                 env:
                   - name: WORKLOAD_DNS_UPSTREAM
                     value: "${ziti_dns_ip}"

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -87,7 +87,7 @@ env:
   - name: ZITI_ENROLLMENT_TIMEOUT
     value: "2m"
   - name: ZITI_SIDECAR_IMAGE
-    value: "openziti/ziti-tunnel:1.6.15"
+    value: "openziti/ziti-tunnel:2.0.0-pre8"
   - name: ZITI_MANAGEMENT_ADDRESS
     value: "ziti-management:50051"
   - name: GROUP_SYNC_ENABLED

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -68,7 +68,7 @@ functions:
                 - name: EGRESS_CA_NAMESPACE
                   value: "__EGRESS_CA_NAMESPACE__"
                 - name: ZITI_SIDECAR_IMAGE
-                  value: "openziti/ziti-tunnel:1.6.15"
+                  value: "openziti/ziti-tunnel:2.0.0-pre8"
                 - name: ZITI_ENROLLMENT_CONTROLLER_RESOLVE_HOST
                   value: "__ZITI_ENROLLMENT_CONTROLLER_RESOLVE_HOST__"
                 - name: ZITI_ENROLLMENT_CONTROLLER_PORT

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,7 +207,7 @@ func FromEnv() (Config, error) {
 	}
 	cfg.ZitiSidecarImage = os.Getenv("ZITI_SIDECAR_IMAGE")
 	if cfg.ZitiSidecarImage == "" {
-		cfg.ZitiSidecarImage = "openziti/ziti-tunnel:1.6.15"
+		cfg.ZitiSidecarImage = "openziti/ziti-tunnel:2.0.0-pre8"
 	}
 	clusterDNS := os.Getenv("CLUSTER_DNS")
 	cfg.WorkloadDNSUpstream = os.Getenv("WORKLOAD_DNS_UPSTREAM")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const defaultZitiSidecarImage = "openziti/ziti-tunnel:1.6.15"
+const defaultZitiSidecarImage = "openziti/ziti-tunnel:2.0.0-pre8"
 
 func TestFromEnvDefaultsNonZiti(t *testing.T) {
 	setBaseEnv(t)
@@ -104,7 +104,7 @@ func TestZitiWorkflowKeepsSourceOfTruthRefsAndDnsValidation(t *testing.T) {
 		"dnsPolicy: None",
 		"timeout 10 nc -vz -w 5 ziti-router.agyn.dev 2496",
 		"name: Verify stock sidecar runtime DNS path",
-		"image: openziti/ziti-tunnel:1.6.15",
+		"image: openziti/ziti-tunnel:2.0.0-pre8",
 		"bash -c '</dev/tcp/ziti.agyn.dev/2496'",
 		"name: Verify gateway Ziti service binding",
 		"gateway listening on ziti service gateway",


### PR DESCRIPTION
`0e45c83` ("Fix workload Ziti sidecar initialization", #220) **downgraded** the sidecar under the changelog line *"fix(config): pin released ziti tunnel"*:

```diff
-  cfg.ZitiSidecarImage = "openziti/ziti-tunnel:2.0.0-pre8"
+  cfg.ZitiSidecarImage = "openziti/ziti-tunnel:1.6.15"
```

in code, chart, devspace, and e2e at once.

The platform moved to 2.x months ago. The bundle image installs a `3.2.0-pre6` controller and a `3.0.0-pre5` router, and `bundle-vm`'s overlay has been overriding this default back to `2.0.0-pre8` ever since — with a comment noting the code default is "two majors behind".

So the working configuration was an overlay correcting a default nobody revisited. Any deploy that replaces the orchestrator's env block reverts it — a `devspace run-pipeline deploy` does exactly that, which is how a cluster ends up on `1.6.15`.

**The symptom that surfaced it:** `1.6.15` mishandles the parallel A/AAAA query `getaddrinfo` issues for `AF_UNSPEC`. Inside a workload:

| | |
|---|---|
| `getent ahostsv4 google.com` | ✓ |
| `getent ahostsv6 google.com` | ✓ |
| `getent ahosts google.com` (both) | **empty** |
| `curl -4 https://google.com` | `301` |
| `curl https://google.com` | `Could not resolve host` |

That is also what the MCP containers' `no-aaaa` `RES_OPTIONS` was for — added in the same commit that did the downgrade. Left in place here (harmless on 2.x) rather than removed in the same change.

Everything now pins `2.0.0-pre8`, so the overlay and the default agree and a dev deploy no longer silently reverts a cluster.