### PR TITLE
Default the values every installation was restating

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -89,12 +89,19 @@ env:
     # Empty rather than "registry." when no domain is configured: the chart is
     # linted and installed standalone, where global carries no ingress.
     value: "{{ with .Values.global }}{{ with .ingress }}{{ with .baseDomain }}registry.{{ . }}{{ end }}{{ end }}{{ end }}"
+  # In-cluster name, like every other service address above it. Empty meant each
+  # installation restated the one value it could ever be.
   - name: METERING_SERVICE_ADDRESS
-    value: ""
+    value: "metering:50051"
   - name: METERING_SAMPLE_INTERVAL
     value: "60s"
+  # On: an agent workload reaches the Gateway only over the overlay, and with
+  # this off the orchestrator builds no ziti-management client, so createIdentity
+  # returns nil and the workload dies on "produced zero addresses". Every install
+  # that ships the overlay wants it, so it is the default rather than something
+  # each one repeats.
   - name: ZITI_ENABLED
-    value: "false"
+    value: "true"
   - name: ZITI_LEASE_RENEWAL_INTERVAL
     value: "2m"
   - name: ZITI_ENROLLMENT_TIMEOUT
@@ -103,12 +110,15 @@ env:
     value: "openziti/ziti-tunnel:2.0.0-pre8"
   - name: ZITI_MANAGEMENT_ADDRESS
     value: "ziti-management:50051"
+  # Users, apps and agents group-sync against this service; with it off,
+  # create-user and create-agent block about thirty seconds on a downstream
+  # timeout, so the working configuration is the default one.
   - name: GROUP_SYNC_ENABLED
-    value: "false"
+    value: "true"
   - name: GROUPS_ADDRESS
     value: "groups:50051"
   - name: NATS_URL
-    value: ""
+    value: "nats://nats:4222"
   # Upstream DNS resolver used by the workload Ziti tunnel after enrollment.
   - name: WORKLOAD_DNS_UPSTREAM
     value: ""
@@ -158,8 +168,12 @@ env:
     value: ""
   - name: LEASE_NAME
     value: ""
+  # The CA lives beside this service, so the release namespace is the answer in
+  # every install. service-base templates env values, so it is derived rather
+  # than named by each one -- a literal here silently reads the wrong namespace
+  # when the release moves.
   - name: EGRESS_CA_NAMESPACE
-    value: ""
+    value: "{{ .Release.Namespace }}"
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""


### PR DESCRIPTION
Found auditing why the bundled VM's values file is 507 lines.

The umbrella replaces this chart's `env` list wholesale rather than adding to it, so every installation has to restate all forty entries just to keep the ones it does not care about. The bundled VM's copy restates thirty-five — and it had already drifted:

- `AGYND_CLI_INIT_IMAGE` pinned **0.14.41** against the **0.16.0** this chart ships
- `SANDBOX_INIT_IMAGE`, `CLUSTER_DNS`, `LEASE_NAME`, `STOP_TIMEOUT_SEC`, `SANDBOX_WORKSPACE_SIZE_GB`, `SANDBOX_RECONCILE_ORGANIZATION_IDS` and both `AGYND_*_DIRECT_ADDRESS` dropped entirely — they are simply absent on the running deployment

## What changes

Values that are the same in every install become defaults, so nothing downstream has to name them:

| Key | Was | Now |
|---|---|---|
| `ZITI_ENABLED` | `false` | `true` — an agent reaches the Gateway only over the overlay; off, `createIdentity` returns nil and the workload dies on "produced zero addresses" |
| `GROUP_SYNC_ENABLED` | `false` | `true` — off, create-user and create-agent block ~30s on a downstream timeout |
| `NATS_URL` | empty | `nats://nats:4222` |
| `METERING_SERVICE_ADDRESS` | empty | `metering:50051`, like every other address beside it |
| `EGRESS_CA_NAMESPACE` | empty | `{{ .Release.Namespace }}` — the CA lives beside this service, so a literal reads the wrong namespace when the release moves |

`AGENT_GATEWAY_ADDRESS` and `AGENT_TRACING_ADDRESS` stay empty on purpose: `config.go` picks coherent Ziti or cluster names from `ZITI_ENABLED`, so naming them is what installations were doing unnecessarily.

## Templating

service-base 0.1.5 runs `tpl` over env values, with a comment saying exactly this: *"an installation that names only its domain has to restate every hostname built from it."* `IMAGE_PROXY_HOST` already relied on it; `EGRESS_CA_NAMESPACE` now does too.

Rendered against `global.ingress.baseDomain=agyn.dev`: `IMAGE_PROXY_HOST=registry.agyn.dev`, `EGRESS_CA_NAMESPACE=agyn-platform`, `AGYND_CLI_INIT_IMAGE=0.16.0`.