### PR TITLE
Take the agynd and agyn CLIs that know the overlay is .agyn

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -151,9 +151,9 @@ env:
   - name: AGYND_RUNNERS_DIRECT_ADDRESS
     value: ""
   - name: AGYND_CLI_INIT_IMAGE
-    value: "ghcr.io/agynio/agynd-cli-init:0.16.0"
+    value: "ghcr.io/agynio/agynd-cli-init:0.22.0"
   - name: AGYN_CLI_INIT_IMAGE
-    value: "ghcr.io/agynio/agyn-cli-init:0.3.0"
+    value: "ghcr.io/agynio/agyn-cli-init:0.5.0"
   - name: SANDBOX_WORKSPACE_SIZE_GB
     value: "10"
   - name: POLL_INTERVAL


### PR DESCRIPTION
Bumps the init images the Orchestrator hands every workload:

- `agynd-cli-init` 0.16.0 → 0.22.0
- `agyn-cli-init` 0.3.0 → 0.5.0

agynd decides whether to attach the platform credential and strip proxy
variables by testing the LLM base URL's hostname suffix. One built before
the `.ziti` → `.agyn` rename tests for the old suffix, so it would treat
`llm-proxy.agyn` as a public endpoint and attach a credential to it.

Both pins were already behind their repos before this change.