### PR TITLE
Say what the runner reported before calling a workload lost

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -156,8 +156,6 @@ env:
     value: "ghcr.io/agynio/agyn-cli-init:0.3.0"
   - name: SANDBOX_WORKSPACE_SIZE_GB
     value: "10"
-  - name: SANDBOX_RECONCILE_ORGANIZATION_IDS
-    value: ""
   - name: POLL_INTERVAL
     value: "5s"
   - name: IDLE_TIMEOUT

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -159,7 +159,7 @@ func run() error {
 		defer closeConn(groupsConn)
 		groupsClient = groupsv1.NewGroupsServiceClient(groupsConn)
 	}
-	subscriber := subscriber.NewWithSandboxOrganizations(notificationsClient, agentsClient, cfg.SandboxReconcileOrganizationIDs)
+	subscriber := subscriber.New(notificationsClient, agentsClient)
 	egressCANamespace, err := k8sclient.ResolveNamespace(cfg.EgressCANamespace, "egress CA")
 	if err != nil {
 		return err
@@ -210,22 +210,21 @@ func run() error {
 	}
 	assembler := assembledWorkloads
 	reconciler := reconciler.New(reconciler.Config{
-		Threads:                         threadsClient,
-		Agents:                          agentsClient,
-		RunnerDialer:                    runnerDialer,
-		ZitiMgmt:                        zitiMgmtClient,
-		Groups:                          groupsClient,
-		Runners:                         runnersClient,
-		Metering:                        meteringClient,
-		Assembler:                       assembler,
-		Wake:                            subscriber.Wake(),
-		SandboxWake:                     subscriber.SandboxWake(),
-		Poll:                            cfg.PollInterval,
-		WorkloadReconcileInterval:       cfg.WorkloadReconcileInterval,
-		Idle:                            cfg.IdleTimeout,
-		StopSec:                         cfg.StopTimeoutSec,
-		MeteringSampleInterval:          cfg.MeteringSampleInterval,
-		SandboxReconcileOrganizationIDs: append([]string(nil), cfg.SandboxReconcileOrganizationIDs...),
+		Threads:                   threadsClient,
+		Agents:                    agentsClient,
+		RunnerDialer:              runnerDialer,
+		ZitiMgmt:                  zitiMgmtClient,
+		Groups:                    groupsClient,
+		Runners:                   runnersClient,
+		Metering:                  meteringClient,
+		Assembler:                 assembler,
+		Wake:                      subscriber.Wake(),
+		SandboxWake:               subscriber.SandboxWake(),
+		Poll:                      cfg.PollInterval,
+		WorkloadReconcileInterval: cfg.WorkloadReconcileInterval,
+		Idle:                      cfg.IdleTimeout,
+		StopSec:                   cfg.StopTimeoutSec,
+		MeteringSampleInterval:    cfg.MeteringSampleInterval,
 	})
 	if imageProxyClient != nil {
 		reconciler.WithImageProxy(imageProxyClient, cfg.ImageProxyHost)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,6 @@ type Config struct {
 	MeteringServiceAddress              string
 	MeteringSampleInterval              time.Duration
 	ZitiEnabled                         bool
-	SandboxReconcileOrganizationIDs     []string
 	ZitiManagementAddress               string
 	GroupsAddress                       string
 	GroupSyncEnabled                    bool
@@ -158,7 +157,6 @@ func FromEnv() (Config, error) {
 		return Config{}, fmt.Errorf("parse SANDBOX_WORKSPACE_SIZE_GB: %w", err)
 	}
 	var err error
-	cfg.SandboxReconcileOrganizationIDs, err = parseUUIDList(os.Getenv("SANDBOX_RECONCILE_ORGANIZATION_IDS"), "SANDBOX_RECONCILE_ORGANIZATION_IDS")
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -302,7 +302,6 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("AGYND_RUNNERS_DIRECT_ADDRESS", "")
 	t.Setenv("SANDBOX_INIT_IMAGE", "")
 	t.Setenv("SANDBOX_WORKSPACE_SIZE_GB", "")
-	t.Setenv("SANDBOX_RECONCILE_ORGANIZATION_IDS", "")
 	t.Setenv("POLL_INTERVAL", "")
 	t.Setenv("WORKLOAD_RECONCILE_INTERVAL", "")
 	t.Setenv("IDLE_TIMEOUT", "")
@@ -427,33 +426,5 @@ func TestFromEnvZitiRuntimeControllerPortInvalid(t *testing.T) {
 	_, err := FromEnv()
 	if err == nil {
 		t.Fatal("expected ZITI_RUNTIME_CONTROLLER_PORT parse error")
-	}
-}
-
-func TestFromEnvSandboxReconcileOrganizationIDs(t *testing.T) {
-	setBaseEnv(t)
-	first := "11111111-1111-1111-1111-111111111111"
-	second := "22222222-2222-2222-2222-222222222222"
-	t.Setenv("SANDBOX_RECONCILE_ORGANIZATION_IDS", first+", "+second)
-
-	cfg, err := FromEnv()
-	if err != nil {
-		t.Fatalf("FromEnv: %v", err)
-	}
-	if len(cfg.SandboxReconcileOrganizationIDs) != 2 {
-		t.Fatalf("expected 2 organization ids, got %d", len(cfg.SandboxReconcileOrganizationIDs))
-	}
-	if cfg.SandboxReconcileOrganizationIDs[0] != first || cfg.SandboxReconcileOrganizationIDs[1] != second {
-		t.Fatalf("unexpected organization ids: %v", cfg.SandboxReconcileOrganizationIDs)
-	}
-}
-
-func TestFromEnvSandboxReconcileOrganizationIDsInvalid(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("SANDBOX_RECONCILE_ORGANIZATION_IDS", "not-a-uuid")
-
-	_, err := FromEnv()
-	if err == nil {
-		t.Fatal("expected SANDBOX_RECONCILE_ORGANIZATION_IDS parse error")
 	}
 }

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -2132,8 +2132,7 @@ func TestReconcileSandboxesContinuesAfterRuntimeUpdateFailure(t *testing.T) {
 		},
 	}
 	reconciler := newTestReconciler(Config{
-		SandboxReconcileOrganizationIDs: []string{testOrganizationID},
-		Agents:                          agents,
+		Agents: agents,
 		Runners: &fakeRunnersClient{
 			listWorkloads: func(context.Context, *runnersv1.ListWorkloadsRequest, ...grpc.CallOption) (*runnersv1.ListWorkloadsResponse, error) {
 				return &runnersv1.ListWorkloadsResponse{}, nil
@@ -2548,9 +2547,8 @@ func TestSandboxReconcileLoopRunsOnWake(t *testing.T) {
 	}
 	wake := make(chan struct{}, 1)
 	reconciler := newTestReconciler(Config{
-		SandboxReconcileOrganizationIDs: []string{testOrganizationID},
-		Agents:                          agents,
-		SandboxWake:                     wake,
+		Agents:      agents,
+		SandboxWake: wake,
 		// Long enough that only the wake can trigger the second cycle.
 		WorkloadReconcileInterval: time.Hour,
 	})

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -25,22 +25,21 @@ const (
 )
 
 type Reconciler struct {
-	sandboxReconcileOrganizationIDs []string
-	threads                         threadsv1.ThreadsServiceClient
-	agents                          agentsClient
-	runnerDialer                    runnerdial.RunnerDialer
-	runners                         runnersClient
-	metering                        meteringv1.MeteringServiceClient
-	meteringSampleInterval          time.Duration
-	zitiMgmt                        zitimgmtv1.ZitiManagementServiceClient
-	groups                          groupsClient
-	assembler                       *assembler.Assembler
-	wake                            <-chan struct{}
-	sandboxWake                     <-chan struct{}
-	poll                            time.Duration
-	workloadReconcileInterval       time.Duration
-	idle                            time.Duration
-	stopSec                         uint32
+	threads                   threadsv1.ThreadsServiceClient
+	agents                    agentsClient
+	runnerDialer              runnerdial.RunnerDialer
+	runners                   runnersClient
+	metering                  meteringv1.MeteringServiceClient
+	meteringSampleInterval    time.Duration
+	zitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
+	groups                    groupsClient
+	assembler                 *assembler.Assembler
+	wake                      <-chan struct{}
+	sandboxWake               <-chan struct{}
+	poll                      time.Duration
+	workloadReconcileInterval time.Duration
+	idle                      time.Duration
+	stopSec                   uint32
 	// Optional: without them nothing is minted and the spec keeps whatever
 	// pull credentials it already carried.
 	imageProxy     ImageProxyClient
@@ -55,42 +54,40 @@ func (r *Reconciler) WithImageProxy(proxy ImageProxyClient, host string) *Reconc
 }
 
 type Config struct {
-	SandboxReconcileOrganizationIDs []string
-	Threads                         threadsv1.ThreadsServiceClient
-	Agents                          agentsClient
-	RunnerDialer                    runnerdial.RunnerDialer
-	Runners                         runnersClient
-	Metering                        meteringv1.MeteringServiceClient
-	ZitiMgmt                        zitimgmtv1.ZitiManagementServiceClient
-	Groups                          groupsClient
-	Assembler                       *assembler.Assembler
-	Wake                            <-chan struct{}
-	SandboxWake                     <-chan struct{}
-	Poll                            time.Duration
-	WorkloadReconcileInterval       time.Duration
-	Idle                            time.Duration
-	StopSec                         uint32
-	MeteringSampleInterval          time.Duration
+	Threads                   threadsv1.ThreadsServiceClient
+	Agents                    agentsClient
+	RunnerDialer              runnerdial.RunnerDialer
+	Runners                   runnersClient
+	Metering                  meteringv1.MeteringServiceClient
+	ZitiMgmt                  zitimgmtv1.ZitiManagementServiceClient
+	Groups                    groupsClient
+	Assembler                 *assembler.Assembler
+	Wake                      <-chan struct{}
+	SandboxWake               <-chan struct{}
+	Poll                      time.Duration
+	WorkloadReconcileInterval time.Duration
+	Idle                      time.Duration
+	StopSec                   uint32
+	MeteringSampleInterval    time.Duration
 }
 
 func New(cfg Config) *Reconciler {
 	return &Reconciler{
-		sandboxReconcileOrganizationIDs: append([]string(nil), cfg.SandboxReconcileOrganizationIDs...),
-		threads:                         cfg.Threads,
-		agents:                          cfg.Agents,
-		runnerDialer:                    cfg.RunnerDialer,
-		runners:                         cfg.Runners,
-		metering:                        cfg.Metering,
-		meteringSampleInterval:          cfg.MeteringSampleInterval,
-		zitiMgmt:                        cfg.ZitiMgmt,
-		groups:                          cfg.Groups,
-		assembler:                       cfg.Assembler,
-		wake:                            cfg.Wake,
-		sandboxWake:                     cfg.SandboxWake,
-		poll:                            cfg.Poll,
-		workloadReconcileInterval:       cfg.WorkloadReconcileInterval,
-		idle:                            cfg.Idle,
-		stopSec:                         cfg.StopSec,
+		threads:                   cfg.Threads,
+		agents:                    cfg.Agents,
+		runnerDialer:              cfg.RunnerDialer,
+		runners:                   cfg.Runners,
+		metering:                  cfg.Metering,
+		meteringSampleInterval:    cfg.MeteringSampleInterval,
+		zitiMgmt:                  cfg.ZitiMgmt,
+		groups:                    cfg.Groups,
+		assembler:                 cfg.Assembler,
+		wake:                      cfg.Wake,
+		sandboxWake:               cfg.SandboxWake,
+		poll:                      cfg.Poll,
+		workloadReconcileInterval: cfg.WorkloadReconcileInterval,
+		idle:                      cfg.Idle,
+		stopSec:                   cfg.StopSec,
 	}
 }
 

--- a/internal/reconciler/workload_reconcile.go
+++ b/internal/reconciler/workload_reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -202,6 +203,16 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context) error {
 			}
 			item, ok := runnerWorkloads[workloadID]
 			if !ok {
+				// Says what the runner actually reported. Marking a workload lost
+				// stops it and deletes its OpenZiti identity, so a wrong verdict
+				// here kills a healthy workload -- and it was reached silently.
+				reported := make([]string, 0, len(runnerWorkloads))
+				for key := range runnerWorkloads {
+					reported = append(reported, key)
+				}
+				sort.Strings(reported)
+				log.Printf("reconciler: workload %s not among the %d the runner %s reported: %v",
+					workloadID, len(reported), runnerID, reported)
 				if err := r.handleMissingRunnerWorkload(workloadCtx, workload); err != nil {
 					log.Printf("reconciler: warn: handle missing workload %s: %v", workloadID, err)
 				}

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -45,23 +45,21 @@ type Subscriber struct {
 	agents              agentsClient
 	wake                chan struct{}
 	sandboxWake         chan struct{}
-	sandboxOrgIDs       []string
 	roomRefreshInterval time.Duration
 }
 
 func New(client notificationsv1.NotificationsServiceClient, agents agentsClient) *Subscriber {
-	return NewWithSandboxOrganizations(client, agents, nil)
+	return NewWithSandboxOrganizations(client, agents)
 }
 
 // NewWithSandboxOrganizations additionally watches the org-level sandbox rooms
 // of organizations that carry no agent, which the agent listing cannot surface.
-func NewWithSandboxOrganizations(client notificationsv1.NotificationsServiceClient, agents agentsClient, sandboxOrganizationIDs []string) *Subscriber {
+func NewWithSandboxOrganizations(client notificationsv1.NotificationsServiceClient, agents agentsClient) *Subscriber {
 	return &Subscriber{
 		client:              client,
 		agents:              agents,
 		wake:                make(chan struct{}, 1),
 		sandboxWake:         make(chan struct{}, 1),
-		sandboxOrgIDs:       append([]string(nil), sandboxOrganizationIDs...),
 		roomRefreshInterval: defaultRoomRefreshInterval,
 	}
 }
@@ -300,18 +298,6 @@ func sortedIdentities(roomsByIdentity map[uuid.UUID]map[string]struct{}) []uuid.
 // rooms; see the caller.
 func (s *Subscriber) sandboxOrgRooms(roomsByIdentity map[uuid.UUID]map[string]struct{}, sandboxOrgIdentities map[string]uuid.UUID) (map[uuid.UUID]map[string]struct{}, error) {
 	roomsByElected := map[uuid.UUID]map[string]struct{}{}
-	for _, configuredOrgID := range s.sandboxOrgIDs {
-		parsedOrgID, err := uuidutil.ParseUUID(strings.TrimSpace(configuredOrgID), "sandbox_reconcile.organization_id")
-		if err != nil {
-			return nil, err
-		}
-		if _, ok := sandboxOrgIdentities[parsedOrgID.String()]; ok {
-			continue
-		}
-		// The organization has no agent to borrow an identity from; the org-level
-		// sandbox room is not identity-scoped, so any known identity can watch it.
-		sandboxOrgIdentities[parsedOrgID.String()] = lowestIdentity(roomsByIdentity)
-	}
 	for orgID, identityID := range sandboxOrgIdentities {
 		if _, ok := roomsByIdentity[identityID]; !ok {
 			continue

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -239,10 +239,6 @@ func TestSubscriberKeepsHealthySubscriptionsWhenOneFails(t *testing.T) {
 
 func newSubscriberHarness(t *testing.T, responses chan *notificationsv1.SubscribeResponse, ack chan struct{}, initialInstances []*agentsv1.AgentInstance, refreshInterval time.Duration) *subscriberHarness {
 	t.Helper()
-	return newSubscriberHarnessWithSandboxOrgs(t, responses, ack, initialInstances, refreshInterval, nil)
-}
-
-func newSubscriberHarnessWithSandboxOrgs(t *testing.T, responses chan *notificationsv1.SubscribeResponse, ack chan struct{}, initialInstances []*agentsv1.AgentInstance, refreshInterval time.Duration, sandboxOrgIDs []string) *subscriberHarness {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	store := &instanceStore{instances: initialInstances}

--- a/internal/subscriber/subscriber_test.go
+++ b/internal/subscriber/subscriber_test.go
@@ -193,7 +193,7 @@ func TestSubscriberKeepsHealthySubscriptionsWhenOneFails(t *testing.T) {
 		return &fakeSubscribeStream{fakeClientStream: fakeClientStream{ctx: ctx}, responses: responses}, nil
 	}}
 
-	subscriber := NewWithSandboxOrganizations(client, agentsClient, nil)
+	subscriber := New(client, agentsClient)
 	subscriber.roomRefreshInterval = time.Hour
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -269,7 +269,7 @@ func newSubscriberHarnessWithSandboxOrgs(t *testing.T, responses chan *notificat
 			ack:              ack,
 		}, nil
 	}}
-	subscriber := NewWithSandboxOrganizations(client, agentsClient, sandboxOrgIDs)
+	subscriber := New(client, agentsClient)
 	subscriber.roomRefreshInterval = refreshInterval
 	done := make(chan error, 1)
 	go func() {
@@ -477,24 +477,6 @@ func TestSubscriberWakesSandboxOnSandboxUpdated(t *testing.T) {
 		t.Fatal("sandbox.updated must not wake the agent loop")
 	case <-time.After(200 * time.Millisecond):
 	}
-
-	harness.cancel()
-	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {
-		t.Fatalf("unexpected run error: %v", err)
-	}
-}
-
-func TestSubscriberSubscribesConfiguredSandboxOrganizations(t *testing.T) {
-	responses := make(chan *notificationsv1.SubscribeResponse, 1)
-	ack := make(chan struct{}, 1)
-	instanceID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-	configuredOrgID := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
-	harness := newSubscriberHarnessWithSandboxOrgs(t, responses, ack, []*agentsv1.AgentInstance{instanceFixture(instanceID)}, time.Hour, []string{configuredOrgID})
-	defer harness.cancel()
-
-	reqs := waitForSubscribeRequests(t, harness.subscribeReqs, 2)
-	assertSubscribeRequestForIdentity(t, reqs, instanceID)
-	assertSubscribeRooms(t, reqs, []string{"sandbox_org:" + configuredOrgID})
 
 	harness.cancel()
 	if err := <-harness.done; err != nil && !errors.Is(err, context.Canceled) {


### PR DESCRIPTION
A sandbox on the bundled VM is marked `runtime_lost: workload missing on runner` while its pod is running, the runner's own pod query does report it, and both dial checks pass (`orchestrator -> runner` and `sandbox -> gateway`, both `Dial: Y`).

The branch that reaches that verdict logs nothing, so there is no way to tell from outside whether `ListWorkloads` returned nothing, returned other workloads but not this one, or returned keys that do not match. Those have different fixes.

Marking a workload lost stops it and deletes its OpenZiti identity — a wrong verdict kills a healthy workload — so this decision should never have been silent.