### PR TITLE
Follow the platform to its own namespace

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,7 +1,7 @@
 version: v2beta1
 
 vars:
-  ORCHESTRATOR_NAMESPACE: platform
+  ORCHESTRATOR_NAMESPACE: agyn-platform
   DEV_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:


### PR DESCRIPTION
The install moved to `agyn-platform` on 2026-08-09. `platform` is empty, so the DevSpace patch and sync looked for a deployment that was no longer there — the same fix console-app made in agynio/console-app#140.

E2E has not reached this step since; it has been failing in the shared provisioning action, which agynio/e2e#255 fixes. This is what it hits next.