### PR TITLE
Resolve a catalog image reference without gating on the proxy

### DIFF
--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -20,33 +20,33 @@ import (
 )
 
 const (
-	listPageSize                              int32 = 100
-	rpcTimeout                                      = 10 * time.Second
-	agynBinVolumeName                               = "agyn-bin"
+	listPageSize      int32 = 100
+	rpcTimeout              = 10 * time.Second
+	agynBinVolumeName       = "agyn-bin"
 	// The volume is the whole /agyn tree: binaries under bin/, and the agent
 	// runtime's config.json beside it rather than among them.
-	agynBinMountPath                                = "/agyn"
-	agynBinBinaryPath                               = "/agyn/bin/agynd"
-	mcpBasePort                                     = 8100
-	mcpResolverOptions                              = "attempts:1 timeout:1 no-aaaa"
-	mcpNodeOptions                                  = "--dns-result-order=ipv4first"
-	ZitiEnrollContainerName                         = "ziti-enroll"
-	ZitiSidecarContainerName                        = "ziti-sidecar"
-	zitiIdentityVolumeName                          = "ziti-identity"
-	zitiIdentityMountPath                           = "/netfoundry"
-	ZitiIdentityBasename                            = "agent"
-	ZitiEnrollmentTokenEnvVar                       = "ZITI_ENROLL_TOKEN"
-	ZitiIdentityBasenameEnvVar                      = "ZITI_IDENTITY_BASENAME"
-	ZitiIdentityDirEnvVar                           = "ZITI_IDENTITY_DIR"
-	ZitiEnrollmentControllerResolveHostEnvVar       = "ZITI_ENROLLMENT_CONTROLLER_RESOLVE_HOST"
-	ZitiEnrollmentControllerPortEnvVar              = "ZITI_ENROLLMENT_CONTROLLER_PORT"
-	egressCACertPath                                = "/etc/agyn/egress-ca/ca.crt"
-	egressCACertDir                                 = "/etc/agyn/egress-ca"
-	zitiDNSNameserver                               = "127.0.0.1"
-	zitiEnrollEntrypoint                            = "/usr/bin/bash"
-	zitiSidecarEntrypoint                           = "/usr/bin/bash"
-	zitiSidecarServicePollRate                      = "1"
-	zitiEnrollScript                                = `workload_dns_upstream="$1"
+	agynBinMountPath                          = "/agyn"
+	agynBinBinaryPath                         = "/agyn/bin/agynd"
+	mcpBasePort                               = 8100
+	mcpResolverOptions                        = "attempts:1 timeout:1 no-aaaa"
+	mcpNodeOptions                            = "--dns-result-order=ipv4first"
+	ZitiEnrollContainerName                   = "ziti-enroll"
+	ZitiSidecarContainerName                  = "ziti-sidecar"
+	zitiIdentityVolumeName                    = "ziti-identity"
+	zitiIdentityMountPath                     = "/netfoundry"
+	ZitiIdentityBasename                      = "agent"
+	ZitiEnrollmentTokenEnvVar                 = "ZITI_ENROLL_TOKEN"
+	ZitiIdentityBasenameEnvVar                = "ZITI_IDENTITY_BASENAME"
+	ZitiIdentityDirEnvVar                     = "ZITI_IDENTITY_DIR"
+	ZitiEnrollmentControllerResolveHostEnvVar = "ZITI_ENROLLMENT_CONTROLLER_RESOLVE_HOST"
+	ZitiEnrollmentControllerPortEnvVar        = "ZITI_ENROLLMENT_CONTROLLER_PORT"
+	egressCACertPath                          = "/etc/agyn/egress-ca/ca.crt"
+	egressCACertDir                           = "/etc/agyn/egress-ca"
+	zitiDNSNameserver                         = "127.0.0.1"
+	zitiEnrollEntrypoint                      = "/usr/bin/bash"
+	zitiSidecarEntrypoint                     = "/usr/bin/bash"
+	zitiSidecarServicePollRate                = "1"
+	zitiEnrollScript                          = `workload_dns_upstream="$1"
 workload_dns_nameserver="$2"
 enrollment_controller_resolve_host="$3"
 enrollment_controller_port_override="$4"
@@ -461,13 +461,22 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, agentInstanceID, thre
 	if environment != nil {
 		environmentID := environment.GetMeta().GetId()
 		mainImage = environment.GetImage()
-		if rewriter.enabled() && environment.GetWorkspaceImageId() != "" {
+		// See sandbox assembly: a catalog reference resolves only through the
+		// Image Proxy, so an unconfigured proxy is a broken deployment rather
+		// than a mode in which the reference is ignored.
+		if environment.GetWorkspaceImageId() != "" {
+			if !rewriter.enabled() {
+				return nil, fmt.Errorf("environment %s names a workspace image but the image proxy is not configured", environmentID)
+			}
 			mainImage, err = rewriter.Rewrite(ctx, environment.GetWorkspaceImageId(), environment.GetWorkspaceImageTag())
 			if err != nil {
 				return nil, fmt.Errorf("environment %s workspace image: %w", environmentID, err)
 			}
 		}
-		if rewriter.enabled() && environment.GetAgentRuntimeImageId() != "" {
+		if environment.GetAgentRuntimeImageId() != "" {
+			if !rewriter.enabled() {
+				return nil, fmt.Errorf("environment %s names an agent runtime image but the image proxy is not configured", environmentID)
+			}
 			agentRuntimeImage, err = rewriter.Rewrite(ctx, environment.GetAgentRuntimeImageId(), environment.GetAgentRuntimeImageTag())
 			if err != nil {
 				return nil, fmt.Errorf("environment %s agent runtime image: %w", environmentID, err)

--- a/internal/assembler/sandbox.go
+++ b/internal/assembler/sandbox.go
@@ -84,13 +84,23 @@ func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandb
 	rewriter := newImageRewriter(a.images, a.organizations, a.cfg.ImageProxyHost)
 	mainImage := environment.GetImage()
 	agentRuntimeImage := ""
-	if rewriter.enabled() && environment.GetWorkspaceImageId() != "" {
+	// A catalog reference resolves only through the Image Proxy, which is the
+	// only path a workload's images are pulled by. Skipping the lookup when it
+	// is unconfigured silently dropped the environment's agent runtime, and the
+	// sandbox came up with no agent CLI and nothing said so.
+	if environment.GetWorkspaceImageId() != "" {
+		if !rewriter.enabled() {
+			return nil, fmt.Errorf("environment %s names a workspace image but the image proxy is not configured", environmentID)
+		}
 		mainImage, err = rewriter.Rewrite(ctx, environment.GetWorkspaceImageId(), environment.GetWorkspaceImageTag())
 		if err != nil {
 			return nil, fmt.Errorf("environment %s workspace image: %w", environmentID, err)
 		}
 	}
-	if rewriter.enabled() && environment.GetAgentRuntimeImageId() != "" {
+	if environment.GetAgentRuntimeImageId() != "" {
+		if !rewriter.enabled() {
+			return nil, fmt.Errorf("environment %s names an agent runtime image but the image proxy is not configured", environmentID)
+		}
 		agentRuntimeImage, err = rewriter.Rewrite(ctx, environment.GetAgentRuntimeImageId(), environment.GetAgentRuntimeImageTag())
 		if err != nil {
 			return nil, fmt.Errorf("environment %s agent runtime image: %w", environmentID, err)

--- a/internal/assembler/sandbox_test.go
+++ b/internal/assembler/sandbox_test.go
@@ -129,6 +129,32 @@ func (f *sandboxFixture) assemble(t *testing.T) *SandboxAssembleResult {
 	return result
 }
 
+// The environment's agent runtime was only read when the Image Proxy happened
+// to be configured, so an unconfigured proxy silently produced a sandbox with
+// no agent CLI -- /agyn/bin held agyn and agynd and nothing else.
+func TestAssembleSandboxFailsWhenImageProxyIsUnconfigured(t *testing.T) {
+	fixture := newSandboxFixture()
+	previous := fixture.agents.GetEnvironmentFunc
+	fixture.agents.GetEnvironmentFunc = func(ctx context.Context, req *agentsv1.GetEnvironmentRequest, opts ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
+		resp, err := previous(ctx, req, opts...)
+		if err != nil {
+			return nil, err
+		}
+		resp.Environment.AgentRuntimeImageId = uuid.NewString()
+		resp.Environment.AgentRuntimeImageTag = "1.0.0"
+		return resp, nil
+	}
+
+	assembler := NewWithRunnersAndEgressCA(fixture.agents, fixture.runners, fixture.secrets, fixture.cfg, fixture.egressCACert)
+	_, err := assembler.AssembleSandbox(context.Background(), fixture.sandbox, fixture.workspaceVolumeID)
+	if err == nil {
+		t.Fatal("expected assembly to fail when the environment names a runtime image the proxy cannot resolve")
+	}
+	if !strings.Contains(err.Error(), "image proxy is not configured") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestAssembleSandboxUsesEnvironmentImageAndFlavor(t *testing.T) {
 	fixture := newSandboxFixture()
 	result := fixture.assemble(t)


### PR DESCRIPTION
The environment's images were only read when the Image Proxy happened to be configured. The workspace image falls back to the deprecated free-form reference so it survived; the agent runtime image has no fallback and was dropped silently — a sandbox came up with `agyn` and `agynd` in `/agyn/bin` and no agent CLI.

`architecture/image-proxy.md` has the proxy as *the only path* a workload's images are pulled by, so it is not an optional mode: a catalog reference that cannot be resolved is a broken deployment and now fails at assembly.