### PR TITLE
Remove the legacy init container

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -154,8 +154,6 @@ env:
     value: "ghcr.io/agynio/agynd-cli-init:0.16.0"
   - name: AGYN_CLI_INIT_IMAGE
     value: "ghcr.io/agynio/agyn-cli-init:0.3.0"
-  - name: SANDBOX_INIT_IMAGE
-    value: "ghcr.io/agynio/agent-init-codex:latest"
   - name: SANDBOX_WORKSPACE_SIZE_GB
     value: "10"
   - name: SANDBOX_RECONCILE_ORGANIZATION_IDS

--- a/internal/assembler/assembler.go
+++ b/internal/assembler/assembler.go
@@ -549,21 +549,18 @@ func (a *Assembler) Assemble(ctx context.Context, agentID, agentInstanceID, thre
 		InlineFileMounts: egressCAInlineFileMounts(a.egressCACert),
 	}
 	// Two chart-pinned platform init containers, then the environment's agent
-	// runtime. A workload whose environment names no runtime falls back to the
-	// agent's own init image, which carries all three today.
+	// runtime. Naming no runtime is refused rather than substituted: the
+	// substitute was the agent's own init image, and a workload assembled
+	// without a runtime starts and then has no CLI to spawn.
 	initContainers, err := a.platformInitContainers()
 	if err != nil {
 		return nil, err
 	}
-	if runtimeInit := a.agentRuntimeInitContainer(agentRuntimeImage); runtimeInit != nil {
-		initContainers = append(initContainers, runtimeInit)
-	} else {
-		legacy, err := a.legacyInitContainer(agent.GetInitImage())
-		if err != nil {
-			return nil, fmt.Errorf("agent %s: %w", agentID, err)
-		}
-		initContainers = append(initContainers, legacy)
+	runtimeInit := a.agentRuntimeInitContainer(agentRuntimeImage)
+	if runtimeInit == nil {
+		return nil, fmt.Errorf("agent %s: environment names no agent runtime image", agentID)
 	}
+	initContainers = append(initContainers, runtimeInit)
 	if a.cfg.ZitiEnabled {
 		if _, err := gatewayHost(a.cfg.AgentGatewayAddress); err != nil {
 			return nil, err

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -75,7 +75,8 @@ func TestAssemblerMainContainer(t *testing.T) {
 		AgyndRunnersDirectAddress: "10.42.0.11:50051",
 	}
 
-	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, &cfg)
+	withRuntimeEnvironment(agent, agentsClient, &cfg)
+	assembler := withCatalog(NewWithRunners(agentsClient, runnersWithDefaultFlavor(), &testutil.FakeSecretsClient{}, &cfg), agent.GetOrganizationId())
 	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -127,12 +128,12 @@ func TestAssemblerMainContainer(t *testing.T) {
 	if len(request.InitContainers) != 1 {
 		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
 	}
-	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
+	initContainer := testutil.FindInitContainer(request.InitContainers, agentRuntimeInit)
 	if initContainer == nil {
-		t.Fatal("expected agent-init init container")
+		t.Fatalf("expected the %s init container", agentRuntimeInit)
 	}
-	if initContainer.Image != agent.GetInitImage() {
-		t.Fatalf("expected init container image %q, got %q", agent.GetInitImage(), initContainer.Image)
+	if initContainer.Image != testResolvedRuntimeRef {
+		t.Fatalf("expected init container image %q, got %q", testResolvedRuntimeRef, initContainer.Image)
 	}
 	if len(initContainer.Mounts) != 1 {
 		t.Fatalf("expected 1 init container mount, got %d", len(initContainer.Mounts))
@@ -191,76 +192,6 @@ func TestAssemblerMainContainer(t *testing.T) {
 	}
 }
 
-func TestAssemblerReusesWorkspaceMount(t *testing.T) {
-	ctx := context.Background()
-	agentID := uuid.New()
-	threadID := uuid.New()
-	volumeID := uuid.New()
-	workspacePath := "/workspace"
-
-	agent := &agentsv1.Agent{
-		Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
-		OrganizationId: "org-1",
-		Image:          "agent-image",
-		InitImage:      "agent-init-image",
-	}
-
-	agentsClient := &testutil.FakeAgentsClient{
-		GetAgentFunc: func(_ context.Context, req *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
-			if req.GetId() != agentID.String() {
-				return nil, errors.New("unexpected agent id")
-			}
-			return &agentsv1.GetAgentResponse{Agent: agent}, nil
-		},
-		ListEnvsFunc: func(_ context.Context, _ *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
-			return &agentsv1.ListEnvsResponse{}, nil
-		},
-		ListVolumesFunc: func(_ context.Context, req *agentsv1.ListVolumesRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
-			if req.GetEnvironmentId() != "" {
-				return &agentsv1.ListVolumesResponse{Volumes: []*agentsv1.Volume{
-					{
-						Meta:       &agentsv1.EntityMeta{Id: volumeID.String()},
-						Name:       "workspace",
-						MountPath:  workspacePath,
-						Persistent: true,
-						Size:       "1Gi",
-					},
-				}}, nil
-			}
-			return &agentsv1.ListVolumesResponse{}, nil
-		},
-		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
-			return &agentsv1.ListMcpsResponse{}, nil
-		},
-	}
-
-	cfg := config.Config{
-		AgentGatewayAddress: "gateway:50051",
-		AgentLLMBaseURL:     "http://llm:8080/v1",
-	}
-
-	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, &cfg)
-	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
-	if err != nil {
-		t.Fatalf("assemble: %v", err)
-	}
-	request := result.Request
-	// Volumes belong to the environment. An agent without one declares none, so
-	// the only volume is the platform's own binary mount.
-	if len(request.Volumes) != 1 {
-		t.Fatalf("expected 1 volume, got %d", len(request.Volumes))
-	}
-	if findVolumeSpec(request.Volumes, agynBinVolumeName) == nil {
-		t.Fatalf("expected %s volume", agynBinVolumeName)
-	}
-	if findMountByPath(request.Main.Mounts, workspacePath) != nil {
-		t.Fatalf("expected no workspace mount without an environment declaring one")
-	}
-	if len(request.InitContainers) != 1 {
-		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
-	}
-}
-
 func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	ctx := context.Background()
 	agentID := uuid.New()
@@ -311,7 +242,8 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 		ZitiRuntimeControllerPort:           "443",
 	}
 
-	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, &cfg)
+	withRuntimeEnvironment(agent, agentsClient, &cfg)
+	assembler := withCatalog(NewWithRunners(agentsClient, runnersWithDefaultFlavor(), &testutil.FakeSecretsClient{}, &cfg), agent.GetOrganizationId())
 	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -349,12 +281,12 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if request.InitContainers[3].GetName() != zitiServiceWaitContainerName {
 		t.Fatalf("expected %s to be fourth init container", zitiServiceWaitContainerName)
 	}
-	if request.InitContainers[4].GetName() != "agent-init" {
-		t.Fatalf("expected agent-init to be fifth init container")
+	if request.InitContainers[4].GetName() != agentRuntimeInit {
+		t.Fatalf("expected %s to be fifth init container", agentRuntimeInit)
 	}
-	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
+	initContainer := testutil.FindInitContainer(request.InitContainers, agentRuntimeInit)
 	if initContainer == nil {
-		t.Fatal("expected agent-init container")
+		t.Fatalf("expected the %s container", agentRuntimeInit)
 	}
 	if len(request.Sidecars) != 0 {
 		t.Fatalf("expected 0 sidecars, got %d", len(request.Sidecars))
@@ -468,8 +400,8 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringMap(zitiSidecar.AdditionalProperties, expectedProperties) {
 		t.Fatalf("expected ziti sidecar properties %+v, got %+v", expectedProperties, zitiSidecar.AdditionalProperties)
 	}
-	if request.InitContainers[2].GetName() != zitiGatewayWaitContainerName || request.InitContainers[3].GetName() != zitiServiceWaitContainerName || request.InitContainers[4].GetName() != "agent-init" {
-		t.Fatalf("expected restartable ziti sidecar init to be followed by ziti wait containers and agent-init, got %s, %s, then %s", request.InitContainers[2].GetName(), request.InitContainers[3].GetName(), request.InitContainers[4].GetName())
+	if request.InitContainers[2].GetName() != zitiGatewayWaitContainerName || request.InitContainers[3].GetName() != zitiServiceWaitContainerName || request.InitContainers[4].GetName() != agentRuntimeInit {
+		t.Fatalf("expected restartable ziti sidecar init to be followed by ziti wait containers and %s, got %s, %s, then %s", agentRuntimeInit, request.InitContainers[2].GetName(), request.InitContainers[3].GetName(), request.InitContainers[4].GetName())
 	}
 	assertSameZitiIdentityMount(t, zitiSidecar)
 	zitiGatewayWait := testutil.FindInitContainer(request.InitContainers, zitiGatewayWaitContainerName)
@@ -584,117 +516,6 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 	assertEnv(t, envs, "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 }
 
-func TestAssemblerInitImageOverride(t *testing.T) {
-	ctx := context.Background()
-	agentID := uuid.New()
-	threadID := uuid.New()
-
-	agent := &agentsv1.Agent{
-		Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
-		OrganizationId: "org-1",
-		Image:          "agent-image",
-		InitImage:      "agent-init-image",
-	}
-
-	agentsClient := &testutil.FakeAgentsClient{
-		GetAgentFunc: func(_ context.Context, req *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
-			if req.GetId() != agentID.String() {
-				return nil, errors.New("unexpected agent id")
-			}
-			return &agentsv1.GetAgentResponse{Agent: agent}, nil
-		},
-		ListSkillsFunc: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
-			return &agentsv1.ListSkillsResponse{}, nil
-		},
-		ListEnvsFunc: func(_ context.Context, _ *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
-			return &agentsv1.ListEnvsResponse{}, nil
-		},
-		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
-			return &agentsv1.ListInitScriptsResponse{}, nil
-		},
-		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
-			return &agentsv1.ListVolumesResponse{}, nil
-		},
-		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
-			return &agentsv1.ListMcpsResponse{}, nil
-		},
-	}
-
-	cfg := config.Config{
-		AgentGatewayAddress: "gateway:50051",
-		AgentLLMBaseURL:     "http://llm:8080/v1",
-	}
-
-	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, &cfg)
-	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
-	if err != nil {
-		t.Fatalf("assemble: %v", err)
-	}
-	request := result.Request
-	if len(request.InitContainers) != 1 {
-		t.Fatalf("expected 1 init container, got %d", len(request.InitContainers))
-	}
-	initContainer := testutil.FindInitContainer(request.InitContainers, "agent-init")
-	if initContainer == nil {
-		t.Fatal("expected agent-init container")
-	}
-	if initContainer.Image != agent.GetInitImage() {
-		t.Fatalf("expected init image %q, got %q", agent.GetInitImage(), initContainer.Image)
-	}
-}
-
-func TestAssemblerErrorsOnEmptyInitImage(t *testing.T) {
-	ctx := context.Background()
-	agentID := uuid.New()
-	threadID := uuid.New()
-
-	agent := &agentsv1.Agent{
-		Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
-		OrganizationId: "org-1",
-		Image:          "agent-image",
-		InitImage:      "",
-	}
-
-	agentsClient := &testutil.FakeAgentsClient{
-		GetAgentFunc: func(_ context.Context, req *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
-			if req.GetId() != agentID.String() {
-				return nil, errors.New("unexpected agent id")
-			}
-			return &agentsv1.GetAgentResponse{Agent: agent}, nil
-		},
-		ListSkillsFunc: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
-			return &agentsv1.ListSkillsResponse{}, nil
-		},
-		ListEnvsFunc: func(_ context.Context, _ *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
-			return &agentsv1.ListEnvsResponse{}, nil
-		},
-		ListInitScriptsFunc: func(_ context.Context, _ *agentsv1.ListInitScriptsRequest, _ ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
-			return &agentsv1.ListInitScriptsResponse{}, nil
-		},
-		ListVolumesFunc: func(context.Context, *agentsv1.ListVolumesRequest, ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
-			return &agentsv1.ListVolumesResponse{}, nil
-		},
-		ListMcpsFunc: func(_ context.Context, _ *agentsv1.ListMcpsRequest, _ ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
-			return &agentsv1.ListMcpsResponse{}, nil
-		},
-	}
-
-	cfg := &config.Config{
-		AgentGatewayAddress: "gateway:50051",
-		AgentLLMBaseURL:     "http://llm:8080/v1",
-	}
-	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, cfg)
-	_, err := assembler.Assemble(ctx, agentID, threadID, threadID)
-	if err == nil {
-		t.Fatal("expected error for empty init image")
-	}
-	// An agent whose environment names no agent runtime still needs its own
-	// init image, since that is where its agent CLI comes from.
-	if !strings.Contains(err.Error(), "init image is required") {
-		t.Fatalf("expected an init image required error, got %q", err.Error())
-	}
-}
-
 func TestAssemblerResolvesSecretEnv(t *testing.T) {
 	ctx := context.Background()
 	agentID := uuid.New()
@@ -711,9 +532,10 @@ func TestAssemblerResolvesSecretEnv(t *testing.T) {
 		},
 	}
 
+	agent := &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image"}
 	agentsClient := &testutil.FakeAgentsClient{
 		GetAgentFunc: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
-			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image", InitImage: "agent-init-image"}}, nil
+			return &agentsv1.GetAgentResponse{Agent: agent}, nil
 		},
 		ListSkillsFunc: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
 			return &agentsv1.ListSkillsResponse{}, nil
@@ -738,10 +560,12 @@ func TestAssemblerResolvesSecretEnv(t *testing.T) {
 		},
 	}
 
-	assembler := New(agentsClient, secretsClient, &config.Config{
+	cfg := &config.Config{
 		AgentGatewayAddress: "gateway:50051",
 		AgentLLMBaseURL:     "http://llm:8080/v1",
-	})
+	}
+	withRuntimeEnvironment(agent, agentsClient, cfg)
+	assembler := withCatalog(NewWithRunners(agentsClient, runnersWithDefaultFlavor(), secretsClient, cfg), agent.GetOrganizationId())
 	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -762,9 +586,10 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 	mcpID := uuid.New()
 	volumeID := uuid.New()
 
+	agent := &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image"}
 	agentsClient := &testutil.FakeAgentsClient{
 		GetAgentFunc: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
-			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image", InitImage: "agent-init-image"}}, nil
+			return &agentsv1.GetAgentResponse{Agent: agent}, nil
 		},
 		ListSkillsFunc: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
 			return &agentsv1.ListSkillsResponse{}, nil
@@ -811,7 +636,8 @@ func TestAssemblerBuildsMcpSidecarAndVolumes(t *testing.T) {
 		AgentGatewayAddress: "gateway:50051",
 		AgentLLMBaseURL:     "http://llm:8080/v1",
 	}
-	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, cfg)
+	withRuntimeEnvironment(agent, agentsClient, cfg)
+	assembler := withCatalog(NewWithRunners(agentsClient, runnersWithDefaultFlavor(), &testutil.FakeSecretsClient{}, cfg), agent.GetOrganizationId())
 	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -928,15 +754,15 @@ func TestSharedVolumeReachesBothContainersOfTheAssembledPod(t *testing.T) {
 	mcpID := uuid.New()
 	volumeID := uuid.New()
 
+	agent := &agentsv1.Agent{
+		Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
+		OrganizationId: "org-1",
+		Image:          "agent-image",
+		EnvironmentId:  environmentID.String(),
+	}
 	agentsClient := &testutil.FakeAgentsClient{
 		GetAgentFunc: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
-			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{
-				Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
-				OrganizationId: "org-1",
-				Image:          "agent-image",
-				InitImage:      "agent-init-image",
-				EnvironmentId:  environmentID.String(),
-			}}, nil
+			return &agentsv1.GetAgentResponse{Agent: agent}, nil
 		},
 		GetEnvironmentFunc: func(_ context.Context, req *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
 			if req.GetId() != environmentID.String() {
@@ -949,6 +775,9 @@ func TestSharedVolumeReachesBothContainersOfTheAssembledPod(t *testing.T) {
 				Image:          "environment-image",
 				RunnerId:       testAgentEnvironmentRunnerID,
 				Flavor:         testAgentEnvironmentFlavor,
+				// Assembly refuses a workload whose environment names no runtime.
+				AgentRuntimeImageId:  testRuntimeImageID,
+				AgentRuntimeImageTag: testRuntimeImageTag,
 			}}, nil
 		},
 		ListSkillsFunc: func(context.Context, *agentsv1.ListSkillsRequest, ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
@@ -990,10 +819,14 @@ func TestSharedVolumeReachesBothContainersOfTheAssembledPod(t *testing.T) {
 			}}}, nil
 		},
 	}
-	assembler := NewWithRunners(agentsClient, runnersClient, &testutil.FakeSecretsClient{}, &config.Config{
+	cfg := &config.Config{
 		AgentGatewayAddress: "gateway:50051",
 		AgentLLMBaseURL:     "http://llm:8080/v1",
-	})
+	}
+	// This test wires its own environment, runner and flavor; it only needs the
+	// catalog that resolves the runtime image the environment names.
+	cfg.ImageProxyHost = testCatalogProxyHost
+	assembler := withCatalog(NewWithRunners(agentsClient, runnersClient, &testutil.FakeSecretsClient{}, cfg), agent.GetOrganizationId())
 	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -1086,9 +919,10 @@ func TestAssemblerMcpPortAllocation(t *testing.T) {
 	lowID := "11111111-1111-1111-1111-111111111111"
 	highID := "22222222-2222-2222-2222-222222222222"
 
+	agent := &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image"}
 	agentsClient := &testutil.FakeAgentsClient{
 		GetAgentFunc: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
-			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image", InitImage: "agent-init-image"}}, nil
+			return &agentsv1.GetAgentResponse{Agent: agent}, nil
 		},
 		ListSkillsFunc: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
 			return &agentsv1.ListSkillsResponse{}, nil
@@ -1114,7 +948,8 @@ func TestAssemblerMcpPortAllocation(t *testing.T) {
 		AgentGatewayAddress: "gateway:50051",
 		AgentLLMBaseURL:     "http://llm:8080/v1",
 	}
-	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, cfg)
+	withRuntimeEnvironment(agent, agentsClient, cfg)
+	assembler := withCatalog(NewWithRunners(agentsClient, runnersWithDefaultFlavor(), &testutil.FakeSecretsClient{}, cfg), agent.GetOrganizationId())
 	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -1155,9 +990,10 @@ func TestAssemblerNoMcpsNoAgentMcpServersEnv(t *testing.T) {
 	agentID := uuid.New()
 	threadID := uuid.New()
 
+	agent := &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image"}
 	agentsClient := &testutil.FakeAgentsClient{
 		GetAgentFunc: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
-			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image", InitImage: "agent-init-image"}}, nil
+			return &agentsv1.GetAgentResponse{Agent: agent}, nil
 		},
 		ListSkillsFunc: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
 			return &agentsv1.ListSkillsResponse{}, nil
@@ -1176,10 +1012,12 @@ func TestAssemblerNoMcpsNoAgentMcpServersEnv(t *testing.T) {
 		},
 	}
 
-	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, &config.Config{
+	cfg := &config.Config{
 		AgentGatewayAddress: "gateway:50051",
 		AgentLLMBaseURL:     "http://llm:8080/v1",
-	})
+	}
+	withRuntimeEnvironment(agent, agentsClient, cfg)
+	assembler := withCatalog(NewWithRunners(agentsClient, runnersWithDefaultFlavor(), &testutil.FakeSecretsClient{}, cfg), agent.GetOrganizationId())
 	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -1297,9 +1135,10 @@ func TestAssemblerDistributesEgressCA(t *testing.T) {
 	mcpID := uuid.New()
 	cert := []byte("test-ca")
 
+	agent := &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image"}
 	agentsClient := &testutil.FakeAgentsClient{
 		GetAgentFunc: func(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
-			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Meta: &agentsv1.EntityMeta{Id: agentID.String()}, OrganizationId: "org-1", Image: "agent-image", InitImage: "agent-init-image"}}, nil
+			return &agentsv1.GetAgentResponse{Agent: agent}, nil
 		},
 		ListSkillsFunc: func(_ context.Context, _ *agentsv1.ListSkillsRequest, _ ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
 			return &agentsv1.ListSkillsResponse{}, nil
@@ -1318,7 +1157,7 @@ func TestAssemblerDistributesEgressCA(t *testing.T) {
 		},
 	}
 
-	assembler := NewWithEgressCA(agentsClient, &testutil.FakeSecretsClient{}, &config.Config{
+	cfg := &config.Config{
 		AgentGatewayAddress:              "gateway:50051",
 		AgentLLMBaseURL:                  "http://llm:8080/v1",
 		ZitiEnabled:                      true,
@@ -1327,7 +1166,9 @@ func TestAssemblerDistributesEgressCA(t *testing.T) {
 		ZitiEnrollmentDNSUpstream:        "10.43.0.10",
 		ZitiRuntimeControllerResolveHost: "istio-ingressgateway.istio-gateway.svc.cluster.local",
 		ZitiRuntimeControllerPort:        "443",
-	}, cert)
+	}
+	withRuntimeEnvironment(agent, agentsClient, cfg)
+	assembler := withCatalog(NewWithRunnersAndEgressCA(agentsClient, runnersWithDefaultFlavor(), &testutil.FakeSecretsClient{}, cfg, cert), agent.GetOrganizationId())
 	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -2003,6 +1844,9 @@ func newAgentEnvironmentFixture() *agentEnvironmentFixture {
 				Image:          testAgentEnvironmentImage,
 				RunnerId:       testAgentEnvironmentRunnerID,
 				Flavor:         testAgentEnvironmentFlavor,
+				// Assembly refuses a workload whose environment names no runtime.
+				AgentRuntimeImageId:  testRuntimeImageID,
+				AgentRuntimeImageTag: testRuntimeImageTag,
 			}}, nil
 		},
 		ListEnvsFunc: func(context.Context, *agentsv1.ListEnvsRequest, ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
@@ -2031,7 +1875,8 @@ func newAgentEnvironmentFixture() *agentEnvironmentFixture {
 
 func (f *agentEnvironmentFixture) assemble(t *testing.T) *AssembleResult {
 	t.Helper()
-	assembler := NewWithRunners(f.agents, f.runners, f.secrets, f.cfg)
+	f.cfg.ImageProxyHost = testCatalogProxyHost
+	assembler := withCatalog(NewWithRunners(f.agents, f.runners, f.secrets, f.cfg), "org-1")
 	result, err := assembler.Assemble(context.Background(), f.agentID, f.threadID, f.threadID)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -2058,44 +1903,15 @@ func TestAssemblerUsesEnvironmentImageAndRunner(t *testing.T) {
 	if result.Flavor != testAgentEnvironmentFlavor {
 		t.Fatalf("expected environment flavor %q, got %q", testAgentEnvironmentFlavor, result.Flavor)
 	}
-	// The init image stays the agent's: an environment supplies the runtime an
-	// agent runs in, not the bootstrap that seeds it.
-	initContainer := testutil.FindInitContainer(result.Request.GetInitContainers(), "agent-init")
-	if initContainer == nil || initContainer.GetImage() != "agent-init-image" {
-		t.Fatalf("expected the agent's init image, got %+v", initContainer)
+	// The runtime the environment names is what seeds the workload: there is no
+	// longer an agent-supplied init image to fall back to.
+	initContainer := testutil.FindInitContainer(result.Request.GetInitContainers(), agentRuntimeInit)
+	if initContainer == nil {
+		t.Fatalf("expected the %s init container", agentRuntimeInit)
 	}
 	// Carried out of assembly so the reconciler can record it on the workload's
 	// OpenZiti identity.
 	if result.EnvironmentID != fixture.agent.GetEnvironmentId() {
 		t.Fatalf("expected environment id %q, got %q", fixture.agent.GetEnvironmentId(), result.EnvironmentID)
-	}
-}
-
-func TestAssemblerWithoutEnvironmentKeepsAgentImageAndPlacement(t *testing.T) {
-	fixture := newAgentEnvironmentFixture()
-	fixture.agent.EnvironmentId = ""
-	// Agents predating environments must not reach for one at all.
-	fixture.agents.GetEnvironmentFunc = func(context.Context, *agentsv1.GetEnvironmentRequest, ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
-		return nil, errors.New("unexpected environment lookup")
-	}
-	fixture.agents.ListEnvsFunc = func(_ context.Context, req *agentsv1.ListEnvsRequest, _ ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
-		if req.GetEnvironmentId() != "" {
-			return nil, errors.New("unexpected environment-scoped env listing")
-		}
-		return &agentsv1.ListEnvsResponse{}, nil
-	}
-	fixture.runners.listFlavors = func(context.Context, *runnersv1.ListFlavorsRequest, ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
-		return nil, errors.New("unexpected flavor lookup")
-	}
-
-	result := fixture.assemble(t)
-
-	if result.Request.GetMain().GetImage() != testAgentInlineImage {
-		t.Fatalf("expected the agent's inline image %q, got %q", testAgentInlineImage, result.Request.GetMain().GetImage())
-	}
-	// An empty runner id is what keeps these agents on label and capability
-	// selection in the reconciler.
-	if result.RunnerID != "" {
-		t.Fatalf("expected no environment runner, got %q", result.RunnerID)
 	}
 }

--- a/internal/assembler/catalog_test.go
+++ b/internal/assembler/catalog_test.go
@@ -1,0 +1,101 @@
+package assembler
+
+import (
+	"context"
+
+	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
+	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
+	"github.com/agynio/agents-orchestrator/internal/config"
+	"github.com/agynio/agents-orchestrator/internal/testutil"
+	"github.com/google/uuid"
+
+	imagesv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/images/v1"
+	organizationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/organizations/v1"
+	"google.golang.org/grpc"
+)
+
+// The catalog an environment's runtime image resolves through. Every workload
+// needs one now that naming no runtime is refused, so these stand in for the
+// two services the rewriter reads.
+type fakeImagesClient struct {
+	name           string
+	organizationID string
+}
+
+func (f *fakeImagesClient) GetImage(_ context.Context, req *imagesv1.GetImageRequest, _ ...grpc.CallOption) (*imagesv1.GetImageResponse, error) {
+	return &imagesv1.GetImageResponse{Image: &imagesv1.Image{
+		Meta:           &imagesv1.EntityMeta{Id: req.GetId()},
+		Name:           f.name,
+		OrganizationId: f.organizationID,
+	}}, nil
+}
+
+type fakeOrganizationsClient struct {
+	slug string
+}
+
+func (f *fakeOrganizationsClient) GetOrganization(_ context.Context, req *organizationsv1.GetOrganizationRequest, _ ...grpc.CallOption) (*organizationsv1.GetOrganizationResponse, error) {
+	return &organizationsv1.GetOrganizationResponse{Organization: &organizationsv1.Organization{
+		Id:   req.GetId(),
+		Slug: f.slug,
+	}}, nil
+}
+
+const (
+	testCatalogProxyHost   = "registry.agyn.test"
+	testCatalogOrgSlug     = "org-one"
+	testRuntimeImageName   = "agent-runtime"
+	testRuntimeImageTag    = "1.0.0"
+	testCatalogRunnerID    = "11111111-1111-1111-1111-111111111111"
+	testRuntimeImageID     = "22222222-2222-2222-2222-222222222222"
+	testResolvedRuntimeRef = testCatalogProxyHost + "/" + testCatalogOrgSlug + "/" + testRuntimeImageName + ":" + testRuntimeImageTag
+)
+
+// withCatalog wires an assembler to resolve the runtime image an environment
+// names. Assembly refuses a workload without one, so a test that assembles at
+// all needs this.
+func withCatalog(a *Assembler, organizationID string) *Assembler {
+	return a.WithCatalog(
+		&fakeImagesClient{name: testRuntimeImageName, organizationID: organizationID},
+		&fakeOrganizationsClient{slug: testCatalogOrgSlug},
+		nil,
+	)
+}
+
+// withRuntimeEnvironment gives an agent the environment assembly now requires:
+// one naming a runtime image, resolved through the catalog. The environment
+// carries the agent's own image so a test asserting on the main container still
+// sees what it set.
+func withRuntimeEnvironment(agent *agentsv1.Agent, client *testutil.FakeAgentsClient, cfg *config.Config) {
+	environmentID := uuid.NewString()
+	agent.EnvironmentId = environmentID
+	cfg.ImageProxyHost = testCatalogProxyHost
+	client.GetEnvironmentFunc = func(_ context.Context, _ *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
+		return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{
+			Meta:                 &agentsv1.EntityMeta{Id: environmentID},
+			OrganizationId:       agent.GetOrganizationId(),
+			Image:                agent.GetImage(),
+			RunnerId:             testCatalogRunnerID,
+			AgentRuntimeImageId:  testRuntimeImageID,
+			AgentRuntimeImageTag: testRuntimeImageTag,
+		}}, nil
+	}
+}
+
+// runnersWithDefaultFlavor serves the one flavor an environment's runner needs.
+// Naming no flavor takes the runner's default, which is what these tests want:
+// they assert on containers, not on placement.
+func runnersWithDefaultFlavor() *fakeRunnersClient {
+	return &fakeRunnersClient{
+		listFlavors: func(context.Context, *runnersv1.ListFlavorsRequest, ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{{
+				Name:    "default",
+				Default: true,
+				Resources: &runnersv1.ComputeResources{
+					RequestsCpu:    "500m",
+					RequestsMemory: "512Mi",
+				},
+			}}}, nil
+		},
+	}
+}

--- a/internal/assembler/initcontainers.go
+++ b/internal/assembler/initcontainers.go
@@ -1,7 +1,6 @@
 package assembler
 
 import (
-	"fmt"
 	"strings"
 
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
@@ -18,7 +17,6 @@ const (
 	agyndCLIInitName    = "agynd-cli-init"
 	agynCLIInitName     = "agyn-cli-init"
 	agentRuntimeInit    = "agent-runtime"
-	legacyAgentInitName = "agent-init"
 )
 
 // platformInitContainers builds the two chart-pinned init containers every
@@ -72,20 +70,3 @@ func (a *Assembler) agentRuntimeInitContainer(image string) *runnerv1.ContainerS
 	return container
 }
 
-// legacyInitContainer is the single init container a workload got before the
-// platform binaries were split out. It is used when the environment names no
-// agent runtime image, which is every workload still on the free-form image.
-func (a *Assembler) legacyInitContainer(image string) (*runnerv1.ContainerSpec, error) {
-	if strings.TrimSpace(image) == "" {
-		return nil, fmt.Errorf("init image is required when the environment names no agent runtime image")
-	}
-	container := &runnerv1.ContainerSpec{
-		Image: image,
-		Name:  legacyAgentInitName,
-		Mounts: []*runnerv1.VolumeMount{
-			{Volume: agynBinVolumeName, MountPath: agynBinMountPath},
-		},
-	}
-	applyEgressCA(container, a.egressCACert)
-	return container, nil
-}

--- a/internal/assembler/initcontainers_test.go
+++ b/internal/assembler/initcontainers_test.go
@@ -60,18 +60,3 @@ func TestAgentRuntimeInitContainer(t *testing.T) {
 		t.Fatalf("image = %q, want the proxy reference unchanged", container.GetImage())
 	}
 }
-
-func TestLegacyInitContainerRequiresAnImage(t *testing.T) {
-	a := assemblerWithInitImages("", "")
-
-	if _, err := a.legacyInitContainer(""); err == nil {
-		t.Fatal("expected an empty init image to be refused")
-	}
-	container, err := a.legacyInitContainer("ghcr.io/agynio/agent-init-codex:latest")
-	if err != nil {
-		t.Fatalf("legacyInitContainer: %v", err)
-	}
-	if container.GetName() != legacyAgentInitName {
-		t.Fatalf("name = %q", container.GetName())
-	}
-}

--- a/internal/assembler/resources_test.go
+++ b/internal/assembler/resources_test.go
@@ -68,7 +68,8 @@ func TestAssemblerAggregatesResourceRequests(t *testing.T) {
 		AgentGatewayAddress: "gateway:50051",
 		AgentLLMBaseURL:     "http://llm:8080/v1",
 	}
-	assembler := New(agentsClient, &testutil.FakeSecretsClient{}, &cfg)
+	withRuntimeEnvironment(agent, agentsClient, &cfg)
+	assembler := withCatalog(NewWithRunners(agentsClient, runnersWithDefaultFlavor(), &testutil.FakeSecretsClient{}, &cfg), agent.GetOrganizationId())
 
 	result, err := assembler.Assemble(ctx, agentID, threadID, threadID)
 	if err != nil {

--- a/internal/assembler/sandbox.go
+++ b/internal/assembler/sandbox.go
@@ -140,12 +140,6 @@ func (a *Assembler) AssembleSandbox(ctx context.Context, sandbox *agentsv1.Sandb
 	}
 	if runtimeInit := a.agentRuntimeInitContainer(agentRuntimeImage); runtimeInit != nil {
 		initContainers = append(initContainers, runtimeInit)
-	} else if len(initContainers) == 0 {
-		legacy, err := a.legacyInitContainer(a.cfg.SandboxInitImage)
-		if err != nil {
-			return nil, fmt.Errorf("sandbox: %w", err)
-		}
-		initContainers = append(initContainers, legacy)
 	}
 	// Provisioned disks are attributed to the sandbox that owns them, which is
 	// what volume reconciliation and metering read.

--- a/internal/assembler/sandbox_test.go
+++ b/internal/assembler/sandbox_test.go
@@ -65,7 +65,6 @@ func newSandboxFixture() *sandboxFixture {
 			AgentGatewayAddress:    testSandboxGatewayURL,
 			AgentLLMBaseURL:        "http://llm:8080/v1",
 			AgentTracingAddress:    "tracing:50051",
-			SandboxInitImage:       testSandboxInitImage,
 			SandboxWorkspaceSizeGB: testSandboxSizeGB,
 		},
 	}
@@ -90,6 +89,10 @@ func newSandboxFixture() *sandboxFixture {
 				Image:          testSandboxImage,
 				RunnerId:       testSandboxRunnerID,
 				Flavor:         testSandboxFlavor,
+				// Assembly no longer substitutes a legacy image, so the
+				// environment names the runtime the sandbox seeds from.
+				AgentRuntimeImageId:  testRuntimeImageID,
+				AgentRuntimeImageTag: testRuntimeImageTag,
 			}}, nil
 		},
 		ListVolumesFunc: func(_ context.Context, req *agentsv1.ListVolumesRequest, _ ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
@@ -135,7 +138,8 @@ func newSandboxFixture() *sandboxFixture {
 
 func (f *sandboxFixture) assemble(t *testing.T) *SandboxAssembleResult {
 	t.Helper()
-	assembler := NewWithRunnersAndEgressCA(f.agents, f.runners, f.secrets, f.cfg, f.egressCACert)
+	f.cfg.ImageProxyHost = testCatalogProxyHost
+	assembler := withCatalog(NewWithRunnersAndEgressCA(f.agents, f.runners, f.secrets, f.cfg, f.egressCACert), "org-1")
 	result, err := assembler.AssembleSandbox(context.Background(), f.sandbox)
 	if err != nil {
 		t.Fatalf("assemble sandbox: %v", err)
@@ -228,8 +232,8 @@ func TestAssembleSandboxRunsInitContainerAndHolderCommand(t *testing.T) {
 		t.Fatalf("expected 1 init container, got %d", len(initContainers))
 	}
 	initContainer := initContainers[0]
-	if initContainer.GetImage() != testSandboxInitImage {
-		t.Fatalf("expected init image %q, got %q", testSandboxInitImage, initContainer.GetImage())
+	if initContainer.GetImage() != testResolvedRuntimeRef {
+		t.Fatalf("expected init image %q, got %q", testResolvedRuntimeRef, initContainer.GetImage())
 	}
 	initMount := findVolumeMount(initContainer, agynBinVolumeName)
 	if initMount == nil || initMount.GetMountPath() != agynBinMountPath {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,6 @@ type Config struct {
 	AgentLLMBaseURL                     string
 	AgyndAgentsDirectAddress            string
 	AgyndRunnersDirectAddress           string
-	SandboxInitImage                    string
 	// The two platform init images, injected into every workload. They are not
 	// a configuration surface: an agent's behaviour is configured through the
 	// agent, and the platform's own binaries are not a choice anyone makes.
@@ -151,10 +150,6 @@ func FromEnv() (Config, error) {
 	cfg.ImagesAddress = os.Getenv("IMAGES_ADDRESS")
 	cfg.OrganizationsAddress = os.Getenv("ORGANIZATIONS_ADDRESS")
 	cfg.ImageProxyAddress = os.Getenv("IMAGE_PROXY_ADDRESS")
-	cfg.SandboxInitImage = os.Getenv("SANDBOX_INIT_IMAGE")
-	if cfg.SandboxInitImage == "" {
-		cfg.SandboxInitImage = "ghcr.io/agynio/agent-init-codex:latest"
-	}
 	cfg.SandboxWorkspaceSizeGB = os.Getenv("SANDBOX_WORKSPACE_SIZE_GB")
 	if cfg.SandboxWorkspaceSizeGB == "" {
 		cfg.SandboxWorkspaceSizeGB = "10"

--- a/internal/reconciler/lifecycle_test.go
+++ b/internal/reconciler/lifecycle_test.go
@@ -11,6 +11,8 @@ import (
 	agentsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/agents/v1"
 	groupsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/groups/v1"
 	identityv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/identity/v1"
+	imagesv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/images/v1"
+	organizationsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/organizations/v1"
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runners/v1"
 	threadsv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/threads/v1"
@@ -1755,7 +1757,7 @@ func newTestAssembler(agentID uuid.UUID, zitiEnabled bool) *assembler.Assembler 
 				Meta:           &agentsv1.EntityMeta{Id: agentID.String()},
 				OrganizationId: testOrganizationID,
 				Image:          "agent-image",
-				InitImage:      "agent-init-image",
+				EnvironmentId:  testAssemblerEnvironmentID,
 				Resources: &agentsv1.ComputeResources{
 					RequestsCpu:    "500m",
 					RequestsMemory: "1Gi",
@@ -1791,7 +1793,58 @@ func newTestAssembler(agentID uuid.UUID, zitiEnabled bool) *assembler.Assembler 
 		ZitiRuntimeControllerResolveHost:    "istio-ingressgateway.istio-gateway.svc.cluster.local",
 		ZitiRuntimeControllerPort:           "443",
 	}
-	return assembler.New(agentsClient, &testutil.FakeSecretsClient{}, cfg)
+	cfg.ImageProxyHost = testAssemblerProxyHost
+	agentsClient.GetEnvironmentFunc = func(_ context.Context, _ *agentsv1.GetEnvironmentRequest, _ ...grpc.CallOption) (*agentsv1.GetEnvironmentResponse, error) {
+		return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{
+			Meta:                 &agentsv1.EntityMeta{Id: testAssemblerEnvironmentID},
+			OrganizationId:       testOrganizationID,
+			Image:                "agent-image",
+			RunnerId:             testAssemblerRunnerID,
+			AgentRuntimeImageId:  testAssemblerRuntimeImageID,
+			AgentRuntimeImageTag: "1.0.0",
+		}}, nil
+	}
+	runners := &fakeRunnersClient{
+		listFlavors: func(context.Context, *runnersv1.ListFlavorsRequest, ...grpc.CallOption) (*runnersv1.ListFlavorsResponse, error) {
+			return &runnersv1.ListFlavorsResponse{Flavors: []*runnersv1.Flavor{{
+				Name:    "default",
+				Default: true,
+				Resources: &runnersv1.ComputeResources{
+					RequestsCpu:    "500m",
+					RequestsMemory: "1Gi",
+				},
+			}}}, nil
+		},
+	}
+	return assembler.NewWithRunners(agentsClient, runners, &testutil.FakeSecretsClient{}, cfg).
+		WithCatalog(&fakeImagesClient{}, &fakeOrganizationsClient{}, nil)
+}
+
+const (
+	testAssemblerEnvironmentID  = "33333333-3333-3333-3333-333333333333"
+	testAssemblerRunnerID       = "44444444-4444-4444-4444-444444444444"
+	testAssemblerRuntimeImageID = "55555555-5555-5555-5555-555555555555"
+	testAssemblerProxyHost      = "registry.agyn.test"
+)
+
+// The catalog the environment's runtime image resolves through.
+type fakeImagesClient struct{}
+
+func (f *fakeImagesClient) GetImage(_ context.Context, req *imagesv1.GetImageRequest, _ ...grpc.CallOption) (*imagesv1.GetImageResponse, error) {
+	return &imagesv1.GetImageResponse{Image: &imagesv1.Image{
+		Meta:           &imagesv1.EntityMeta{Id: req.GetId()},
+		Name:           "agent-runtime",
+		OrganizationId: testOrganizationID,
+	}}, nil
+}
+
+type fakeOrganizationsClient struct{}
+
+func (f *fakeOrganizationsClient) GetOrganization(_ context.Context, req *organizationsv1.GetOrganizationRequest, _ ...grpc.CallOption) (*organizationsv1.GetOrganizationResponse, error) {
+	return &organizationsv1.GetOrganizationResponse{Organization: &organizationsv1.Organization{
+		Id:   req.GetId(),
+		Slug: "org-one",
+	}}, nil
 }
 
 // newTestEnvironmentAssembler builds an assembler for an agent that runs in an
@@ -1820,11 +1873,13 @@ func newTestEnvironmentAssembler(agentID, environmentID uuid.UUID, runnerID stri
 				return nil, errors.New("unexpected environment id")
 			}
 			return &agentsv1.GetEnvironmentResponse{Environment: &agentsv1.Environment{
-				Meta:           &agentsv1.EntityMeta{Id: environmentID.String()},
-				OrganizationId: testOrganizationID,
-				Name:           "shared-runtime",
-				Image:          testEnvironmentImage,
-				RunnerId:       runnerID,
+				Meta:                 &agentsv1.EntityMeta{Id: environmentID.String()},
+				AgentRuntimeImageId:  testAssemblerRuntimeImageID,
+				AgentRuntimeImageTag: "1.0.0",
+				OrganizationId:       testOrganizationID,
+				Name:                 "shared-runtime",
+				Image:                testEnvironmentImage,
+				RunnerId:             runnerID,
 			}}, nil
 		},
 		ListSkillsFunc: func(context.Context, *agentsv1.ListSkillsRequest, ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
@@ -1860,7 +1915,9 @@ func newTestEnvironmentAssembler(agentID, environmentID uuid.UUID, runnerID stri
 		AgentGatewayAddress: "gateway:50051",
 		AgentLLMBaseURL:     "http://llm:8080/v1",
 	}
-	return assembler.NewWithRunners(agentsClient, runnersClient, &testutil.FakeSecretsClient{}, cfg)
+	cfg.ImageProxyHost = testAssemblerProxyHost
+	return assembler.NewWithRunners(agentsClient, runnersClient, &testutil.FakeSecretsClient{}, cfg).
+		WithCatalog(&fakeImagesClient{}, &fakeOrganizationsClient{}, nil)
 }
 
 func envMap(envs []*runnerv1.EnvVar) map[string]string {

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -1659,7 +1659,6 @@ func TestStartSandboxWorkloadMarksRunningOnRunnerRunning(t *testing.T) {
 	cfg := &config.Config{
 		AgentGatewayAddress:                 "gateway:50051",
 		AgentLLMBaseURL:                     "http://llm:8080/v1",
-		SandboxInitImage:                    "sandbox-init-image",
 		SandboxWorkspaceSizeGB:              "10",
 		ZitiEnabled:                         true,
 		ZitiSidecarImage:                    "ziti-sidecar-image",
@@ -1906,7 +1905,6 @@ func TestStartSandboxWorkloadWritesRuntimeRunning(t *testing.T) {
 	cfg := &config.Config{
 		AgentGatewayAddress:    "gateway:50051",
 		AgentLLMBaseURL:        "http://llm:8080/v1",
-		SandboxInitImage:       "sandbox-init-image",
 		SandboxWorkspaceSizeGB: "10",
 	}
 	reconciler := newTestReconciler(Config{
@@ -2023,7 +2021,6 @@ func TestStartSandboxWorkloadFailureWritesRuntimeFailed(t *testing.T) {
 		Assembler: assembler.NewWithRunners(agents, runners, &testutil.FakeSecretsClient{}, &config.Config{
 			AgentGatewayAddress:    "gateway:50051",
 			AgentLLMBaseURL:        "http://llm:8080/v1",
-			SandboxInitImage:       "sandbox-init-image",
 			SandboxWorkspaceSizeGB: "10",
 		}),
 	})
@@ -2094,7 +2091,6 @@ func TestReconcileSandboxStartsFromStartingRuntimeState(t *testing.T) {
 		Assembler: assembler.NewWithRunners(agents, runners, &testutil.FakeSecretsClient{}, &config.Config{
 			AgentGatewayAddress:    "gateway:50051",
 			AgentLLMBaseURL:        "http://llm:8080/v1",
-			SandboxInitImage:       "sandbox-init-image",
 			SandboxWorkspaceSizeGB: "10",
 		}),
 	})


### PR DESCRIPTION
The single init container a workload got before the platform binaries were split out. Two callers substituted it when no agent runtime image was named:

- **a sandbox**, from `SANDBOX_INIT_IMAGE` — on a branch that could never fire, since it required `len(initContainers) == 0` and the two platform init containers are never empty
- **an agent**, from its own `init_image`

Naming no runtime is now refused rather than substituted. A workload assembled without one starts and then has no CLI to spawn, which is a worse failure than the one at assembly.

## Tests

Environment-less agents are not supported, so three tests covered a shape that no longer exists and are gone: `TestAssemblerWithoutEnvironmentKeepsAgentImageAndPlacement`, `TestAssemblerReusesWorkspaceMount` (its assertion was "expected no workspace mount without an environment declaring one"), and the two `init_image` tests.

The rest gain the environment, runtime image and catalog a real workload has. That cascades — an environment requires a runner, a runner requires flavor resolution — so the fixtures now wire a runners client too, which is why the diff is larger than the removal.

Also removed: the `SandboxInitImage` config field, its Go default, and its chart values entry.

`agents.init_image` is deprecated in agynio/api#182.