### PR TITLE
Name the overlay .agyn, not .ziti

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -78,11 +78,11 @@ functions:
                 - name: ZITI_RUNTIME_CONTROLLER_PORT
                   value: "__ZITI_RUNTIME_CONTROLLER_PORT__"
                 - name: AGENT_GATEWAY_ADDRESS
-                  value: "gateway.ziti:443"
+                  value: "gateway.agyn:443"
                 - name: AGENT_TRACING_ADDRESS
-                  value: "tracing.ziti:443"
+                  value: "tracing.agyn:443"
                 - name: AGENT_LLM_BASE_URL
-                  value: "http://llm-proxy.ziti/v1"
+                  value: "http://llm-proxy.agyn/v1"
                 - name: AGYND_AGENTS_DIRECT_ADDRESS
                   value: "__AGYND_AGENTS_DIRECT_ADDRESS__"
                 - name: AGYND_RUNNERS_DIRECT_ADDRESS

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -229,9 +229,9 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	}
 
 	cfg := config.Config{
-		AgentGatewayAddress:                 "gateway.ziti:443",
-		AgentTracingAddress:                 "tracing.ziti:443",
-		AgentLLMBaseURL:                     "http://llm-proxy.ziti/v1",
+		AgentGatewayAddress:                 "gateway.agyn:443",
+		AgentTracingAddress:                 "tracing.agyn:443",
+		AgentLLMBaseURL:                     "http://llm-proxy.agyn/v1",
 		ZitiEnabled:                         true,
 		ZitiSidecarImage:                    "ziti-image",
 		WorkloadDNSUpstream:                 "10.43.0.10",
@@ -418,20 +418,20 @@ func TestAssemblerAddsZitiSidecar(t *testing.T) {
 	if !equalStringSlice(zitiGatewayWait.Cmd, expectedWaitCmd) {
 		t.Fatalf("expected ziti gateway wait cmd %+v, got %+v", expectedWaitCmd, zitiGatewayWait.Cmd)
 	}
-	if !strings.Contains(zitiGatewayWait.Cmd[1], "getent ahostsv4 gateway.ziti") {
-		t.Fatalf("expected ziti gateway wait to resolve gateway.ziti through pod resolver, got %+v", zitiGatewayWait.Cmd)
+	if !strings.Contains(zitiGatewayWait.Cmd[1], "getent ahostsv4 gateway.agyn") {
+		t.Fatalf("expected ziti gateway wait to resolve gateway.agyn through pod resolver, got %+v", zitiGatewayWait.Cmd)
 	}
-	if strings.Contains(zitiGatewayWait.Cmd[1], "gateway.ziti 127.0.0.1") {
+	if strings.Contains(zitiGatewayWait.Cmd[1], "gateway.agyn 127.0.0.1") {
 		t.Fatalf("expected ziti gateway wait not to bypass pod resolver config, got %+v", zitiGatewayWait.Cmd)
 	}
-	if !strings.Contains(zitiGatewayWait.Cmd[1], "/dev/tcp/gateway.ziti/443") {
-		t.Fatalf("expected ziti gateway wait to connect to gateway.ziti through tunnel, got %+v", zitiGatewayWait.Cmd)
+	if !strings.Contains(zitiGatewayWait.Cmd[1], "/dev/tcp/gateway.agyn/443") {
+		t.Fatalf("expected ziti gateway wait to connect to gateway.agyn through tunnel, got %+v", zitiGatewayWait.Cmd)
 	}
 	resolverConfig := "nameserver 127.0.0.1\nnameserver " + cfg.WorkloadDNSUpstream + "\nsearch svc.cluster.local cluster.local\noptions ndots:5 timeout:1 attempts:1\n"
 	if !strings.Contains(zitiGatewayWait.Cmd[1], strconv.Quote(resolverConfig)) {
 		t.Fatalf("expected ziti gateway wait to make tunnel DNS first in resolv.conf, got %+v", zitiGatewayWait.Cmd)
 	}
-	if !strings.Contains(zitiGatewayWait.Cmd[1], "dns lookup failed for gateway.ziti") || !strings.Contains(zitiGatewayWait.Cmd[1], "tcp connect failed for gateway.ziti:443") {
+	if !strings.Contains(zitiGatewayWait.Cmd[1], "dns lookup failed for gateway.agyn") || !strings.Contains(zitiGatewayWait.Cmd[1], "tcp connect failed for gateway.agyn:443") {
 		t.Fatalf("expected ziti gateway wait diagnostics to distinguish DNS and TCP failures, got %+v", zitiGatewayWait.Cmd)
 	}
 	zitiServiceWait := testutil.FindInitContainer(request.InitContainers, zitiServiceWaitContainerName)
@@ -509,10 +509,10 @@ func TestAssemblerZitiDefaultsFromEnv(t *testing.T) {
 
 	assembler := New(&testutil.FakeAgentsClient{}, &testutil.FakeSecretsClient{}, &cfg)
 	envs := envMap(assembler.baseAgentEnvVars(agent, agentID, threadID))
-	assertEnv(t, envs, "GATEWAY_ADDRESS", "gateway.ziti:443")
-	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://gateway.ziti:443")
-	assertEnv(t, envs, "LLM_BASE_URL", "http://llm-proxy.ziti/v1")
-	assertEnv(t, envs, "TRACING_ADDRESS", "tracing.ziti:443")
+	assertEnv(t, envs, "GATEWAY_ADDRESS", "gateway.agyn:443")
+	assertEnv(t, envs, "AGYN_GATEWAY_URL", "http://gateway.agyn:443")
+	assertEnv(t, envs, "LLM_BASE_URL", "http://llm-proxy.agyn/v1")
+	assertEnv(t, envs, "TRACING_ADDRESS", "tracing.agyn:443")
 	assertEnv(t, envs, "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 }
 
@@ -1644,22 +1644,22 @@ func assertFileEquals(t *testing.T, path, expected string) {
 }
 
 func TestZitiServiceWaitTargetsLLMProxyTCP(t *testing.T) {
-	target, err := zitiServiceWaitTarget("http://llm-proxy.ziti/v1")
+	target, err := zitiServiceWaitTarget("http://llm-proxy.agyn/v1")
 	if err != nil {
 		t.Fatalf("zitiServiceWaitTarget: %v", err)
 	}
-	if target.host != "llm-proxy.ziti" || target.port != "80" {
-		t.Fatalf("expected llm-proxy.ziti:80, got %s:%s", target.host, target.port)
+	if target.host != "llm-proxy.agyn" || target.port != "80" {
+		t.Fatalf("expected llm-proxy.agyn:80, got %s:%s", target.host, target.port)
 	}
 	cmd := buildZitiServiceWaitCommand(target, "10.43.0.10")
-	if !strings.Contains(cmd[1], "getent ahostsv4 llm-proxy.ziti") {
-		t.Fatalf("expected ziti service wait to resolve llm-proxy.ziti through pod resolver, got %+v", cmd)
+	if !strings.Contains(cmd[1], "getent ahostsv4 llm-proxy.agyn") {
+		t.Fatalf("expected ziti service wait to resolve llm-proxy.agyn through pod resolver, got %+v", cmd)
 	}
-	if strings.Contains(cmd[1], "llm-proxy.ziti 127.0.0.1") {
+	if strings.Contains(cmd[1], "llm-proxy.agyn 127.0.0.1") {
 		t.Fatalf("expected ziti service wait not to bypass pod resolver config, got %+v", cmd)
 	}
-	if !strings.Contains(cmd[1], "/dev/tcp/llm-proxy.ziti/80") {
-		t.Fatalf("expected ziti service wait to connect to llm-proxy.ziti:80 through tunnel, got %+v", cmd)
+	if !strings.Contains(cmd[1], "/dev/tcp/llm-proxy.agyn/80") {
+		t.Fatalf("expected ziti service wait to connect to llm-proxy.agyn:80 through tunnel, got %+v", cmd)
 	}
 	if strings.Contains(cmd[1], "/v1/models") || strings.Contains(cmd[1], "curl") {
 		t.Fatalf("expected ziti service wait not to use HTTP/model-list readiness, got %+v", cmd)
@@ -1667,12 +1667,12 @@ func TestZitiServiceWaitTargetsLLMProxyTCP(t *testing.T) {
 }
 
 func TestZitiServiceWaitTargetPreservesExplicitPort(t *testing.T) {
-	target, err := zitiServiceWaitTarget("https://llm-proxy.ziti:8443/v1")
+	target, err := zitiServiceWaitTarget("https://llm-proxy.agyn:8443/v1")
 	if err != nil {
 		t.Fatalf("zitiServiceWaitTarget: %v", err)
 	}
-	if target.host != "llm-proxy.ziti" || target.port != "8443" {
-		t.Fatalf("expected llm-proxy.ziti:8443, got %s:%s", target.host, target.port)
+	if target.host != "llm-proxy.agyn" || target.port != "8443" {
+		t.Fatalf("expected llm-proxy.agyn:8443, got %s:%s", target.host, target.port)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,7 +120,7 @@ func FromEnv() (Config, error) {
 	cfg.AgentGatewayAddress = os.Getenv("AGENT_GATEWAY_ADDRESS")
 	if cfg.AgentGatewayAddress == "" {
 		if cfg.ZitiEnabled {
-			cfg.AgentGatewayAddress = "gateway.ziti:443"
+			cfg.AgentGatewayAddress = "gateway.agyn:443"
 		} else {
 			cfg.AgentGatewayAddress = "gateway:8080"
 		}
@@ -128,7 +128,7 @@ func FromEnv() (Config, error) {
 	cfg.AgentTracingAddress = os.Getenv("AGENT_TRACING_ADDRESS")
 	if cfg.AgentTracingAddress == "" {
 		if cfg.ZitiEnabled {
-			cfg.AgentTracingAddress = "tracing.ziti:443"
+			cfg.AgentTracingAddress = "tracing.agyn:443"
 		} else {
 			cfg.AgentTracingAddress = "tracing:50051"
 		}
@@ -136,7 +136,7 @@ func FromEnv() (Config, error) {
 	cfg.AgentLLMBaseURL = os.Getenv("AGENT_LLM_BASE_URL")
 	if cfg.AgentLLMBaseURL == "" {
 		if cfg.ZitiEnabled {
-			cfg.AgentLLMBaseURL = "http://llm-proxy.ziti/v1"
+			cfg.AgentLLMBaseURL = "http://llm-proxy.agyn/v1"
 		} else {
 			cfg.AgentLLMBaseURL = "http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080/v1"
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -143,14 +143,14 @@ func TestFromEnvDefaultsZiti(t *testing.T) {
 	if !cfg.ZitiEnabled {
 		t.Fatal("expected ZitiEnabled to be true")
 	}
-	if cfg.AgentGatewayAddress != "gateway.ziti:443" {
-		t.Fatalf("expected gateway address %q, got %q", "gateway.ziti:443", cfg.AgentGatewayAddress)
+	if cfg.AgentGatewayAddress != "gateway.agyn:443" {
+		t.Fatalf("expected gateway address %q, got %q", "gateway.agyn:443", cfg.AgentGatewayAddress)
 	}
-	if cfg.AgentTracingAddress != "tracing.ziti:443" {
-		t.Fatalf("expected tracing address %q, got %q", "tracing.ziti:443", cfg.AgentTracingAddress)
+	if cfg.AgentTracingAddress != "tracing.agyn:443" {
+		t.Fatalf("expected tracing address %q, got %q", "tracing.agyn:443", cfg.AgentTracingAddress)
 	}
-	if cfg.AgentLLMBaseURL != "http://llm-proxy.ziti/v1" {
-		t.Fatalf("expected llm base url %q, got %q", "http://llm-proxy.ziti/v1", cfg.AgentLLMBaseURL)
+	if cfg.AgentLLMBaseURL != "http://llm-proxy.agyn/v1" {
+		t.Fatalf("expected llm base url %q, got %q", "http://llm-proxy.agyn/v1", cfg.AgentLLMBaseURL)
 	}
 	if cfg.ZitiEnrollmentTimeout != 2*time.Minute {
 		t.Fatalf("expected ziti enrollment timeout %q, got %q", 2*time.Minute, cfg.ZitiEnrollmentTimeout)


### PR DESCRIPTION
Renames the OpenZiti overlay hostnames from `.ziti` to `.agyn`:
`gateway.agyn`, `llm-proxy.agyn`, `tracing.agyn`, and `exposed-<uuid>.agyn`.

The TLD was never a DNS zone — the workload tunneler answers only for
hostnames an `intercept.v1` config names, and forwards everything else
upstream. So this is a naming change, not a networking one.

Not touched: the `ziti` Kubernetes namespace and `*.ziti.svc.cluster.local`,
the `ziti.<domain>` CoreDNS rewrites, and the `ziti-workload-dns` zone keys.

Coordinated across expose, agents-orchestrator, agynd-cli, agyn-cli,
networks, egress, files-mcp, platform-charts, bundle-vm, e2e,
platform-controller and the docs. There is no installed base to migrate.