### PR TITLE
Ship the agynd that provisions the CLI's first-run state

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -141,7 +141,7 @@ env:
   - name: AGYND_RUNNERS_DIRECT_ADDRESS
     value: ""
   - name: AGYND_CLI_INIT_IMAGE
-    value: "ghcr.io/agynio/agynd-cli-init:0.14.41"
+    value: "ghcr.io/agynio/agynd-cli-init:0.16.0"
   - name: AGYN_CLI_INIT_IMAGE
     value: "ghcr.io/agynio/agyn-cli-init:0.3.0"
   - name: SANDBOX_INIT_IMAGE


### PR DESCRIPTION
Bumps `AGYND_CLI_INIT_IMAGE` from `0.14.41` to `0.16.0`.

The pin is manual, and it had fallen two releases behind — `0.15.0` never reached a workload either.

[agynd-cli#173](https://github.com/agynio/agynd-cli/pull/173) is what makes this worth shipping: `agynd` now writes Claude Code's first-run state (`~/.claude.json`) and prepares the agent CLI in **holder mode**, so a sandbox shell starts into work instead of the onboarding wizard. It also sets `skipDangerousModePermissionPrompt`, without which the `bypassPermissions` mode we configure is silently downgraded to the default and tools stop for approval.