### PR TITLE
Render IMAGE_PROXY_HOST only when a domain is configured

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -86,7 +86,9 @@ env:
   # the only path a workload's images are pulled by, so leaving this empty
   # disables every catalog image reference rather than falling back to one.
   - name: IMAGE_PROXY_HOST
-    value: "registry.{{ .Values.global.ingress.baseDomain }}"
+    # Empty rather than "registry." when no domain is configured: the chart is
+    # linted and installed standalone, where global carries no ingress.
+    value: "{{ with .Values.global }}{{ with .ingress }}{{ with .baseDomain }}registry.{{ . }}{{ end }}{{ end }}{{ end }}"
   - name: METERING_SERVICE_ADDRESS
     value: ""
   - name: METERING_SAMPLE_INTERVAL


### PR DESCRIPTION
`helm lint` runs the chart standalone, where `.Values.global` carries no `ingress`, so `.Values.global.ingress.baseDomain` was a nil dereference and the v0.15.1 release failed at the chart step (the image published fine).

Guard it with `with` so the var renders `registry.<domain>` under the umbrella and empty without one — empty rather than a dangling `registry.`.