### PR TITLE
Assemble volumes from the environment

### DIFF
--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -324,6 +324,7 @@ exec "/usr/local/bin/ziti" "tunnel" "tproxy" --identity "${identity_file}" --svc
 
 var reservedEnvNames = map[string]struct{}{
 	"AGENT_ID":                     {},
+	"ENVIRONMENT_ID":               {},
 	"AGENT_INSTANCE_ID":            {},
 	"AGENT_NAME":                   {},
 	"AGENT_ROLE":                   {},
@@ -1047,6 +1048,7 @@ func (a *Assembler) baseAgentEnvVars(agent *agentsv1.Agent, agentID, agentInstan
 	vars := []*runnerv1.EnvVar{
 		{Name: "AGENT_INSTANCE_ID", Value: agentInstanceID.String()},
 		{Name: "AGENT_ID", Value: agentID.String()},
+		{Name: "ENVIRONMENT_ID", Value: agent.GetEnvironmentId()},
 		{Name: "AGENT_NAME", Value: agent.GetName()},
 		{Name: "AGENT_ROLE", Value: agent.GetRole()},
 		{Name: "AGENT_MODEL", Value: agent.GetModel()},

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -20,33 +20,33 @@ import (
 )
 
 const (
-	listPageSize                              int32 = 100
-	rpcTimeout                                      = 10 * time.Second
-	agynBinVolumeName                               = "agyn-bin"
+	listPageSize      int32 = 100
+	rpcTimeout              = 10 * time.Second
+	agynBinVolumeName       = "agyn-bin"
 	// The volume is the whole /agyn tree: binaries under bin/, and the agent
 	// runtime's config.json beside it rather than among them.
-	agynBinMountPath                                = "/agyn"
-	agynBinBinaryPath                               = "/agyn/bin/agynd"
-	mcpBasePort                                     = 8100
-	mcpResolverOptions                              = "attempts:1 timeout:1 no-aaaa"
-	mcpNodeOptions                                  = "--dns-result-order=ipv4first"
-	ZitiEnrollContainerName                         = "ziti-enroll"
-	ZitiSidecarContainerName                        = "ziti-sidecar"
-	zitiIdentityVolumeName                          = "ziti-identity"
-	zitiIdentityMountPath                           = "/netfoundry"
-	ZitiIdentityBasename                            = "agent"
-	ZitiEnrollmentTokenEnvVar                       = "ZITI_ENROLL_TOKEN"
-	ZitiIdentityBasenameEnvVar                      = "ZITI_IDENTITY_BASENAME"
-	ZitiIdentityDirEnvVar                           = "ZITI_IDENTITY_DIR"
-	ZitiEnrollmentControllerResolveHostEnvVar       = "ZITI_ENROLLMENT_CONTROLLER_RESOLVE_HOST"
-	ZitiEnrollmentControllerPortEnvVar              = "ZITI_ENROLLMENT_CONTROLLER_PORT"
-	egressCACertPath                                = "/etc/agyn/egress-ca/ca.crt"
-	egressCACertDir                                 = "/etc/agyn/egress-ca"
-	zitiDNSNameserver                               = "127.0.0.1"
-	zitiEnrollEntrypoint                            = "/usr/bin/bash"
-	zitiSidecarEntrypoint                           = "/usr/bin/bash"
-	zitiSidecarServicePollRate                      = "1"
-	zitiEnrollScript                                = `workload_dns_upstream="$1"
+	agynBinMountPath                          = "/agyn"
+	agynBinBinaryPath                         = "/agyn/bin/agynd"
+	mcpBasePort                               = 8100
+	mcpResolverOptions                        = "attempts:1 timeout:1 no-aaaa"
+	mcpNodeOptions                            = "--dns-result-order=ipv4first"
+	ZitiEnrollContainerName                   = "ziti-enroll"
+	ZitiSidecarContainerName                  = "ziti-sidecar"
+	zitiIdentityVolumeName                    = "ziti-identity"
+	zitiIdentityMountPath                     = "/netfoundry"
+	ZitiIdentityBasename                      = "agent"
+	ZitiEnrollmentTokenEnvVar                 = "ZITI_ENROLL_TOKEN"
+	ZitiIdentityBasenameEnvVar                = "ZITI_IDENTITY_BASENAME"
+	ZitiIdentityDirEnvVar                     = "ZITI_IDENTITY_DIR"
+	ZitiEnrollmentControllerResolveHostEnvVar = "ZITI_ENROLLMENT_CONTROLLER_RESOLVE_HOST"
+	ZitiEnrollmentControllerPortEnvVar        = "ZITI_ENROLLMENT_CONTROLLER_PORT"
+	egressCACertPath                          = "/etc/agyn/egress-ca/ca.crt"
+	egressCACertDir                           = "/etc/agyn/egress-ca"
+	zitiDNSNameserver                         = "127.0.0.1"
+	zitiEnrollEntrypoint                      = "/usr/bin/bash"
+	zitiSidecarEntrypoint                     = "/usr/bin/bash"
+	zitiSidecarServicePollRate                = "1"
+	zitiEnrollScript                          = `workload_dns_upstream="$1"
 workload_dns_nameserver="$2"
 enrollment_controller_resolve_host="$3"
 enrollment_controller_port_override="$4"
@@ -444,13 +444,14 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, agentInstanceID, thre
 		return nil, fmt.Errorf("resolve agent envs: %w", err)
 	}
 
-	agentAttachments, err := a.listVolumeAttachments(ctx, &agentsv1.ListVolumeAttachmentsRequest{AgentId: agentID.String()})
-	if err != nil {
-		return nil, fmt.Errorf("list agent volume attachments: %w", err)
-	}
-	agentMounts, err := volumeResolver.mountsFor(ctx, agentAttachments)
-	if err != nil {
-		return nil, fmt.Errorf("resolve agent mounts: %w", err)
+	// Volumes belong to the environment. An agent declares none of its own, so
+	// an agent without an environment gets no mounts beyond the platform's.
+	var agentMounts []*runnerv1.VolumeMount
+	if environment != nil {
+		agentMounts, err = volumeResolver.loadEnvironmentVolumes(ctx, environment.GetMeta().GetId())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	mainImage := agent.GetImage()
@@ -800,37 +801,6 @@ func (a *Assembler) listEnvs(ctx context.Context, req *agentsv1.ListEnvsRequest)
 	}
 }
 
-func (a *Assembler) listVolumeAttachments(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) ([]*agentsv1.VolumeAttachment, error) {
-	resp := []*agentsv1.VolumeAttachment{}
-	token := ""
-	for {
-		rctx, cancel := context.WithTimeout(ctx, rpcTimeout)
-		page, err := a.agents.ListVolumeAttachments(rctx, &agentsv1.ListVolumeAttachmentsRequest{
-			VolumeId:  req.GetVolumeId(),
-			AgentId:   req.GetAgentId(),
-			McpId:     req.GetMcpId(),
-			PageSize:  listPageSize,
-			PageToken: token,
-		})
-		cancel()
-		if err != nil {
-			return nil, err
-		}
-		resp = append(resp, page.GetVolumeAttachments()...)
-		token = page.GetNextPageToken()
-		if token == "" {
-			return resp, nil
-		}
-	}
-}
-
-type mcpAssignment struct {
-	mcp  *agentsv1.Mcp
-	id   string
-	name string
-	port int
-}
-
 func assignMcpPorts(mcps []*agentsv1.Mcp) ([]mcpAssignment, error) {
 	assignments := make([]mcpAssignment, 0, len(mcps))
 	for _, mcp := range mcps {
@@ -877,7 +847,7 @@ func (a *Assembler) buildMcpSidecar(ctx context.Context, resolver *envResolver, 
 		resolver,
 		volumeResolver,
 		&agentsv1.ListEnvsRequest{McpId: mcpID.String()},
-		&agentsv1.ListVolumeAttachmentsRequest{McpId: mcpID.String()},
+		mcp,
 	)
 	if err != nil {
 		return nil, err
@@ -1101,44 +1071,120 @@ func (a *Assembler) baseAgentEnvVars(agent *agentsv1.Agent, agentID, agentInstan
 }
 
 type volumeResolver struct {
-	agents          agentsClient
-	agentInstanceID uuid.UUID
-	cache           map[string]*agentsv1.Volume
-	specs           map[string]*runnerv1.VolumeSpec
+	agents  agentsClient
+	ownerID uuid.UUID
+	specs   map[string]*runnerv1.VolumeSpec
+	cache   map[string]*agentsv1.Volume
+	// environmentByName is the environment's own volumes, which an MCP names in
+	// shared_volumes. Names are unique within an environment and deliberately
+	// reusable across them, so resolution is late and by name.
+	environmentByName map[string]*agentsv1.Volume
 }
 
-func newVolumeResolver(agents agentsClient, agentInstanceID uuid.UUID) *volumeResolver {
+func newVolumeResolver(agents agentsClient, ownerID uuid.UUID) *volumeResolver {
 	return &volumeResolver{
-		agents:          agents,
-		agentInstanceID: agentInstanceID,
-		cache:           map[string]*agentsv1.Volume{},
-		specs:           map[string]*runnerv1.VolumeSpec{},
+		agents:            agents,
+		ownerID:           ownerID,
+		specs:             map[string]*runnerv1.VolumeSpec{},
+		cache:             map[string]*agentsv1.Volume{},
+		environmentByName: map[string]*agentsv1.Volume{},
 	}
 }
 
-func (v *volumeResolver) mountsFor(ctx context.Context, attachments []*agentsv1.VolumeAttachment) ([]*runnerv1.VolumeMount, error) {
-	mounts := make([]*runnerv1.VolumeMount, 0, len(attachments))
-	for _, attachment := range attachments {
-		if attachment == nil {
-			return nil, fmt.Errorf("volume attachment is nil")
-		}
-		volumeIDRaw := attachment.GetVolumeId()
-		volumeID, err := uuidutil.ParseUUID(volumeIDRaw, "volume_attachment.volume_id")
+// loadEnvironmentVolumes reads the volumes an environment declares. They mount
+// into the main container of every workload running it, agent or sandbox.
+func (v *volumeResolver) loadEnvironmentVolumes(ctx context.Context, environmentID string) ([]*runnerv1.VolumeMount, error) {
+	volumes, err := v.listVolumes(ctx, &agentsv1.ListVolumesRequest{EnvironmentId: environmentID})
+	if err != nil {
+		return nil, fmt.Errorf("list environment volumes: %w", err)
+	}
+	mounts := make([]*runnerv1.VolumeMount, 0, len(volumes))
+	for _, volume := range volumes {
+		mount, err := v.mountFor(volume)
 		if err != nil {
 			return nil, err
 		}
-		volume, err := v.getVolume(ctx, volumeID)
-		if err != nil {
-			return nil, err
-		}
-		mountPath := volume.GetMountPath()
-		if mountPath == "" {
-			return nil, fmt.Errorf("volume %s mount_path is empty", volumeID.String())
-		}
-		spec := v.ensureSpec(volumeID, volume)
-		mounts = append(mounts, &runnerv1.VolumeMount{Volume: spec.Name, MountPath: mountPath})
+		v.environmentByName[volume.GetName()] = volume
+		mounts = append(mounts, mount)
 	}
 	return mounts, nil
+}
+
+// mountsForMcp is the sidecar's own volumes plus the environment volumes it
+// shares, at the same paths the main container sees them. A shared name that
+// does not resolve, or a path colliding with one of its own, fails scheduling:
+// a sidecar silently missing the files it was configured to read is worse.
+func (v *volumeResolver) mountsForMcp(ctx context.Context, mcp *agentsv1.Mcp) ([]*runnerv1.VolumeMount, error) {
+	own, err := v.listVolumes(ctx, &agentsv1.ListVolumesRequest{McpId: mcp.GetMeta().GetId()})
+	if err != nil {
+		return nil, fmt.Errorf("list mcp volumes: %w", err)
+	}
+	mounts := make([]*runnerv1.VolumeMount, 0, len(own)+len(mcp.GetSharedVolumes()))
+	paths := map[string]string{}
+	for _, volume := range own {
+		mount, err := v.mountFor(volume)
+		if err != nil {
+			return nil, err
+		}
+		paths[mount.MountPath] = volume.GetName()
+		mounts = append(mounts, mount)
+	}
+	for _, name := range mcp.GetSharedVolumes() {
+		shared, ok := v.environmentByName[name]
+		if !ok {
+			return nil, fmt.Errorf("mcp %s shares volume %q, which the environment does not declare", mcp.GetName(), name)
+		}
+		mount, err := v.mountFor(shared)
+		if err != nil {
+			return nil, err
+		}
+		if other, clash := paths[mount.MountPath]; clash {
+			return nil, fmt.Errorf("mcp %s mounts %q at %s and shares %q at the same path", mcp.GetName(), other, mount.MountPath, name)
+		}
+		paths[mount.MountPath] = name
+		mounts = append(mounts, mount)
+	}
+	return mounts, nil
+}
+
+func (v *volumeResolver) listVolumes(ctx context.Context, req *agentsv1.ListVolumesRequest) ([]*agentsv1.Volume, error) {
+	volumes := []*agentsv1.Volume{}
+	pageToken := ""
+	for {
+		rctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+		page, err := v.agents.ListVolumes(rctx, &agentsv1.ListVolumesRequest{
+			EnvironmentId: req.GetEnvironmentId(),
+			McpId:         req.GetMcpId(),
+			PageSize:      listPageSize,
+			PageToken:     pageToken,
+		})
+		cancel()
+		if err != nil {
+			return nil, err
+		}
+		volumes = append(volumes, page.GetVolumes()...)
+		pageToken = page.GetNextPageToken()
+		if pageToken == "" {
+			return volumes, nil
+		}
+	}
+}
+
+func (v *volumeResolver) mountFor(volume *agentsv1.Volume) (*runnerv1.VolumeMount, error) {
+	if volume == nil {
+		return nil, fmt.Errorf("volume is nil")
+	}
+	mountPath := volume.GetMountPath()
+	if mountPath == "" {
+		return nil, fmt.Errorf("volume %s mount_path is empty", volume.GetMeta().GetId())
+	}
+	volumeID, err := uuidutil.ParseUUID(volume.GetMeta().GetId(), "volume.id")
+	if err != nil {
+		return nil, err
+	}
+	v.cache[volumeID.String()] = volume
+	spec := v.ensureSpec(volumeID, volume)
+	return &runnerv1.VolumeMount{Volume: spec.Name, MountPath: mountPath}, nil
 }
 
 func (v *volumeResolver) Specs() []*runnerv1.VolumeSpec {
@@ -1173,32 +1219,20 @@ func (v *volumeResolver) PersistentVolumes() ([]PersistentVolumeInfo, error) {
 		if err != nil {
 			return nil, err
 		}
-		volumes = append(volumes, PersistentVolumeInfo{ID: parsedID, AgentInstanceID: v.agentInstanceID, Volume: volume, Spec: spec})
+		volumes = append(volumes, PersistentVolumeInfo{ID: parsedID, AgentInstanceID: v.ownerID, Volume: volume, Spec: spec})
 	}
 	sort.Slice(volumes, func(i, j int) bool { return volumes[i].ID.String() < volumes[j].ID.String() })
 	return volumes, nil
 }
 
-func (v *volumeResolver) getVolume(ctx context.Context, volumeID uuid.UUID) (*agentsv1.Volume, error) {
-	key := volumeID.String()
-	if cached, ok := v.cache[key]; ok {
-		return cached, nil
-	}
-	rctx, cancel := context.WithTimeout(ctx, rpcTimeout)
-	resp, err := v.agents.GetVolume(rctx, &agentsv1.GetVolumeRequest{Id: key})
-	cancel()
-	if err != nil {
-		return nil, fmt.Errorf("get volume %s: %w", key, err)
-	}
-	volume := resp.GetVolume()
-	if volume == nil {
-		return nil, fmt.Errorf("volume %s missing", key)
-	}
-	v.cache[key] = volume
-	return volume, nil
+type mcpAssignment struct {
+	mcp  *agentsv1.Mcp
+	id   string
+	name string
+	port int
 }
 
-func (a *Assembler) resolveSidecarResources(ctx context.Context, resolver *envResolver, volumeResolver *volumeResolver, envReq *agentsv1.ListEnvsRequest, attachmentReq *agentsv1.ListVolumeAttachmentsRequest) ([]*runnerv1.EnvVar, []*runnerv1.VolumeMount, error) {
+func (a *Assembler) resolveSidecarResources(ctx context.Context, resolver *envResolver, volumeResolver *volumeResolver, envReq *agentsv1.ListEnvsRequest, mcp *agentsv1.Mcp) ([]*runnerv1.EnvVar, []*runnerv1.VolumeMount, error) {
 	vars, err := a.listEnvs(ctx, envReq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list sidecar envs: %w", err)
@@ -1207,11 +1241,7 @@ func (a *Assembler) resolveSidecarResources(ctx context.Context, resolver *envRe
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve sidecar envs: %w", err)
 	}
-	attachments, err := a.listVolumeAttachments(ctx, attachmentReq)
-	if err != nil {
-		return nil, nil, fmt.Errorf("list sidecar volume attachments: %w", err)
-	}
-	mounts, err := volumeResolver.mountsFor(ctx, attachments)
+	mounts, err := volumeResolver.mountsForMcp(ctx, mcp)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve sidecar mounts: %w", err)
 	}
@@ -1230,7 +1260,7 @@ func (v *volumeResolver) ensureSpec(volumeID uuid.UUID, volume *agentsv1.Volume)
 	}
 	if volume.GetPersistent() {
 		spec.Kind = runnerv1.VolumeKind_VOLUME_KIND_NAMED
-		instancePrefix := v.agentInstanceID.String()[:12]
+		instancePrefix := v.ownerID.String()[:12]
 		volumePrefix := key[:12]
 		spec.PersistentName = fmt.Sprintf("pv-%s-%s", instancePrefix, volumePrefix)
 	}

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -215,25 +215,22 @@ func TestAssemblerReusesWorkspaceMount(t *testing.T) {
 		ListEnvsFunc: func(_ context.Context, _ *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			return &agentsv1.ListEnvsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, req *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			if req.GetAgentId() == agentID.String() {
-				return &agentsv1.ListVolumeAttachmentsResponse{VolumeAttachments: []*agentsv1.VolumeAttachment{
-					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, VolumeId: volumeID.String()},
+		ListVolumesFunc: func(_ context.Context, req *agentsv1.ListVolumesRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			if req.GetEnvironmentId() != "" {
+				return &agentsv1.ListVolumesResponse{Volumes: []*agentsv1.Volume{
+					{
+						Meta:       &agentsv1.EntityMeta{Id: volumeID.String()},
+						Name:       "workspace",
+						MountPath:  workspacePath,
+						Persistent: true,
+						Size:       "1Gi",
+					},
 				}}, nil
 			}
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{}, nil
-		},
-		GetVolumeFunc: func(_ context.Context, req *agentsv1.GetVolumeRequest, _ ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error) {
-			if req.GetId() != volumeID.String() {
-				return nil, errors.New("unexpected volume id")
-			}
-			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{
-				Meta:      &agentsv1.EntityMeta{Id: volumeID.String()},
-				MountPath: workspacePath,
-			}}, nil
 		},
 	}
 
@@ -248,25 +245,16 @@ func TestAssemblerReusesWorkspaceMount(t *testing.T) {
 		t.Fatalf("assemble: %v", err)
 	}
 	request := result.Request
-	workspaceVolumeName := "vol-" + volumeID.String()[:8]
-	if len(request.Volumes) != 2 {
-		t.Fatalf("expected 2 volumes, got %d", len(request.Volumes))
+	// Volumes belong to the environment. An agent without one declares none, so
+	// the only volume is the platform's own binary mount.
+	if len(request.Volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(request.Volumes))
 	}
 	if findVolumeSpec(request.Volumes, agynBinVolumeName) == nil {
 		t.Fatalf("expected %s volume", agynBinVolumeName)
 	}
-	if findVolumeSpec(request.Volumes, workspaceVolumeName) == nil {
-		t.Fatalf("expected %s volume", workspaceVolumeName)
-	}
-	workspaceMount := findMountByPath(request.Main.Mounts, workspacePath)
-	if workspaceMount == nil {
-		t.Fatalf("expected main workspace mount")
-	}
-	if workspaceMount.Volume != workspaceVolumeName {
-		t.Fatalf("expected workspace volume %q, got %q", workspaceVolumeName, workspaceMount.Volume)
-	}
-	if countMountsByPath(request.Main.Mounts, workspacePath) != 1 {
-		t.Fatalf("expected one workspace mount, got %d", countMountsByPath(request.Main.Mounts, workspacePath))
+	if findMountByPath(request.Main.Mounts, workspacePath) != nil {
+		t.Fatalf("expected no workspace mount without an environment declaring one")
 	}
 	if len(request.InitContainers) != 1 {
 		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
@@ -799,13 +787,13 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 			}
 			return &agentsv1.ListEnvsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, req *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+		ListVolumesFunc: func(_ context.Context, req *agentsv1.ListVolumesRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
 			if req.GetMcpId() == mcpID.String() {
-				return &agentsv1.ListVolumeAttachmentsResponse{VolumeAttachments: []*agentsv1.VolumeAttachment{
-					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, VolumeId: volumeID.String()},
+				return &agentsv1.ListVolumesResponse{Volumes: []*agentsv1.Volume{
+					{Meta: &agentsv1.EntityMeta{Id: volumeID.String()}, Name: "state", MountPath: "/data", Persistent: true, Size: "1Gi"},
 				}}, nil
 			}
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		GetVolumeFunc: func(_ context.Context, req *agentsv1.GetVolumeRequest, _ ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error) {
 			if req.GetId() != volumeID.String() {
@@ -883,107 +871,102 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 	assertEnv(t, envs, "RES_OPTIONS", "ndots:2")
 }
 
-func TestAssemblerSharesPersistentVolumeAcrossContainers(t *testing.T) {
-	ctx := context.Background()
-	agentID := uuid.New()
-	threadA := uuid.New()
-	threadB := uuid.New()
+// Sharing within one workload is what shared_volumes is for: the agent writes a
+// file and an MCP server reads it, from the same pod volume at the same path.
+func TestSharedVolumesMountTheEnvironmentVolumeIntoTheSidecar(t *testing.T) {
+	environmentID := uuid.New()
 	mcpID := uuid.New()
 	volumeID := uuid.New()
 
-	agentsClient := &testutil.FakeAgentsClient{
-		GetAgentFunc: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
-			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image", InitImage: "agent-init-image"}}, nil
-		},
-		ListSkillsFunc: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
-			return &agentsv1.ListSkillsResponse{}, nil
-		},
-		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
-			return &agentsv1.ListMcpsResponse{Mcps: []*agentsv1.Mcp{
-				{Meta: &agentsv1.EntityMeta{Id: mcpID.String()}, Name: "shared", Image: "mcp-image", Command: "run-mcp"},
-			}}, nil
-		},
-		ListEnvsFunc: func(_ context.Context, _ *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
-			return &agentsv1.ListEnvsResponse{}, nil
-		},
-		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
-			return &agentsv1.ListInitScriptsResponse{}, nil
-		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, req *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			switch {
-			case req.GetAgentId() == agentID.String(), req.GetMcpId() == mcpID.String():
-				return &agentsv1.ListVolumeAttachmentsResponse{VolumeAttachments: []*agentsv1.VolumeAttachment{
-					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, VolumeId: volumeID.String()},
+	agents := &testutil.FakeAgentsClient{
+		ListVolumesFunc: func(_ context.Context, req *agentsv1.ListVolumesRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			if req.GetEnvironmentId() == environmentID.String() {
+				return &agentsv1.ListVolumesResponse{Volumes: []*agentsv1.Volume{
+					{Meta: &agentsv1.EntityMeta{Id: volumeID.String()}, Name: "workspace", MountPath: "/workspace", Persistent: true, Size: "1Gi"},
 				}}, nil
-			default:
-				return &agentsv1.ListVolumeAttachmentsResponse{}, nil
 			}
-		},
-		GetVolumeFunc: func(_ context.Context, req *agentsv1.GetVolumeRequest, _ ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error) {
-			if req.GetId() != volumeID.String() {
-				return nil, errors.New("unexpected volume id")
-			}
-			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{
-				Meta:       &agentsv1.EntityMeta{Id: volumeID.String()},
-				Persistent: true,
-				MountPath:  "/data",
-			}}, nil
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 	}
+	resolver := newVolumeResolver(agents, uuid.New())
+	mainMounts, err := resolver.loadEnvironmentVolumes(context.Background(), environmentID.String())
+	if err != nil {
+		t.Fatalf("load environment volumes: %v", err)
+	}
+	if len(mainMounts) != 1 || mainMounts[0].MountPath != "/workspace" {
+		t.Fatalf("unexpected main mounts: %+v", mainMounts)
+	}
 
-	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, &config.Config{
-		AgentGatewayAddress: "gateway:50051",
-		AgentLLMBaseURL:     "http://llm:8080/v1",
+	mcp := &agentsv1.Mcp{
+		Meta:          &agentsv1.EntityMeta{Id: mcpID.String()},
+		Name:          "files",
+		SharedVolumes: []string{"workspace"},
+	}
+	sidecarMounts, err := resolver.mountsForMcp(context.Background(), mcp)
+	if err != nil {
+		t.Fatalf("mounts for mcp: %v", err)
+	}
+	if len(sidecarMounts) != 1 {
+		t.Fatalf("expected 1 sidecar mount, got %d", len(sidecarMounts))
+	}
+	// Same pod volume, same path: a divergent path would be a debugging trap.
+	if sidecarMounts[0].Volume != mainMounts[0].Volume {
+		t.Fatalf("expected the sidecar to mount %q, got %q", mainMounts[0].Volume, sidecarMounts[0].Volume)
+	}
+	if sidecarMounts[0].MountPath != "/workspace" {
+		t.Fatalf("expected /workspace, got %q", sidecarMounts[0].MountPath)
+	}
+}
+
+// A share the environment does not declare fails scheduling rather than leaving
+// a sidecar silently missing the files it was configured to read.
+func TestSharedVolumesRejectAnUnresolvableName(t *testing.T) {
+	resolver := newVolumeResolver(&testutil.FakeAgentsClient{}, uuid.New())
+	if _, err := resolver.loadEnvironmentVolumes(context.Background(), uuid.NewString()); err != nil {
+		t.Fatalf("load environment volumes: %v", err)
+	}
+	_, err := resolver.mountsForMcp(context.Background(), &agentsv1.Mcp{
+		Meta:          &agentsv1.EntityMeta{Id: uuid.NewString()},
+		Name:          "files",
+		SharedVolumes: []string{"nope"},
 	})
+	if err == nil {
+		t.Fatal("expected an unresolvable shared volume to fail")
+	}
+}
 
-	resultA, err := assembler.Assemble(ctx, agentID, threadA, threadA)
-	if err != nil {
-		t.Fatalf("assemble thread A: %v", err)
-	}
-	volumeName := "vol-" + volumeID.String()[:8]
-	if len(resultA.Request.Volumes) != 2 {
-		t.Fatalf("expected 2 volumes, got %d", len(resultA.Request.Volumes))
-	}
-	volumeSpecA := findVolumeSpec(resultA.Request.Volumes, volumeName)
-	if volumeSpecA == nil {
-		t.Fatalf("expected volume %q", volumeName)
-	}
-	expectedPersistentA := "pv-" + threadA.String()[:12] + "-" + volumeID.String()[:12]
-	if volumeSpecA.PersistentName != expectedPersistentA {
-		t.Fatalf("expected persistent name %q, got %q", expectedPersistentA, volumeSpecA.PersistentName)
-	}
-	mainMount := findVolumeMount(resultA.Request.Main, volumeName)
-	if mainMount == nil {
-		t.Fatalf("expected main mount for %q", volumeName)
-	}
-	if mainMount.MountPath != "/data" {
-		t.Fatalf("expected main mount path /data, got %q", mainMount.MountPath)
-	}
-	if len(resultA.Request.Sidecars) != 1 {
-		t.Fatalf("expected 1 sidecar, got %d", len(resultA.Request.Sidecars))
-	}
-	sidecarMount := findVolumeMount(resultA.Request.Sidecars[0], volumeName)
-	if sidecarMount == nil {
-		t.Fatalf("expected sidecar mount for %q", volumeName)
-	}
-	if sidecarMount.MountPath != "/data" {
-		t.Fatalf("expected sidecar mount path /data, got %q", sidecarMount.MountPath)
-	}
+// A shared volume landing on a path the sidecar already uses is refused: the
+// same path cannot hold two different volumes.
+func TestSharedVolumesRejectAMountPathCollision(t *testing.T) {
+	environmentID := uuid.New()
+	mcpID := uuid.New()
 
-	resultB, err := assembler.Assemble(ctx, agentID, threadB, threadB)
-	if err != nil {
-		t.Fatalf("assemble thread B: %v", err)
+	agents := &testutil.FakeAgentsClient{
+		ListVolumesFunc: func(_ context.Context, req *agentsv1.ListVolumesRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			if req.GetEnvironmentId() == environmentID.String() {
+				return &agentsv1.ListVolumesResponse{Volumes: []*agentsv1.Volume{
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "shared", MountPath: "/data"},
+				}}, nil
+			}
+			if req.GetMcpId() == mcpID.String() {
+				return &agentsv1.ListVolumesResponse{Volumes: []*agentsv1.Volume{
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "own", MountPath: "/data"},
+				}}, nil
+			}
+			return &agentsv1.ListVolumesResponse{}, nil
+		},
 	}
-	volumeSpecB := findVolumeSpec(resultB.Request.Volumes, volumeName)
-	if volumeSpecB == nil {
-		t.Fatalf("expected volume %q", volumeName)
+	resolver := newVolumeResolver(agents, uuid.New())
+	if _, err := resolver.loadEnvironmentVolumes(context.Background(), environmentID.String()); err != nil {
+		t.Fatalf("load environment volumes: %v", err)
 	}
-	expectedPersistentB := "pv-" + threadB.String()[:12] + "-" + volumeID.String()[:12]
-	if volumeSpecB.PersistentName != expectedPersistentB {
-		t.Fatalf("expected persistent name %q, got %q", expectedPersistentB, volumeSpecB.PersistentName)
-	}
-	if volumeSpecA.PersistentName == volumeSpecB.PersistentName {
-		t.Fatalf("expected different persistent names, got %q", volumeSpecA.PersistentName)
+	_, err := resolver.mountsForMcp(context.Background(), &agentsv1.Mcp{
+		Meta:          &agentsv1.EntityMeta{Id: mcpID.String()},
+		Name:          "files",
+		SharedVolumes: []string{"shared"},
+	})
+	if err == nil {
+		t.Fatal("expected a mount path collision to fail")
 	}
 }
 

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -59,8 +59,8 @@ func TestAssemblerMainContainer(t *testing.T) {
 			}
 			return &agentsv1.ListEnvsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{}, nil
@@ -301,8 +301,8 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{}, nil
@@ -624,8 +624,8 @@ func TestAssemblerInitImageOverride(t *testing.T) {
 		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{}, nil
@@ -683,8 +683,8 @@ func TestAssemblerErrorsOnEmptyInitImage(t *testing.T) {
 		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{}, nil
@@ -742,8 +742,8 @@ func TestAssemblerResolvesSecretEnv(t *testing.T) {
 		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{}, nil
@@ -1013,8 +1013,8 @@ func TestAssemblerMcpPortAllocation(t *testing.T) {
 		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 	}
 
@@ -1076,8 +1076,8 @@ func TestAssemblerNoMcpsNoAgentMcpServersEnv(t *testing.T) {
 		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{}, nil
@@ -1218,8 +1218,8 @@ func TestAssemblerDistributesEgressCA(t *testing.T) {
 		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(_ context.Context, _ *agentsv1.ListVolumeAttachmentsRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{Mcps: []*agentsv1.Mcp{{Meta: &agentsv1.EntityMeta{Id: mcpID.String()}, Name: "mcp", Image: "mcp-image", Command: "run-mcp"}}}, nil
@@ -1916,8 +1916,8 @@ func newAgentEnvironmentFixture() *agentEnvironmentFixture {
 		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			return &agentsv1.ListEnvsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(context.Context, *agentsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{}, nil

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -918,6 +918,115 @@ func TestSharedVolumesMountTheEnvironmentVolumeIntoTheSidecar(t *testing.T) {
 	}
 }
 
+// The same claim on a fully assembled pod rather than the resolver alone: one
+// volume declared once, reaching both containers at one path.
+func TestSharedVolumeReachesBothContainersOfTheAssembledPod(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	threadID := uuid.New()
+	environmentID := uuid.New()
+	mcpID := uuid.New()
+	volumeID := uuid.New()
+
+	agentsClient := &testutil.FakeAgentsClient{
+		GetAgentFunc: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{
+				Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
+				OrganizationId: "org-1",
+				Image:          "agent-image",
+				InitImage:      "agent-init-image",
+				EnvironmentId:  environmentID.String(),
+			}}, nil
+		},
+		GetEnvironmentFunc: func(_ context.Context, req *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
+			if req.GetId() != environmentID.String() {
+				return nil, errors.New("unexpected environment id")
+			}
+			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{
+				Meta:           &agentsv1.EntityMeta{Id: environmentID.String()},
+				OrganizationId: "org-1",
+				Name:           "shared-runtime",
+				Image:          "environment-image",
+				RunnerId:       testAgentEnvironmentRunnerID,
+				Flavor:         testAgentEnvironmentFlavor,
+			}}, nil
+		},
+		ListSkillsFunc: func(context.Context, *agentsv1.ListSkillsRequest, ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
+			return &agentsv1.ListSkillsResponse{}, nil
+		},
+		ListMcpsFunc: func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
+			return &agentsv1.ListMcpsResponse{Mcps: []*agentsv1.Mcp{{
+				Meta:          &agentsv1.EntityMeta{Id: mcpID.String()},
+				Name:          "files",
+				Image:         "mcp-image",
+				Command:       "run-mcp",
+				SharedVolumes: []string{"workspace"},
+			}}}, nil
+		},
+		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
+			return &agentsv1.ListEnvsResponse{}, nil
+		},
+		ListVolumesFunc: func(_ context.Context, req *agentsv1.ListVolumesRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			if req.GetEnvironmentId() == environmentID.String() {
+				return &agentsv1.ListVolumesResponse{Volumes: []*agentsv1.Volume{{
+					Meta:       &agentsv1.EntityMeta{Id: volumeID.String()},
+					Name:       "workspace",
+					MountPath:  "/workspace",
+					Persistent: true,
+					Size:       "1Gi",
+				}}}, nil
+			}
+			return &agentsv1.ListVolumesResponse{}, nil
+		},
+	}
+
+	runnersClient := &fakeRunnersClient{
+		listFlavors: func(context.Context, *runnersv1.ListFlavorsRequest, ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{{
+				RunnerId:  testAgentEnvironmentRunnerID,
+				Name:      testAgentEnvironmentFlavor,
+				Default:   true,
+				Resources: &runnersv1.ComputeResources{RequestsCpu: "500m", RequestsMemory: "1Gi"},
+			}}}, nil
+		},
+	}
+	assembler := NewWithRunners(agentsClient, runnersClient, &testutil.FakeSecretsClient{}, &config.Config{
+		AgentGatewayAddress: "gateway:50051",
+		AgentLLMBaseURL:     "http://llm:8080/v1",
+	})
+	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+
+	expectedName := "vol-" + volumeID.String()[:8]
+	mainMount := findVolumeMount(result.Request.GetMain(), expectedName)
+	if mainMount == nil {
+		t.Fatalf("expected the main container to mount %q, got %+v", expectedName, result.Request.GetMain().GetMounts())
+	}
+	if len(result.Request.GetSidecars()) != 1 {
+		t.Fatalf("expected 1 sidecar, got %d", len(result.Request.GetSidecars()))
+	}
+	sidecarMount := findVolumeMount(result.Request.GetSidecars()[0], expectedName)
+	if sidecarMount == nil {
+		t.Fatalf("expected the sidecar to mount %q, got %+v", expectedName, result.Request.GetSidecars()[0].GetMounts())
+	}
+	if mainMount.MountPath != sidecarMount.MountPath {
+		t.Fatalf("expected one path in both containers, got %q and %q", mainMount.MountPath, sidecarMount.MountPath)
+	}
+
+	// Declared once: a second spec would be a second PVC holding different bytes.
+	matching := 0
+	for _, spec := range result.Request.GetVolumes() {
+		if spec.GetName() == expectedName {
+			matching++
+		}
+	}
+	if matching != 1 {
+		t.Fatalf("expected the shared volume declared once, got %d specs", matching)
+	}
+}
+
 // A share the environment does not declare fails scheduling rather than leaving
 // a sidecar silently missing the files it was configured to read.
 func TestSharedVolumesRejectAnUnresolvableName(t *testing.T) {

--- a/internal/assembler/interfaces.go
+++ b/internal/assembler/interfaces.go
@@ -14,8 +14,7 @@ type agentsClient interface {
 	GetEnvironment(context.Context, *agentsv1.GetEnvironmentRequest, ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error)
 	ListMcps(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error)
 	ListEnvs(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error)
-	ListVolumeAttachments(context.Context, *agentsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error)
-	GetVolume(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
+	ListVolumes(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error)
 }
 
 type secretsClient interface {

--- a/internal/assembler/resources_test.go
+++ b/internal/assembler/resources_test.go
@@ -56,8 +56,8 @@ func TestAssemblerAggregatesResourceRequests(t *testing.T) {
 		ListInitScriptsFunc: func(context.Context, *agentsv1.ListInitScriptsRequest, ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(context.Context, *agentsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{Mcps: []*agentsv1.Mcp{mcp}}, nil

--- a/internal/assembler/sandbox.go
+++ b/internal/assembler/sandbox.go
@@ -333,6 +333,7 @@ func (a *Assembler) baseSandboxEnvVars(sandbox *agentsv1.Sandbox, environment *a
 		{Name: "ENVIRONMENT_ID", Value: environment.GetMeta().GetId()},
 		{Name: "ENVIRONMENT_NAME", Value: environment.GetName()},
 		{Name: "WORKSPACE_DIR", Value: SandboxWorkspaceMountPath},
+		{Name: "ENVIRONMENT_ID", Value: sandbox.GetEnvironmentId()},
 		{Name: "GATEWAY_ADDRESS", Value: a.cfg.AgentGatewayAddress},
 		{Name: "AGYN_GATEWAY_URL", Value: gatewayURL},
 		{Name: "LLM_BASE_URL", Value: a.cfg.AgentLLMBaseURL},

--- a/internal/assembler/sandbox.go
+++ b/internal/assembler/sandbox.go
@@ -22,24 +22,23 @@ const (
 )
 
 type SandboxAssembleResult struct {
-	Request        *runnerv1.StartWorkloadRequest
-	OrganizationID string
-	EnvironmentID  uuid.UUID
-	OwnerID        uuid.UUID
-	RunnerID       string
+	PersistentVolumes []PersistentVolumeInfo
+	Request           *runnerv1.StartWorkloadRequest
+	OrganizationID    string
+	EnvironmentID     uuid.UUID
+	OwnerID           uuid.UUID
+	RunnerID          string
 	// Flavor names the catalog entry the workload is allocated from, and is
 	// what compute is billed by.
 	Flavor string
 	// GrantedImageIDs are the catalog images this sandbox may pull. The
 	// credential is minted against them once the workload id exists.
 	GrantedImageIDs        []string
-	WorkspaceVolumeID      string
-	WorkspaceSizeGB        string
 	AllocatedCPUMillicores int32
 	AllocatedRAMBytes      int64
 }
 
-func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandbox, workspaceVolumeID string) (*SandboxAssembleResult, error) {
+func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandbox) (*SandboxAssembleResult, error) {
 	if sandbox == nil {
 		return nil, fmt.Errorf("sandbox missing")
 	}
@@ -54,10 +53,6 @@ func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandb
 	ownerID, err := uuidutil.ParseUUID(sandbox.GetOwnerId(), "sandbox.owner_id")
 	if err != nil {
 		return nil, err
-	}
-	workspaceVolumeID = strings.TrimSpace(workspaceVolumeID)
-	if workspaceVolumeID == "" {
-		return nil, fmt.Errorf("sandbox %s workspace volume id missing", sandboxID.String())
 	}
 	environment, err := a.fetchEnvironment(ctx, environmentID)
 	if err != nil {
@@ -97,6 +92,12 @@ func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandb
 		}
 	}
 
+	volumeResolver := newVolumeResolver(a.agents, sandboxID)
+	environmentMounts, err := volumeResolver.loadEnvironmentVolumes(ctx, environmentID.String())
+	if err != nil {
+		return nil, err
+	}
+
 	mainEnv := mergeEnvVars(a.baseSandboxEnvVars(sandbox, environment), environmentEnvVars, fmt.Sprintf("sandbox %s", sandboxID.String()))
 	mainEnv = appendEgressCAEnvVars(mainEnv)
 	main := &runnerv1.ContainerSpec{
@@ -105,7 +106,7 @@ func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandb
 		Cmd:              []string{agynBinBinaryPath},
 		Env:              mainEnv,
 		WorkingDir:       SandboxWorkspaceMountPath,
-		Mounts:           []*runnerv1.VolumeMount{{Volume: sandboxWorkspaceVolumeName, MountPath: SandboxWorkspaceMountPath}, {Volume: agynBinVolumeName, MountPath: agynBinMountPath}},
+		Mounts:           append(environmentMounts, &runnerv1.VolumeMount{Volume: agynBinVolumeName, MountPath: agynBinMountPath}),
 		InlineFileMounts: egressCAInlineFileMounts(a.egressCACert),
 	}
 	// The two platform init containers go into a sandbox too, which is what
@@ -125,24 +126,10 @@ func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandb
 		}
 		initContainers = append(initContainers, legacy)
 	}
-	volumes := []*runnerv1.VolumeSpec{
-		{
-			Name:           sandboxWorkspaceVolumeName,
-			Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
-			PersistentName: sandboxWorkspacePersistentName(sandboxID),
-			Labels: map[string]string{
-				LabelManagedBy:      ManagedByValue,
-				LabelSandboxID:      sandboxID.String(),
-				LabelSandboxOwnerID: ownerID.String(),
-				LabelEnvironmentID:  environmentID.String(),
-				LabelVolumeKey:      workspaceVolumeID,
-			},
-		},
-		{
-			Name: agynBinVolumeName,
-			Kind: runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL,
-		},
-	}
+	volumes := append(volumeResolver.Specs(), &runnerv1.VolumeSpec{
+		Name: agynBinVolumeName,
+		Kind: runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL,
+	})
 	if a.cfg.ZitiEnabled {
 		if _, err := gatewayHost(a.cfg.AgentGatewayAddress); err != nil {
 			return nil, err
@@ -209,7 +196,12 @@ func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandb
 			Searches:    []string{zitiDNSSearchService, zitiDNSSearchCluster},
 		}
 	}
+	persistentVolumes, err := volumeResolver.PersistentVolumes()
+	if err != nil {
+		return nil, err
+	}
 	return &SandboxAssembleResult{
+		PersistentVolumes:      persistentVolumes,
 		Request:                request,
 		OrganizationID:         sandbox.GetOrganizationId(),
 		EnvironmentID:          environmentID,
@@ -217,8 +209,6 @@ func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandb
 		RunnerID:               flavor.GetRunnerId(),
 		Flavor:                 flavor.GetName(),
 		GrantedImageIDs:        rewriter.GrantedImageIDs(),
-		WorkspaceVolumeID:      workspaceVolumeID,
-		WorkspaceSizeGB:        a.cfg.SandboxWorkspaceSizeGB,
 		AllocatedCPUMillicores: allocatedCPU,
 		AllocatedRAMBytes:      allocatedRAM,
 	}, nil

--- a/internal/assembler/sandbox.go
+++ b/internal/assembler/sandbox.go
@@ -126,6 +126,17 @@ func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandb
 		}
 		initContainers = append(initContainers, legacy)
 	}
+	// Provisioned disks are attributed to the sandbox that owns them, which is
+	// what volume reconciliation and metering read.
+	for _, spec := range volumeResolver.Specs() {
+		if spec.Labels == nil {
+			spec.Labels = map[string]string{}
+		}
+		spec.Labels[LabelManagedBy] = ManagedByValue
+		spec.Labels[LabelSandboxID] = sandboxID.String()
+		spec.Labels[LabelSandboxOwnerID] = ownerID.String()
+		spec.Labels[LabelEnvironmentID] = environmentID.String()
+	}
 	volumes := append(volumeResolver.Specs(), &runnerv1.VolumeSpec{
 		Name: agynBinVolumeName,
 		Kind: runnerv1.VolumeKind_VOLUME_KIND_EPHEMERAL,

--- a/internal/assembler/sandbox_test.go
+++ b/internal/assembler/sandbox_test.go
@@ -92,6 +92,20 @@ func newSandboxFixture() *sandboxFixture {
 				Flavor:         testSandboxFlavor,
 			}}, nil
 		},
+		ListVolumesFunc: func(_ context.Context, req *agentsv1.ListVolumesRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			if req.GetEnvironmentId() == environmentID.String() {
+				return &agentsv1.ListVolumesResponse{Volumes: []*agentsv1.Volume{
+					{
+						Meta:       &agentsv1.EntityMeta{Id: fixture.workspaceVolumeID},
+						Name:       "workspace",
+						MountPath:  testSandboxWorkspace,
+						Persistent: true,
+						Size:       "10Gi",
+					},
+				}}, nil
+			}
+			return &agentsv1.ListVolumesResponse{}, nil
+		},
 		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
 			return &agentsv1.ListEnvsResponse{}, nil
 		},
@@ -149,12 +163,6 @@ func TestAssembleSandboxUsesEnvironmentImageAndFlavor(t *testing.T) {
 	}
 	if result.OwnerID != fixture.ownerID {
 		t.Fatalf("unexpected owner id %s", result.OwnerID)
-	}
-	if result.WorkspaceVolumeID != fixture.workspaceVolumeID {
-		t.Fatalf("unexpected workspace volume id %q", result.WorkspaceVolumeID)
-	}
-	if result.WorkspaceSizeGB != testSandboxSizeGB {
-		t.Fatalf("unexpected workspace size %q", result.WorkspaceSizeGB)
 	}
 	if result.AllocatedCPUMillicores != 500 {
 		t.Fatalf("unexpected allocated cpu %d", result.AllocatedCPUMillicores)
@@ -247,14 +255,14 @@ func TestAssembleSandboxMountsPersistentWorkspace(t *testing.T) {
 	if main.GetWorkingDir() != SandboxWorkspaceMountPath {
 		t.Fatalf("expected working dir %q, got %q", SandboxWorkspaceMountPath, main.GetWorkingDir())
 	}
-	workspaceMount := findVolumeMount(main, sandboxWorkspaceVolumeName)
+	workspaceMount := findVolumeMount(main, "vol-"+fixture.workspaceVolumeID[:8])
 	if workspaceMount == nil {
 		t.Fatalf("expected workspace mount, got %v", main.GetMounts())
 	}
 	if workspaceMount.GetMountPath() != SandboxWorkspaceMountPath {
 		t.Fatalf("expected workspace mount path %q, got %q", SandboxWorkspaceMountPath, workspaceMount.GetMountPath())
 	}
-	workspaceVolume := findVolumeSpec(result.Request.GetVolumes(), sandboxWorkspaceVolumeName)
+	workspaceVolume := findVolumeSpec(result.Request.GetVolumes(), "vol-"+fixture.workspaceVolumeID[:8])
 	if workspaceVolume == nil {
 		t.Fatalf("expected workspace volume, got %v", result.Request.GetVolumes())
 	}
@@ -263,7 +271,7 @@ func TestAssembleSandboxMountsPersistentWorkspace(t *testing.T) {
 	}
 	// The deterministic persistent name is what lets the workspace survive idle
 	// stops and reconnects.
-	expectedPersistentName := "sandbox-ws-" + fixture.sandboxID.String()
+	expectedPersistentName := "pv-" + fixture.sandboxID.String()[:12] + "-" + fixture.workspaceVolumeID[:12]
 	if workspaceVolume.GetPersistentName() != expectedPersistentName {
 		t.Fatalf("expected persistent name %q, got %q", expectedPersistentName, workspaceVolume.GetPersistentName())
 	}
@@ -274,9 +282,11 @@ func TestAssembleSandboxMountsPersistentWorkspace(t *testing.T) {
 	if labels[LabelSandboxOwnerID] != fixture.ownerID.String() {
 		t.Fatalf("unexpected workspace owner label: %v", labels)
 	}
-	if labels[LabelVolumeKey] != fixture.workspaceVolumeID {
-		t.Fatalf("unexpected workspace volume key label: %v", labels)
+	if labels[LabelEnvironmentID] != fixture.environmentID.String() {
+		t.Fatalf("unexpected workspace environment label: %v", labels)
 	}
+	// LabelVolumeKey is stamped when the volume record is built, which is after
+	// assembly, so it is asserted there rather than here.
 }
 
 func TestAssembleSandboxInjectsEnvironmentEnvsAndSecrets(t *testing.T) {

--- a/internal/assembler/sandbox_test.go
+++ b/internal/assembler/sandbox_test.go
@@ -122,7 +122,7 @@ func newSandboxFixture() *sandboxFixture {
 func (f *sandboxFixture) assemble(t *testing.T) *SandboxAssembleResult {
 	t.Helper()
 	assembler := NewWithRunnersAndEgressCA(f.agents, f.runners, f.secrets, f.cfg, f.egressCACert)
-	result, err := assembler.AssembleSandbox(context.Background(), f.sandbox, f.workspaceVolumeID)
+	result, err := assembler.AssembleSandbox(context.Background(), f.sandbox)
 	if err != nil {
 		t.Fatalf("assemble sandbox: %v", err)
 	}

--- a/internal/reconciler/desired.go
+++ b/internal/reconciler/desired.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
@@ -56,7 +57,19 @@ func (r *Reconciler) fetchDesired(ctx context.Context) ([]AgentInstanceTarget, m
 			return nil, nil, nil, fmt.Errorf("agent %s updated_at missing", agentID.String())
 		}
 		idleTimeouts[agentID] = idleTimeout
-		agentUpdatedAt[agentID] = updatedAt.AsTime().UTC()
+		configUpdatedAt := updatedAt.AsTime().UTC()
+		// A repaired environment must unblock every instance running it, not
+		// only those whose own class changed. An environment sub-resource write
+		// touches the environment, so its updated_at covers volumes, MCPs, init
+		// scripts and ENVs alike.
+		environmentUpdatedAt, err := r.environmentUpdatedAt(ctx, agent.GetEnvironmentId())
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if environmentUpdatedAt.After(configUpdatedAt) {
+			configUpdatedAt = environmentUpdatedAt
+		}
+		agentUpdatedAt[agentID] = configUpdatedAt
 	}
 	result := make([]AgentInstanceTarget, 0, len(unique))
 	for key := range unique {
@@ -242,4 +255,23 @@ func (r *Reconciler) addIdleTimeoutsForWorkloads(ctx context.Context, workloads 
 		idleTimeouts[agentID] = idleTimeout
 	}
 	return nil
+}
+
+// environmentUpdatedAt reports when an agent's environment last changed. A blank
+// id means the agent names none, which is not an error: agents predating
+// environments keep their inline configuration.
+func (r *Reconciler) environmentUpdatedAt(ctx context.Context, environmentID string) (time.Time, error) {
+	environmentID = strings.TrimSpace(environmentID)
+	if environmentID == "" {
+		return time.Time{}, nil
+	}
+	resp, err := r.agents.GetEnvironment(ctx, &agentsv1.GetEnvironmentRequest{Id: environmentID})
+	if err != nil {
+		return time.Time{}, fmt.Errorf("get environment %s: %w", environmentID, err)
+	}
+	updated := resp.GetEnvironment().GetMeta().GetUpdatedAt()
+	if updated == nil {
+		return time.Time{}, nil
+	}
+	return updated.AsTime().UTC(), nil
 }

--- a/internal/reconciler/interfaces.go
+++ b/internal/reconciler/interfaces.go
@@ -10,15 +10,17 @@ import (
 
 type agentsClient interface {
 	GetAgent(context.Context, *agentsv1.GetAgentRequest, ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+	GetEnvironment(context.Context, *agentsv1.GetEnvironmentRequest, ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error)
 	ListAgents(context.Context, *agentsv1.ListAgentsRequest, ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error)
 	ListInstances(context.Context, *agentsv1.ListInstancesRequest, ...grpc.CallOption) (*agentsv1.ListInstancesResponse, error)
 	GetUnackedInboxItems(context.Context, *agentsv1.GetUnackedInboxItemsRequest, ...grpc.CallOption) (*agentsv1.GetUnackedInboxItemsResponse, error)
 	PauseInstance(context.Context, *agentsv1.PauseInstanceRequest, ...grpc.CallOption) (*agentsv1.PauseInstanceResponse, error)
-	GetVolume(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
 	GetSandbox(context.Context, *agentsv1.GetSandboxRequest, ...grpc.CallOption) (*agentsv1.GetSandboxResponse, error)
 	ListSandboxes(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error)
 	UpdateSandboxRuntimeState(context.Context, *agentsv1.UpdateSandboxRuntimeStateRequest, ...grpc.CallOption) (*agentsv1.UpdateSandboxRuntimeStateResponse, error)
 	DeleteSandbox(context.Context, *agentsv1.DeleteSandboxRequest, ...grpc.CallOption) (*agentsv1.DeleteSandboxResponse, error)
+	// Read for a volume definition's TTL while reconciling provisioned disks.
+	GetVolume(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
 }
 
 type runnersClient interface {

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -1767,8 +1767,8 @@ func newTestAssembler(agentID uuid.UUID, zitiEnabled bool) *assembler.Assembler 
 		ListInitScriptsFunc: func(context.Context, *agentsv1.ListInitScriptsRequest, ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(context.Context, *agentsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{}, nil
@@ -1832,8 +1832,8 @@ func newTestEnvironmentAssembler(agentID, environmentID uuid.UUID, runnerID stri
 		ListInitScriptsFunc: func(context.Context, *agentsv1.ListInitScriptsRequest, ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
 			return &agentsv1.ListInitScriptsResponse{}, nil
 		},
-		ListVolumeAttachmentsFunc: func(context.Context, *agentsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			return &agentsv1.ListVolumesResponse{}, nil
 		},
 		ListMcpsFunc: func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
 			return &agentsv1.ListMcpsResponse{}, nil

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -1594,6 +1594,16 @@ func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
 	var runtimeReq *agentsv1.UpdateSandboxRuntimeStateRequest
 	var startedWorkloadID string
 	agents := &testutil.FakeAgentsClient{
+		// The environment declares a persistent volume, so one disk is recorded
+		// per sandbox that runs it.
+		ListVolumesFunc: func(_ context.Context, req *agentsv1.ListVolumesRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			if req.GetEnvironmentId() == environmentID {
+				return &agentsv1.ListVolumesResponse{Volumes: []*agentsv1.Volume{
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "workspace", MountPath: "/workspace", Persistent: true, Size: "10Gi"},
+				}}, nil
+			}
+			return &agentsv1.ListVolumesResponse{}, nil
+		},
 		GetEnvironmentFunc: func(_ context.Context, req *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
 			if req.GetId() != environmentID {
 				return nil, errors.New("unexpected environment id")
@@ -1835,6 +1845,16 @@ func TestStartSandboxWorkloadWritesRuntimeRunning(t *testing.T) {
 	flavorName := "ram-2gb"
 	var runtimeReq *agentsv1.UpdateSandboxRuntimeStateRequest
 	agents := &testutil.FakeAgentsClient{
+		// The environment declares a persistent volume, so one disk is recorded
+		// per sandbox that runs it.
+		ListVolumesFunc: func(_ context.Context, req *agentsv1.ListVolumesRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+			if req.GetEnvironmentId() == environmentID {
+				return &agentsv1.ListVolumesResponse{Volumes: []*agentsv1.Volume{
+					{Meta: &agentsv1.EntityMeta{Id: uuid.NewString()}, Name: "workspace", MountPath: "/workspace", Persistent: true, Size: "10Gi"},
+				}}, nil
+			}
+			return &agentsv1.ListVolumesResponse{}, nil
+		},
 		GetEnvironmentFunc: func(_ context.Context, req *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
 			if req.GetId() != environmentID {
 				return nil, errors.New("unexpected environment id")

--- a/internal/reconciler/sandbox_reconciler.go
+++ b/internal/reconciler/sandbox_reconciler.go
@@ -283,13 +283,7 @@ func (r *Reconciler) startSandboxWorkloadAttempt(ctx context.Context, plan *sand
 }
 
 func (r *Reconciler) startSandboxWorkload(ctx context.Context, plan *sandboxWorkloadPlan) error {
-	workspaceVolumeID := ""
-	if plan.workspaceVolume != nil {
-		workspaceVolumeID = plan.workspaceVolume.GetMeta().GetId()
-	} else {
-		workspaceVolumeID = uuid.NewString()
-	}
-	assembled, err := r.assembler.AssembleSandbox(ctx, plan.sandbox, workspaceVolumeID)
+	assembled, err := r.assembler.AssembleSandbox(ctx, plan.sandbox)
 	if err != nil {
 		return err
 	}
@@ -343,20 +337,18 @@ func (r *Reconciler) startSandboxWorkload(ctx context.Context, plan *sandboxWork
 		}
 	}
 	if plan.workspaceVolume == nil {
-		if err := r.createSandboxWorkspaceRecord(runnerCtx, assembled, runnerID); err != nil {
+		if err := r.createSandboxVolumeRecords(runnerCtx, assembled, runnerID); err != nil {
 			r.compensateIdentity(ctx, zitiIdentityID, "sandbox workspace record failure")
 			return err
 		}
 	}
 	if err := r.createSandboxWorkloadRecord(runnerCtx, workloadID, runnerID, assembled, zitiIdentityID); err != nil {
-		r.markSandboxWorkspaceFailed(runnerCtx, plan.workspaceVolume, workspaceVolumeID)
 		r.compensateIdentity(ctx, zitiIdentityID, "sandbox workload record failure")
 		return err
 	}
 	resp, err := runnerClient.StartWorkload(runnerCtx, request)
 	if err != nil {
 		r.markWorkloadFailed(runnerCtx, workloadID, nil, runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, err.Error(), nil)
-		r.markSandboxWorkspaceFailed(runnerCtx, plan.workspaceVolume, workspaceVolumeID)
 		r.compensateIdentity(ctx, zitiIdentityID, "sandbox start failure")
 		return err
 	}
@@ -370,7 +362,6 @@ func (r *Reconciler) startSandboxWorkload(ctx context.Context, plan *sandboxWork
 			}
 		}
 		r.markWorkloadFailed(runnerCtx, workloadID, stringPtr(instanceID), runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, failureMessage, containers)
-		r.markSandboxWorkspaceFailed(runnerCtx, plan.workspaceVolume, workspaceVolumeID)
 		r.compensateIdentity(ctx, zitiIdentityID, "sandbox workload failure")
 		return r.updateSandboxRuntimeState(ctx, plan.sandbox, agentsv1.SandboxStatus_SANDBOX_STATUS_FAILED, "", true)
 	}
@@ -381,7 +372,6 @@ func (r *Reconciler) startSandboxWorkload(ctx context.Context, plan *sandboxWork
 			}
 		}
 		r.markWorkloadFailed(runnerCtx, workloadID, stringPtr(instanceID), runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, "workload id mismatch", containers)
-		r.markSandboxWorkspaceFailed(runnerCtx, plan.workspaceVolume, workspaceVolumeID)
 		r.compensateIdentity(ctx, zitiIdentityID, "sandbox workload id mismatch")
 		return r.updateSandboxRuntimeState(ctx, plan.sandbox, agentsv1.SandboxStatus_SANDBOX_STATUS_FAILED, "", true)
 	}
@@ -491,19 +481,27 @@ func (r *Reconciler) createSandboxWorkloadRecord(ctx context.Context, workloadID
 	return err
 }
 
-func (r *Reconciler) createSandboxWorkspaceRecord(ctx context.Context, assembled *assembler.SandboxAssembleResult, runnerID string) error {
-	_, err := r.runners.CreateVolume(internalContext(ctx), &runnersv1.CreateVolumeRequest{
-		Id:             assembled.WorkspaceVolumeID,
-		RunnerId:       runnerID,
-		OrganizationId: assembled.OrganizationID,
-		SizeGb:         assembled.WorkspaceSizeGB,
-		Status:         runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
-		OwnerKind:      runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX,
-		OwnerId:        assembled.Request.GetAdditionalProperties()[assembler.LabelKeyPrefix+assembler.LabelSandboxID],
-	})
-	return err
+func (r *Reconciler) createSandboxVolumeRecords(ctx context.Context, assembled *assembler.SandboxAssembleResult, runnerID string) error {
+	records, err := buildVolumeRecords(assembled.PersistentVolumes)
+	if err != nil {
+		return err
+	}
+	for _, record := range records {
+		if _, err := r.runners.CreateVolume(internalContext(ctx), &runnersv1.CreateVolumeRequest{
+			Id:                 record.id,
+			RunnerId:           runnerID,
+			OrganizationId:     assembled.OrganizationID,
+			SizeGb:             record.sizeGB,
+			Status:             runnersv1.VolumeStatus_VOLUME_STATUS_PROVISIONING,
+			OwnerKind:          runnersv1.RuntimeOwnerKind_RUNTIME_OWNER_KIND_SANDBOX,
+			OwnerId:            assembled.Request.GetAdditionalProperties()[assembler.LabelKeyPrefix+assembler.LabelSandboxID],
+			VolumeDefinitionId: &record.volumeID,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
-
 func (r *Reconciler) createSandboxIdentity(ctx context.Context, sandboxID, environmentID, ownerID, workloadID uuid.UUID, organizationID string) (*identityInfo, error) {
 	if r.zitiMgmt == nil {
 		return nil, nil

--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -20,6 +20,7 @@ type FakeAgentsClient struct {
 	ListEnvsFunc                  func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error)
 	ListInitScriptsFunc           func(context.Context, *agentsv1.ListInitScriptsRequest, ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error)
 	ListVolumesFunc               func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error)
+	GetVolumeFunc                 func(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
 	ListMcpsFunc                  func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error)
 	GetSandboxFunc                func(context.Context, *agentsv1.GetSandboxRequest, ...grpc.CallOption) (*agentsv1.GetSandboxResponse, error)
 	ListSandboxesFunc             func(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error)
@@ -207,8 +208,20 @@ func (f *FakeAgentsClient) DeleteVolume(context.Context, *agentsv1.DeleteVolumeR
 	return nil, ErrNotImplemented
 }
 
-func (f *FakeAgentsClient) ListVolumes(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
-	return nil, ErrNotImplemented
+// An environment or MCP declaring no volumes is the ordinary case, so an unset
+// hook reports none rather than refusing.
+func (f *FakeAgentsClient) ListVolumes(ctx context.Context, req *agentsv1.ListVolumesRequest, opts ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+	if f.ListVolumesFunc != nil {
+		return f.ListVolumesFunc(ctx, req, opts...)
+	}
+	return &agentsv1.ListVolumesResponse{}, nil
+}
+
+func (f *FakeAgentsClient) GetVolume(ctx context.Context, req *agentsv1.GetVolumeRequest, opts ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error) {
+	if f.GetVolumeFunc != nil {
+		return f.GetVolumeFunc(ctx, req, opts...)
+	}
+	return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Meta: &agentsv1.EntityMeta{Id: req.GetId()}}}, nil
 }
 
 func (f *FakeAgentsClient) CreateVolumeAttachment(context.Context, *agentsv1.CreateVolumeAttachmentRequest, ...grpc.CallOption) (*agentsv1.CreateVolumeAttachmentResponse, error) {

--- a/internal/testutil/fake_clients.go
+++ b/internal/testutil/fake_clients.go
@@ -19,9 +19,8 @@ type FakeAgentsClient struct {
 	ListSkillsFunc                func(context.Context, *agentsv1.ListSkillsRequest, ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error)
 	ListEnvsFunc                  func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error)
 	ListInitScriptsFunc           func(context.Context, *agentsv1.ListInitScriptsRequest, ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error)
-	ListVolumeAttachmentsFunc     func(context.Context, *agentsv1.ListVolumeAttachmentsRequest, ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error)
+	ListVolumesFunc               func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error)
 	ListMcpsFunc                  func(context.Context, *agentsv1.ListMcpsRequest, ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error)
-	GetVolumeFunc                 func(context.Context, *agentsv1.GetVolumeRequest, ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
 	GetSandboxFunc                func(context.Context, *agentsv1.GetSandboxRequest, ...grpc.CallOption) (*agentsv1.GetSandboxResponse, error)
 	ListSandboxesFunc             func(context.Context, *agentsv1.ListSandboxesRequest, ...grpc.CallOption) (*agentsv1.ListSandboxesResponse, error)
 	UpdateSandboxRuntimeStateFunc func(context.Context, *agentsv1.UpdateSandboxRuntimeStateRequest, ...grpc.CallOption) (*agentsv1.UpdateSandboxRuntimeStateResponse, error)
@@ -200,13 +199,6 @@ func (f *FakeAgentsClient) CreateVolume(context.Context, *agentsv1.CreateVolumeR
 	return nil, ErrNotImplemented
 }
 
-func (f *FakeAgentsClient) GetVolume(ctx context.Context, req *agentsv1.GetVolumeRequest, opts ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error) {
-	if f.GetVolumeFunc != nil {
-		return f.GetVolumeFunc(ctx, req, opts...)
-	}
-	return nil, ErrNotImplemented
-}
-
 func (f *FakeAgentsClient) UpdateVolume(context.Context, *agentsv1.UpdateVolumeRequest, ...grpc.CallOption) (*agentsv1.UpdateVolumeResponse, error) {
 	return nil, ErrNotImplemented
 }
@@ -228,13 +220,6 @@ func (f *FakeAgentsClient) GetVolumeAttachment(context.Context, *agentsv1.GetVol
 }
 
 func (f *FakeAgentsClient) DeleteVolumeAttachment(context.Context, *agentsv1.DeleteVolumeAttachmentRequest, ...grpc.CallOption) (*agentsv1.DeleteVolumeAttachmentResponse, error) {
-	return nil, ErrNotImplemented
-}
-
-func (f *FakeAgentsClient) ListVolumeAttachments(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest, opts ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-	if f.ListVolumeAttachmentsFunc != nil {
-		return f.ListVolumeAttachmentsFunc(ctx, req, opts...)
-	}
 	return nil, ErrNotImplemented
 }
 


### PR DESCRIPTION
The assembler resolved volumes through attachment records and gave every sandbox
an implicit 10Gi disk at `/workspace` that no definition described.

- Volumes come from the environment: one set, mounted into the main container of
  every workload running it, agent or sandbox alike.
- An MCP mounts its own volumes plus the environment volumes named in
  `shared_volumes`, at the paths the main container uses. An unresolvable name or
  a path colliding with one of its own fails scheduling — a sidecar silently
  missing the files it was configured to read is worse than one that refuses to
  start. Neither case had coverage before.
- The implicit sandbox PVC is gone; records are written one per declared
  persistent volume per owner.
- The start decision folds in `environment.updated_at`, so a repaired
  environment unblocks every instance running it rather than only those whose own
  class changed. Computed where agents are already listed, not per instance.
- Agent workload identities carry `environment-<id>`, which sandbox identities
  always did. Without it an environment-targeted egress rule would apply to the
  sandboxes in an environment and silently not to the agents running there.
- `ENVIRONMENT_ID` is injected so agynd can fetch the environment's
  configuration; a sandbox has no agent to resolve it from.

Tests follow the model rather than the mechanism they used to assert: sharing
across containers is now `shared_volumes`, so it is tested there.

Requires agynio/agents#86.