### PR TITLE
Take the agynd that runs a sandbox's init scripts

### DIFF
--- a/charts/agents-orchestrator/values.yaml
+++ b/charts/agents-orchestrator/values.yaml
@@ -159,7 +159,7 @@ env:
   - name: AGYND_RUNNERS_DIRECT_ADDRESS
     value: ""
   - name: AGYND_CLI_INIT_IMAGE
-    value: "ghcr.io/agynio/agynd-cli-init:0.22.1"
+    value: "ghcr.io/agynio/agynd-cli-init:0.22.2"
   - name: AGYN_CLI_INIT_IMAGE
     value: "ghcr.io/agynio/agyn-cli-init:0.16.0"
   - name: SANDBOX_WORKSPACE_SIZE_GB


### PR DESCRIPTION
agynd-cli v0.22.2 runs the environment's init scripts in holder mode, so a sandbox comes up with the tools its environment installs. Pin-only.