### PR TITLE
Stop relaying a placeholder file it cannot interpret

### DIFF
--- a/internal/assembler/llmmode.go
+++ b/internal/assembler/llmmode.go
@@ -19,13 +19,6 @@ const placeholderCredential = "agyn-placeholder-not-a-credential"
 // per environment, or per attachment.
 const nativeRoleAttributePrefix = "llm-native-"
 
-// Where agynd looks for a file placeholder to write. One vendor per workload
-// can use the file kind today; a second would need these keyed by vendor.
-const (
-	placeholderFilePathEnv     = "LLM_PLACEHOLDER_FILE_PATH"
-	placeholderFileContentsEnv = "LLM_PLACEHOLDER_FILE_CONTENTS"
-)
-
 // LLMMode is what a workload needs to reach a model: the mode itself, the role
 // attributes that opt its identity into interception, and the environment
 // variables the container carries.
@@ -101,20 +94,8 @@ func (a *Assembler) resolveLLMMode(ctx context.Context, environment *agentsv1.En
 				mode.EnvVars = append(mode.EnvVars, &runnerv1.EnvVar{Name: env, Value: placeholderCredential})
 			}
 		}
-		// A file placeholder is agynd's to write, and holder mode has no
-		// platform connection to fetch it over -- newHolderDaemon builds no
-		// clients at all. So the path and contents are relayed here, verbatim
-		// from the listing: the orchestrator does not read them and agynd does
-		// not derive them, which is what keeps the vendor table in one place.
-		// The contents are a placeholder, never a credential.
-		if attachment.GetPlaceholderKind() == llmv1.PlaceholderKind_PLACEHOLDER_KIND_FILE {
-			if path := attachment.GetPlaceholderPath(); path != "" {
-				mode.EnvVars = append(mode.EnvVars,
-					&runnerv1.EnvVar{Name: placeholderFilePathEnv, Value: path},
-					&runnerv1.EnvVar{Name: placeholderFileContentsEnv, Value: attachment.GetPlaceholderContents()},
-				)
-			}
-		}
+		// A CLI that reads its credential from a file is agynd's to serve: the
+		// path and shape follow from the CLI, which only agynd knows.
 	}
 	return mode, nil
 }

--- a/internal/assembler/llmmode_test.go
+++ b/internal/assembler/llmmode_test.go
@@ -284,18 +284,16 @@ func TestResolveLLMModeLeavesFilePlaceholdersToAgynd(t *testing.T) {
 		t.Fatalf("role attributes = %v", mode.RoleAttributes)
 	}
 
-	// The path and contents are relayed for agynd -- holder mode has no
-	// platform connection to fetch them over -- but the placeholder itself is
-	// never set as the credential variable the CLI reads.
+	// A file-reading CLI is served by agynd, which knows the path and shape.
+	// Nothing about it passes through the container spec.
 	values := map[string]string{}
 	for _, env := range mode.EnvVars {
 		values[env.GetName()] = env.GetValue()
 	}
-	if values[placeholderFilePathEnv] != ".codex/auth.json" {
-		t.Fatalf("relayed path = %q", values[placeholderFilePathEnv])
-	}
-	if values[placeholderFileContentsEnv] == "" {
-		t.Fatal("file contents were not relayed")
+	for name := range values {
+		if strings.HasPrefix(name, "LLM_PLACEHOLDER") {
+			t.Fatalf("relayed a CLI-specific placeholder: %s", name)
+		}
 	}
 	if _, ok := values["OPENAI_API_KEY"]; ok {
 		t.Fatal("a file placeholder was injected as a credential variable")


### PR DESCRIPTION
Removes the `LLM_PLACEHOLDER_FILE_PATH` / `LLM_PLACEHOLDER_FILE_CONTENTS` relay. `agynd` derives the file from the CLI it runs — see [agynd-cli#178](https://github.com/agynio/agynd-cli/pull/178).

The relay existed so `agynd` could get a document it had no way to construct, because the shape lived in the LLM service. It doesn't any more: the path and contents follow from the CLI, which only `agynd` knows. Passing them through here meant two services carrying CLI-specific bytes neither could interpret.

Unchanged: the `llm-native-<vendor>` role attribute, which is what opts a workload's identity into interception, and the environment-variable placeholder — that one has to be on the container spec, since a sandbox shell comes from the runner's `Exec` and inherits the spec's environment rather than any process's.