### PR TITLE
Take the agynd that waits for the turn it was run for

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -151,7 +151,7 @@ env:
   - name: AGYND_RUNNERS_DIRECT_ADDRESS
     value: ""
   - name: AGYND_CLI_INIT_IMAGE
-    value: "ghcr.io/agynio/agynd-cli-init:0.22.0"
+    value: "ghcr.io/agynio/agynd-cli-init:0.22.1"
   - name: AGYN_CLI_INIT_IMAGE
     value: "ghcr.io/agynio/agyn-cli-init:0.5.0"
   - name: SANDBOX_WORKSPACE_SIZE_GB


### PR DESCRIPTION
agynd 0.22.1. Claude Code fires its `Stop` hook before the assistant's reply reaches the transcript, so the trace hook read a turn with nothing in it and exported the *previous* turn instead of the one it was run for.

Measured on a live workload before the fix: three turns written, two exported. Every run is one turn short when it stops, and a run that answers a single message has no `llm.call` at all.

agynio/agynd-cli#187.