### PR TITLE
Take the generated protobuf from the sync, not the BSR

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -112,7 +112,7 @@ functions:
                     [ "$elapsed" -ge 240 ] && { echo "ERROR: sync timeout waiting for:${missing_files}" >&2; exit 1; }
                   done
                   [ -s /opt/app/data/buf.gen.yaml ] || { echo "ERROR: buf.gen.yaml is empty" >&2; exit 1; }
-                  buf generate buf.build/agynio/api \
+                  [ -d /opt/app/data/.gen ] || buf generate buf.build/agynio/api \
                     --include-imports \
                     --path agynio/api/runner/v1 \
                     --path agynio/api/runners/v1 \
@@ -258,13 +258,11 @@ dev:
             excludePaths:
               - .git/
               - .devspace/
-              - /.gen/
               - /tmp/
               - /.e2e-deps/
             uploadExcludePaths:
               - .git/
               - .devspace/
-              - /.gen/
               - /tmp/
               - /.e2e-deps/
             downloadExcludePaths:


### PR DESCRIPTION
Every container start regenerated from buf.build, so a pod that restarted often enough was rate limited out of building at all — `resource_exhausted`, crashloop, and each retry spent more of the budget that would have let it recover. The generated code is identical between starts, so the fetch bought nothing.

- `.gen` syncs up with the source (removed from `excludePaths` and `uploadExcludePaths`; still excluded from download so the pod never overwrites the local copy)
- `buf generate` runs only when `.gen` is absent

Also takes ~20s off every pod restart.