### PR TITLE
Derive the image proxy host from the installation's domain

### DIFF
--- a/charts/agents-orchestrator/Chart.lock
+++ b/charts/agents-orchestrator/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: service-base
+  repository: oci://ghcr.io/agynio/charts
+  version: 0.1.5
+digest: sha256:5f6c3bd2498ebd08f8cd9ec3c8b722299f976c277a0851c7319997dda67aa670
+generated: "2026-08-07T16:11:41.916466+02:00"

--- a/charts/agents-orchestrator/Chart.lock
+++ b/charts/agents-orchestrator/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: service-base
-  repository: oci://ghcr.io/agynio/charts
-  version: 0.1.5
-digest: sha256:5f6c3bd2498ebd08f8cd9ec3c8b722299f976c277a0851c7319997dda67aa670
-generated: "2026-08-07T16:11:41.916466+02:00"

--- a/charts/agents-orchestrator/Chart.yaml
+++ b/charts/agents-orchestrator/Chart.yaml
@@ -9,5 +9,5 @@ sources:
   - https://github.com/agynio/agents-orchestrator
 dependencies:
   - name: service-base
-    version: ">=0.1.4 <1.0.0"
+    version: ">=0.1.5 <1.0.0"
     repository: oci://ghcr.io/agynio/charts

--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -76,6 +76,17 @@ env:
     value: "secrets:50051"
   - name: RUNNERS_ADDRESS
     value: "runners:50051"
+  - name: IMAGES_ADDRESS
+    value: "images:50051"
+  - name: ORGANIZATIONS_ADDRESS
+    value: "organizations:50051"
+  - name: IMAGE_PROXY_ADDRESS
+    value: "image-proxy:50051"
+  # Derived from the one domain an installation declares. The Image Proxy is
+  # the only path a workload's images are pulled by, so leaving this empty
+  # disables every catalog image reference rather than falling back to one.
+  - name: IMAGE_PROXY_HOST
+    value: "registry.{{ .Values.global.ingress.baseDomain }}"
   - name: METERING_SERVICE_ADDRESS
     value: ""
   - name: METERING_SAMPLE_INTERVAL


### PR DESCRIPTION
`IMAGE_PROXY_HOST` was set only by bundle-vm's overlay, so any other installation ran with the proxy unconfigured — silently dropping every catalog image reference, including the environment's agent runtime.

It now follows `global.ingress.baseDomain` like the platform's other hostnames, with the service addresses it needs defaulting alongside. Requires service-base 0.1.5, which templates env values.