### PR TITLE
Default the identity this service acts as

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -66,6 +66,14 @@ containerPorts: []
 command: []
 args: []
 env:
+  # The identity this service acts as when it calls a platform service that
+  # authorizes its caller. Internal plumbing, not an installation choice: it is
+  # a constant the platform provisions itself with, and Identity registers it
+  # and grants it cluster admin from the same value. Defaulted here so the
+  # service runs out of the box; override only if the platform's admin identity
+  # was installed under a different id.
+  - name: PLATFORM_IDENTITY_ID
+    value: "a3c1e9d2-7f4b-5e1a-9c3d-2b8f6a4e7d10"
   - name: THREADS_ADDRESS
     value: "threads:50051"
   - name: NOTIFICATIONS_ADDRESS


### PR DESCRIPTION
`PLATFORM_IDENTITY_ID` is internal plumbing, not an installation choice — Identity registers this id and grants it cluster admin from the same value, and the umbrella chart describes it as deliberately a constant.

Requiring it without a default made an internal constant look like something every install has to supply, and left this chart unusable standalone.

Defaulted alongside the service addresses it sits with. An override stays available for an install whose admin identity was provisioned under a different id.