### PR TITLE
Forward non-intercepted workload DNS upstream

### DIFF
--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -310,7 +310,8 @@ fi
 EOF
 chmod +x "${ziti_diverter}"
 export GODEBUG="netdns=go+1"
-exec "/usr/local/bin/ziti" "tunnel" "tproxy" --identity "${identity_file}" --svcPollRate "${ZITI_SIDECAR_SERVICE_POLL_RATE}" --resolver "udp://127.0.0.1:53" --diverter "${ziti_diverter}"`
+# Without an upstream the tunneler answers REFUSED for names it does not intercept, which c-ares clients treat as fatal.
+exec "/usr/local/bin/ziti" "tunnel" "tproxy" --identity "${identity_file}" --svcPollRate "${ZITI_SIDECAR_SERVICE_POLL_RATE}" --resolver "udp://127.0.0.1:53" --dnsUpstream "udp://${workload_dns_upstream}:53" --diverter "${ziti_diverter}"`
 	zitiRequiredCapabilityNetAdmin = "NET_ADMIN"
 	zitiRestartPolicyKey           = "restart_policy"
 	zitiRestartPolicyAlways        = "Always"

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -1888,8 +1888,8 @@ func TestZitiSidecarUsesWorkloadDNSForRuntimeAuth(t *testing.T) {
 	if strings.Contains(zitiSidecarScript, `openssl s_client`) {
 		t.Fatalf("expected sidecar startup not to fail before tunnel retry handling, got %q", zitiSidecarScript)
 	}
-	if strings.Contains(zitiSidecarScript, `--dnsUpstream`) {
-		t.Fatalf("expected sidecar script not to use unsupported dns upstream flag, got %q", zitiSidecarScript)
+	if !strings.Contains(zitiSidecarScript, `--dnsUpstream "udp://${workload_dns_upstream}:53"`) {
+		t.Fatalf("expected sidecar script to forward non-intercepted names upstream rather than refuse them, got %q", zitiSidecarScript)
 	}
 	if !strings.Contains(zitiSidecarScript, `--svcPollRate "${ZITI_SIDECAR_SERVICE_POLL_RATE}" --resolver "udp://127.0.0.1:53"`) {
 		t.Fatalf("expected sidecar script to enable service polling and supported DNS resolver, got %q", zitiSidecarScript)


### PR DESCRIPTION
The ziti tunneler's resolver defaults to `--dnsUnanswerable refused`, so it answers REFUSED for every name it does not intercept. With `ndots:5` the search-suffixed form is asked first, so `platform.claude.com.svc.cluster.local` is REFUSED before the real name is ever tried.

glibc treats REFUSED as "try the next nameserver" and walks on to cluster DNS, which is why `getent ahosts`, `dig`, and `curl` all looked healthy. A c-ares client treats it as fatal and stops — Claude Code reported it as `getaddrinfo EREFUSED platform.claude.com`.

Pass `--dnsUpstream` so the tunneler forwards those queries instead of refusing them. The flag is supported by the pinned `openziti/ziti-tunnel:2.0.0-pre8` image; the test that pinned it as unsupported is inverted.

Reproduction: `dig @127.0.0.1 platform.claude.com.svc.cluster.local` inside a workload returned `status: REFUSED`.