### PR TITLE
Inject the agyn CLI that knows environment principals

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -153,7 +153,7 @@ env:
   - name: AGYND_CLI_INIT_IMAGE
     value: "ghcr.io/agynio/agynd-cli-init:0.22.1"
   - name: AGYN_CLI_INIT_IMAGE
-    value: "ghcr.io/agynio/agyn-cli-init:0.5.0"
+    value: "ghcr.io/agynio/agyn-cli-init:0.16.0"
   - name: SANDBOX_WORKSPACE_SIZE_GB
     value: "10"
   - name: POLL_INTERVAL


### PR DESCRIPTION
Workloads were still getting `agyn-cli-init:0.5.0`, which refuses `--principal-type environment` and **panics** rather than naming an unknown principal when listing grants. So the one principal that reaches a sandbox was unusable from inside one.

0.16.0 rather than 0.6.0: a mis-tagged 0.15.0 was published, and deleting its git tag did not stick because the release workflow had already created a GitHub Release that recreated it. The next version has to clear 0.15.0 to be the newest.