### PR TITLE
Ship the agynd that exports codex's event stream

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -141,7 +141,7 @@ env:
   - name: AGYND_RUNNERS_DIRECT_ADDRESS
     value: ""
   - name: AGYND_CLI_INIT_IMAGE
-    value: "ghcr.io/agynio/agynd-cli-init:0.14.37"
+    value: "ghcr.io/agynio/agynd-cli-init:0.14.41"
   - name: AGYN_CLI_INIT_IMAGE
     value: "ghcr.io/agynio/agyn-cli-init:0.3.0"
   - name: SANDBOX_INIT_IMAGE


### PR DESCRIPTION
0.14.41 carries the OTLP log exporter and the translation of codex's events into spans, which is what the run view reads. The chart default still named 0.14.37, so an install that did not override it deployed an agynd that emits none of it.

`bundle-vm` already pins 0.14.41; this brings the chart default in line.