### PR TITLE
Let the image's PATH survive

### DIFF
--- a/internal/assembler/egress_ca_apply.go
+++ b/internal/assembler/egress_ca_apply.go
@@ -6,7 +6,6 @@ func appendEgressCAEnvVars(envs []*runnerv1.EnvVar) []*runnerv1.EnvVar {
 	for _, env := range egressCAEnvVars() {
 		envs = appendPlatformEnvVar(envs, env)
 	}
-	envs = appendWorkloadPathEnvVar(envs)
 	return appendWorkloadSandboxEnvVar(envs)
 }
 
@@ -24,22 +23,13 @@ func appendWorkloadSandboxEnvVar(envs []*runnerv1.EnvVar) []*runnerv1.EnvVar {
 	return appendPlatformEnvVar(envs, &runnerv1.EnvVar{Name: "IS_SANDBOX", Value: "1"})
 }
 
-// appendWorkloadPathEnvVar puts the platform's binaries on PATH for everything
-// that runs in the container, including a shell nobody here started.
-//
-// agynd prepends this for the subprocess it spawns, which covers an agent but
-// not a sandbox: holder mode spawns nothing, and an interactive session comes
-// from the runner's Exec against the pod, inheriting the container spec's
-// environment rather than any process's. Without it a person at the shell finds
-// agyn, agynd and the agent CLI present on disk and none of them on PATH.
-func appendWorkloadPathEnvVar(envs []*runnerv1.EnvVar) []*runnerv1.EnvVar {
-	return appendPlatformEnvVar(envs, &runnerv1.EnvVar{
-		Name: "PATH",
-		// The image's own PATH is not knowable here, so the default login set
-		// is spelled out after the platform's own directory.
-		Value: agynBinDir + ":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-	})
-}
+// PATH is deliberately not set here. A container env entry replaces the image's
+// ENV PATH outright -- Kubernetes offers no way to prepend to it -- so setting
+// one discards whatever the image put there, and an image that installs into a
+// profile directory loses it. Every route to /agyn/bin prepends inside the
+// container instead, where $PATH is the image's: agynd for the subprocess it
+// spawns, the tmux configuration for a persistent shell, the Terminal Proxy for
+// a session. Machine-invoked commands name their binary by absolute path.
 
 func egressCAEnvVars() []*runnerv1.EnvVar {
 	return []*runnerv1.EnvVar{

--- a/internal/assembler/egress_ca_apply_test.go
+++ b/internal/assembler/egress_ca_apply_test.go
@@ -1,38 +1,26 @@
 package assembler
 
 import (
-	"strings"
 	"testing"
 
 	runnerv1 "github.com/agynio/agents-orchestrator/.gen/go/agynio/api/runner/v1"
 )
 
-// A sandbox shell comes from the runner's Exec and inherits the container
-// spec's environment, so PATH has to be there rather than in anything agynd
-// assembles for a subprocess it never spawns in holder mode.
-func TestWorkloadPathIncludesThePlatformBinaries(t *testing.T) {
-	envs := appendEgressCAEnvVars(nil)
-	var path string
-	for _, env := range envs {
+// A container env entry replaces the image's ENV PATH rather than extending it,
+// so setting one here loses whatever the image installed -- the devcontainer's
+// nix profile directories among them. Every route to /agyn/bin prepends inside
+// the container, where the image's PATH is what $PATH holds.
+func TestWorkloadEnvLeavesPathToTheImage(t *testing.T) {
+	for _, env := range appendEgressCAEnvVars(nil) {
 		if env.GetName() == "PATH" {
-			path = env.GetValue()
+			t.Fatalf("PATH = %q, want the image's own to survive", env.GetValue())
 		}
-	}
-	if path == "" {
-		t.Fatal("PATH is not set on the container")
-	}
-	if !strings.HasPrefix(path, agynBinDir+":") {
-		t.Fatalf("PATH = %q, want the platform directory first", path)
-	}
-	if !strings.Contains(path, "/usr/bin") {
-		t.Fatalf("PATH = %q, want the default login set after it", path)
 	}
 }
 
-// The platform's value wins, the same way SSL_CERT_FILE does: a workload that
-// set its own PATH would otherwise leave the agent CLI unreachable, which is
-// the failure this exists to prevent.
-func TestWorkloadPathWinsOverAnEarlierValue(t *testing.T) {
+// A workload that sets its own PATH keeps it: the platform no longer has a
+// value of its own to prefer over it.
+func TestWorkloadPathPassesThrough(t *testing.T) {
 	envs := appendEgressCAEnvVars([]*runnerv1.EnvVar{{Name: "PATH", Value: "/only/this"}})
 	var count int
 	for _, env := range envs {
@@ -40,8 +28,8 @@ func TestWorkloadPathWinsOverAnEarlierValue(t *testing.T) {
 			continue
 		}
 		count++
-		if !strings.HasPrefix(env.GetValue(), agynBinDir+":") {
-			t.Fatalf("PATH = %q", env.GetValue())
+		if env.GetValue() != "/only/this" {
+			t.Fatalf("PATH = %q, want the workload's own value", env.GetValue())
 		}
 	}
 	if count != 1 {


### PR DESCRIPTION
The orchestrator set `PATH` on every workload container. A container env entry replaces the image's `ENV PATH` rather than extending it — Kubernetes has no syntax for prepending — so whatever the image installed was discarded and a guessed default login set took its place.

The devcontainer image sets `ENV PATH=/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}`. Both directories were being dropped, so an environment's init scripts installed tools that were then unreachable: `nix profile install kubectl` succeeded and `kubectl` was not found. Login shells still worked, because `/etc/profile.d/nix.sh` puts the directory back — which is why this looked like init scripts failing rather than a PATH being overwritten.

It also reached MCP sidecars, which do not mount `/agyn`: for them the entry named a directory that does not exist, at the cost of their image's own PATH.

The reason it was set no longer holds. It existed because a sandbox shell came from the runner's Exec and inherited the container spec rather than any process's environment; agynd now owns the tmux server behind persistent shells, and every route to `/agyn/bin` prepends inside the container where `$PATH` is the image's — the tmux `default-command`, the Terminal Proxy's bound shell, agynd for the subprocess it spawns. What the platform invokes itself already uses absolute paths, as `syncEndpoint` does.