### PR TITLE
Mark the workload container as the sandbox it is

### DIFF
--- a/internal/assembler/egress_ca_apply.go
+++ b/internal/assembler/egress_ca_apply.go
@@ -6,7 +6,22 @@ func appendEgressCAEnvVars(envs []*runnerv1.EnvVar) []*runnerv1.EnvVar {
 	for _, env := range egressCAEnvVars() {
 		envs = appendPlatformEnvVar(envs, env)
 	}
-	return appendWorkloadPathEnvVar(envs)
+	envs = appendWorkloadPathEnvVar(envs)
+	return appendWorkloadSandboxEnvVar(envs)
+}
+
+// appendWorkloadSandboxEnvVar marks the container as the isolation boundary the
+// agent CLI is already inside.
+//
+// Claude Code refuses to run with bypassed permissions as root -- the container
+// runs as root, and the refusal is fatal rather than a downgrade. agynd sets
+// this for the subprocess it spawns, which covers an agent but not a sandbox,
+// where the shell comes from the runner's Exec against the pod and inherits the
+// container spec's environment instead. The claim is true either way: the
+// container is the sandbox, and the permission prompt it suppresses guards a
+// developer's own machine, not this one.
+func appendWorkloadSandboxEnvVar(envs []*runnerv1.EnvVar) []*runnerv1.EnvVar {
+	return appendPlatformEnvVar(envs, &runnerv1.EnvVar{Name: "IS_SANDBOX", Value: "1"})
 }
 
 // appendWorkloadPathEnvVar puts the platform's binaries on PATH for everything

--- a/internal/assembler/egress_ca_apply_test.go
+++ b/internal/assembler/egress_ca_apply_test.go
@@ -48,3 +48,18 @@ func TestWorkloadPathWinsOverAnEarlierValue(t *testing.T) {
 		t.Fatalf("PATH appears %d times", count)
 	}
 }
+
+// Claude Code refuses to run with bypassed permissions as root, and a sandbox
+// shell inherits the container spec rather than anything agynd assembled.
+func TestAppendEgressCAEnvVarsMarksTheContainerASandbox(t *testing.T) {
+	envs := appendEgressCAEnvVars(nil)
+	for _, env := range envs {
+		if env.GetName() == "IS_SANDBOX" {
+			if env.GetValue() != "1" {
+				t.Fatalf("IS_SANDBOX = %q, want 1", env.GetValue())
+			}
+			return
+		}
+	}
+	t.Fatalf("IS_SANDBOX not set: %v", envs)
+}


### PR DESCRIPTION
Fixes `--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons`, which stops Claude Code starting at all in a sandbox shell.

Nothing passes that flag. Claude Code applies the same guard to `permissionMode: "bypassPermissions"`, which `agynd` writes into `~/.claude/settings.json`:

```js
if (t === "bypassPermissions" || r) {
  if (process.getuid() === 0 && process.env.IS_SANDBOX !== "1" && !CLAUDE_CODE_BUBBLEWRAP) {
    console.error("--dangerously-skip-permissions cannot be used with root/sudo privileges…")
    process.exit(1)
  }
}
```

Workloads run as root, so it exits. The guard was latent until [agynd-cli#173](https://github.com/agynio/agynd-cli/pull/173) added `skipDangerousModePermissionPrompt`: before that the mode was downgraded to the default *before* this check ran, so it never fired. Making the mode take effect brought the check with it.

`agynd` already sets `IS_SANDBOX=1` for the subprocess it spawns, so agents were never affected. A sandbox shell comes from the runner's `Exec` against the pod and inherits the container spec's environment instead — the same reason `PATH` is set here, right next to this.

The claim is true either way: the container *is* the isolation boundary, and the prompt this suppresses exists to protect a developer's own machine.